### PR TITLE
feat: split app APIs into scoped modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ and everything is packed into `dist/<app>.dcpak`. Pass 2 bundles with Bun
 (iife, unminified) from the cached transforms.
 
 ```tsx
-import { Text, View, createSignal } from "psp-ui";
+import { Text, View } from "psp-ui/components";
+import { createSignal } from "psp-ui/reactivity";
 
 const [count, setCount] = createSignal(0);
 

--- a/demos/cards/app.tsx
+++ b/demos/cards/app.tsx
@@ -9,7 +9,9 @@
 // focus emphasis = translate-y lift + bg/border color (never scale — glyphs
 // don't scale), all text single-line, every class a FULL literal.
 
-import { Text, View, animate, createSignal, onMount, Show, spring, type NodeMirror } from "psp-ui";
+import { Show, Text, View, type NodeMirror } from "psp-ui/components";
+import { animate, spring } from "psp-ui/animation";
+import { createSignal, onMount } from "psp-ui/reactivity";
 
 interface Card {
   title: string;

--- a/demos/hero/app.tsx
+++ b/demos/hero/app.tsx
@@ -2,7 +2,10 @@
 // Uses all three public primitives, class literals, a dynamic style object,
 // focus + onPress, and a signal in text — the exact surface phase v1 supports.
 
-import { Image, Text, View, animate, createMemo, createSignal, onMount, Show, type NodeMirror } from "psp-ui";
+import { Image, Show, Text, View, type NodeMirror } from "psp-ui/components";
+import { animate } from "psp-ui/animation";
+import { useSpriteAnimation } from "psp-ui/hooks";
+import { createSignal, onMount } from "psp-ui/reactivity";
 
 const SPINNER_FRAME_STEP = 3;
 const SPINNER_FRAMES = [
@@ -16,12 +19,6 @@ const SPINNER_FRAMES = [
   "spinner-07.svg",
 ];
 
-const [spinnerFrame, setSpinnerFrame] = createSignal(0);
-
-export function heroFrame(): void {
-  setSpinnerFrame((spinnerFrame() + 1) % (SPINNER_FRAMES.length * SPINNER_FRAME_STEP));
-}
-
 function Stat(props: { label: string; value: string; cls: string }) {
   return (
     <View class="flex-col items-end">
@@ -33,10 +30,7 @@ function Stat(props: { label: string; value: string; cls: string }) {
 
 export default function Hero() {
   const [count, setCount] = createSignal(0);
-  const spinnerSrc = createMemo(() => {
-    const i = Math.floor(spinnerFrame() / SPINNER_FRAME_STEP) % SPINNER_FRAMES.length;
-    return SPINNER_FRAMES[i];
-  });
+  const spinnerSrc = useSpriteAnimation(SPINNER_FRAMES, { frameStep: SPINNER_FRAME_STEP });
   let underline: NodeMirror | undefined;
   onMount(() => {
     // Underline sweeps in once on mount — native tween, zero steady-state JS.

--- a/demos/hero/main.tsx
+++ b/demos/hero/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Hero
-import Hero, { heroFrame } from "./app.tsx";
+import Hero from "./app.tsx";
 import { mount } from "psp-ui";
 
-mount(() => <Hero />, { beforeFrame: heroFrame });
+mount(() => <Hero />);

--- a/demos/library/app.tsx
+++ b/demos/library/app.tsx
@@ -11,7 +11,11 @@
 // pre-split into <Text> lines), every class a FULL literal (the per-tile accent
 // border/gradient is baked per entry, never synthesized).
 
-import { BTN, Image, Text, View, createMemo, createSignal, focusNode, onMount, Show, spring, type NodeMirror } from "psp-ui";
+import { Image, Show, Text, View, type NodeMirror } from "psp-ui/components";
+import { spring } from "psp-ui/animation";
+import { useButtonPress, useFrame } from "psp-ui/hooks";
+import { createMemo, createSignal, onMount } from "psp-ui/reactivity";
+import { BTN, focusNode } from "psp-ui/input";
 
 type Screen = "library" | "loading" | "detail";
 
@@ -93,59 +97,22 @@ const SPINNER_FRAMES = [
 ];
 
 // ---------------------------------------------------------------------------
-// Frame driver (wired by library/main.tsx): edge-detects TRIANGLE (back) and
-// steps the loading screen's frame-capped auto-advance. Runs BEFORE the
-// engine's own input/focus/onPress pass (mount-main.tsx wraps frame).
-// ---------------------------------------------------------------------------
-
-const [screen, setScreen] = createSignal<Screen>("library");
-const [selected, setSelected] = createSignal<Game | null>(null);
-const [selectedIndex, setSelectedIndex] = createSignal(-1);
-const [loadFrame, setLoadFrame] = createSignal(0);
-let prevButtons = 0;
-
-export function libraryFrame(buttons: number): void {
-  const pressed = buttons & ~prevButtons;
-  prevButtons = buttons;
-  if (screen() === "loading") {
-    const n = loadFrame() + 1;
-    setLoadFrame(n);
-    if (n >= LOADING_FRAMES) setScreen("detail");
-    return;
-  }
-  if (screen() === "detail" && pressed & BTN.TRIANGLE) {
-    setScreen("library");
-  }
-}
-
-function openGame(game: Game, index: number): void {
-  setSelected(game);
-  setSelectedIndex(index);
-  if (game.about) {
-    setScreen("detail");
-  } else {
-    setLoadFrame(0);
-    setScreen("loading");
-  }
-}
-
-// ---------------------------------------------------------------------------
 // Screens
 // ---------------------------------------------------------------------------
 
 /** Icon row. Remounts on every return to "library" — onMount restores focus
  *  to the tile that was open (focusNode over the d-pad's own traversal). */
-function Grid() {
+function Grid(props: { selectedIndex: () => number; onOpen: (game: Game, index: number) => void }) {
   const refs: (NodeMirror | undefined)[] = [];
   onMount(() => {
-    const i = selectedIndex();
+    const i = props.selectedIndex();
     if (i >= 0) focusNode(refs[i] ?? null);
   });
   return (
     <View class="flex-row gap-4 justify-center items-center grow">
       {GAMES.map((game, i) => (
         <View class="flex-col items-center gap-2">
-          <View ref={refs[i]} class={game.tileCls} focusable onPress={() => openGame(game, i)}>
+          <View ref={refs[i]} class={game.tileCls} focusable onPress={() => props.onOpen(game, i)}>
             <Show when={game.about}>
               <Image class="w-9 h-9" src="logo.png" />
             </Show>
@@ -159,9 +126,9 @@ function Grid() {
 
 /** SVG-baked spinner — frame-cycled instead of rotating an image quad, because
  *  the v1 texture op is axis-aligned and should stay cheap on PSP. */
-function Loading(props: { title: string }) {
+function Loading(props: { title: string; frame: () => number }) {
   const src = createMemo(() => {
-    const i = Math.floor(loadFrame() / SPINNER_FRAME_STEP) % SPINNER_FRAMES.length;
+    const i = Math.floor(props.frame() / SPINNER_FRAME_STEP) % SPINNER_FRAMES.length;
     return SPINNER_FRAMES[i];
   });
   return (
@@ -221,6 +188,32 @@ function Detail(props: { game: Game }) {
 // ---------------------------------------------------------------------------
 
 export default function Library() {
+  const [screen, setScreen] = createSignal<Screen>("library");
+  const [selected, setSelected] = createSignal<Game | null>(null);
+  const [selectedIndex, setSelectedIndex] = createSignal(-1);
+  const [loadFrame, setLoadFrame] = createSignal(0);
+
+  const openGame = (game: Game, index: number) => {
+    setSelected(game);
+    setSelectedIndex(index);
+    if (game.about) {
+      setScreen("detail");
+    } else {
+      setLoadFrame(0);
+      setScreen("loading");
+    }
+  };
+
+  useButtonPress(BTN.TRIANGLE, () => {
+    if (screen() === "detail") setScreen("library");
+  });
+  useFrame(() => {
+    if (screen() !== "loading") return;
+    const n = loadFrame() + 1;
+    setLoadFrame(n);
+    if (n >= LOADING_FRAMES) setScreen("detail");
+  });
+
   return (
     <View class="relative flex-col w-full h-full p-4 gap-3 bg-gradient-to-b from-slate-50 to-slate-100">
       <View class="flex-row items-end justify-between">
@@ -232,12 +225,12 @@ export default function Library() {
       </View>
 
       <Show when={screen() === "library"}>
-        <Grid />
+        <Grid selectedIndex={selectedIndex} onOpen={openGame} />
         <Text class="text-xs text-slate-500">LEFT / RIGHT move focus · CIRCLE open</Text>
       </Show>
 
       <Show when={screen() === "loading" && selected()}>
-        <Loading title={selected()!.title} />
+        <Loading title={selected()!.title} frame={loadFrame} />
       </Show>
 
       <Show when={screen() === "detail" && selected()}>

--- a/demos/library/main.tsx
+++ b/demos/library/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Game Library
-import Library, { libraryFrame } from "./app.tsx";
+import Library from "./app.tsx";
 import { mount } from "psp-ui";
 
-mount(() => <Library />, { beforeFrame: libraryFrame });
+mount(() => <Library />);

--- a/demos/music/app.tsx
+++ b/demos/music/app.tsx
@@ -11,7 +11,10 @@
 // Design notes: every class a FULL literal (per-track cover accent baked per
 // entry); text single-line.
 
-import { BTN, Text, View, createSignal, type NodeMirror } from "psp-ui";
+import { Text, View } from "psp-ui/components";
+import { useButtonPress, useFrame } from "psp-ui/hooks";
+import { createSignal } from "psp-ui/reactivity";
+import { BTN } from "psp-ui/input";
 
 interface Track {
   title: string;
@@ -45,58 +48,47 @@ const TRACK_FRAMES = 300; // 5s per track at 60 Hz (demo-length, not the real so
 const PROGRESS_TRACK_W = 160; // progress track px — matches the w-[160] track class
 
 // ---------------------------------------------------------------------------
-// Transport state + frame driver (wired by music/main.tsx)
-// ---------------------------------------------------------------------------
-
-const [trackIndex, setTrackIndex] = createSignal(0);
-const [playing, setPlaying] = createSignal(true);
-const [position, setPosition] = createSignal(0); // frames into the current track
-const [barsFrame, setBarsFrame] = createSignal(0);
-let prevButtons = 0;
-
-function selectTrack(i: number): void {
-  setTrackIndex(i);
-  setPosition(0);
-  setPlaying(true);
-}
-
-function nextTrack(): void {
-  setTrackIndex((trackIndex() + 1) % TRACKS.length);
-  setPosition(0);
-}
-
-function prevTrack(): void {
-  setTrackIndex((trackIndex() - 1 + TRACKS.length) % TRACKS.length);
-  setPosition(0);
-}
-
-/** height in px — a resting flat line when paused, a bounded pseudo-random
- *  bounce (per-bar phase offset) while playing. Pure function of barsFrame,
- *  so goldens stay byte-exact for a fixed frame index. */
-function barHeight(i: number): number {
-  if (!playing()) return 6;
-  const v = Math.abs(Math.sin(barsFrame() * 0.15 + i * 1.7));
-  return 6 + Math.round(v * 20);
-}
-
-export function musicFrame(buttons: number): void {
-  const pressed = buttons & ~prevButtons;
-  prevButtons = buttons;
-  if (pressed & BTN.LTRIGGER) prevTrack();
-  if (pressed & BTN.RTRIGGER) nextTrack();
-  if (playing()) {
-    setBarsFrame(barsFrame() + 1);
-    const p = position() + 1;
-    if (p >= TRACK_FRAMES) nextTrack();
-    else setPosition(p);
-  }
-}
-
-// ---------------------------------------------------------------------------
 // App
 // ---------------------------------------------------------------------------
 
 export default function Music() {
+  const [trackIndex, setTrackIndex] = createSignal(0);
+  const [playing, setPlaying] = createSignal(true);
+  const [position, setPosition] = createSignal(0); // frames into the current track
+  const [barsFrame, setBarsFrame] = createSignal(0);
+
+  const selectTrack = (i: number) => {
+    setTrackIndex(i);
+    setPosition(0);
+    setPlaying(true);
+  };
+
+  const nextTrack = () => {
+    setTrackIndex((trackIndex() + 1) % TRACKS.length);
+    setPosition(0);
+  };
+
+  const prevTrack = () => {
+    setTrackIndex((trackIndex() - 1 + TRACKS.length) % TRACKS.length);
+    setPosition(0);
+  };
+
+  useButtonPress(BTN.LTRIGGER, prevTrack);
+  useButtonPress(BTN.RTRIGGER, nextTrack);
+  useFrame(() => {
+    if (!playing()) return;
+    setBarsFrame(barsFrame() + 1);
+    const p = position() + 1;
+    if (p >= TRACK_FRAMES) nextTrack();
+    else setPosition(p);
+  });
+
+  const barHeight = (i: number): number => {
+    if (!playing()) return 6;
+    const v = Math.abs(Math.sin(barsFrame() * 0.15 + i * 1.7));
+    return 6 + Math.round(v * 20);
+  };
+
   const track = () => TRACKS[trackIndex()];
   const pct = () => Math.round((position() / TRACK_FRAMES) * 100);
 

--- a/demos/music/main.tsx
+++ b/demos/music/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Now Playing
-import Music, { musicFrame } from "./app.tsx";
+import Music from "./app.tsx";
 import { mount } from "psp-ui";
 
-mount(() => <Music />, { beforeFrame: musicFrame });
+mount(() => <Music />);

--- a/demos/notifications/app.tsx
+++ b/demos/notifications/app.tsx
@@ -5,15 +5,17 @@
 // Each item staggers in with a delayed opacity+translateX tween on mount;
 // CIRCLE dismisses the focused card — an imperative fade+slide (native
 // `opacity`/`translateX` tweens fired straight from onPress, not a reactive
-// class, so they can't be clobbered by an unrelated re-render) — a frame-
-// driven timer (beforeFrame, same shape as stats.tsx/library.tsx) removes it
-// from the list once the tween has had time to finish.
+// class, so they can't be clobbered by an unrelated re-render) — a local
+// frame hook removes it from the list once the tween has had time to finish.
 //
 // Design notes: p-1 rows / p-3 root — 4 cards is already a tight fit in
 // 480x272 (DESIGN.md punts kinetic scroll, so the list can't overflow the
 // screen); every class a FULL literal.
 
-import { For, Text, View, animate, createSignal, onMount, Show, type NodeMirror } from "psp-ui";
+import { For, Show, Text, View, type NodeMirror } from "psp-ui/components";
+import { animate } from "psp-ui/animation";
+import { useFrame } from "psp-ui/hooks";
+import { createSignal, onMount } from "psp-ui/reactivity";
 
 interface Notice {
   id: string;
@@ -59,39 +61,34 @@ const INITIAL: Notice[] = [
 const DISMISS_FRAMES = 16; // >= the 200ms fade tween (~12 frames), plus margin
 
 // ---------------------------------------------------------------------------
-// Frame driver (wired by notifications/main.tsx): once a dismiss is in
-// flight, counts down and splices the item out when its tween has settled.
-// ---------------------------------------------------------------------------
-
-const [items, setItems] = createSignal<Notice[]>(INITIAL);
-const [dismissingId, setDismissingId] = createSignal<string | null>(null);
-const [dismissFrame, setDismissFrame] = createSignal(0);
-
-export function notificationsFrame(): void {
-  const id = dismissingId();
-  if (id === null) return;
-  const n = dismissFrame() + 1;
-  setDismissFrame(n);
-  if (n >= DISMISS_FRAMES) {
-    setItems(items().filter((it) => it.id !== id));
-    setDismissingId(null);
-    setDismissFrame(0);
-  }
-}
-
-function dismiss(id: string, el: NodeMirror | undefined): void {
-  if (dismissingId() !== null || !el) return;
-  setDismissingId(id);
-  setDismissFrame(0);
-  animate(el, "opacity", 0, { dur: 200, easing: "out" });
-  animate(el, "translateX", 24, { dur: 200, easing: "out" });
-}
-
-// ---------------------------------------------------------------------------
 // App
 // ---------------------------------------------------------------------------
 
 export default function Notifications() {
+  const [items, setItems] = createSignal<Notice[]>(INITIAL);
+  const [dismissingId, setDismissingId] = createSignal<string | null>(null);
+  const [dismissFrame, setDismissFrame] = createSignal(0);
+
+  useFrame(() => {
+    const id = dismissingId();
+    if (id === null) return;
+    const n = dismissFrame() + 1;
+    setDismissFrame(n);
+    if (n >= DISMISS_FRAMES) {
+      setItems(items().filter((it) => it.id !== id));
+      setDismissingId(null);
+      setDismissFrame(0);
+    }
+  });
+
+  const dismiss = (id: string, el: NodeMirror | undefined) => {
+    if (dismissingId() !== null || !el) return;
+    setDismissingId(id);
+    setDismissFrame(0);
+    animate(el, "opacity", 0, { dur: 200, easing: "out" });
+    animate(el, "translateX", 24, { dur: 200, easing: "out" });
+  };
+
   return (
     <View class="flex-col w-full h-full p-3 gap-2 bg-gradient-to-b from-slate-50 to-slate-100">
       <View class="flex-row items-end justify-between">

--- a/demos/notifications/main.tsx
+++ b/demos/notifications/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Notifications
-import Notifications, { notificationsFrame } from "./app.tsx";
+import Notifications from "./app.tsx";
 import { mount } from "psp-ui";
 
-mount(() => <Notifications />, { beforeFrame: notificationsFrame });
+mount(() => <Notifications />);

--- a/demos/settings/app.tsx
+++ b/demos/settings/app.tsx
@@ -8,9 +8,11 @@
 //
 // No custom frame wiring: every interaction is UP/DOWN navigation + CIRCLE
 // press, entirely covered by the engine's default input pass (src/input.ts)
-// — unlike stats.tsx/library.tsx this entry needs no beforeFrame.
+// — unlike continuous demos, this entry needs no frame hook.
 
-import { Text, View, animate, createEffect, createSignal, Show, type NodeMirror } from "psp-ui";
+import { Show, Text, View, type NodeMirror } from "psp-ui/components";
+import { animate } from "psp-ui/animation";
+import { createEffect, createSignal } from "psp-ui/reactivity";
 
 type ThemeName = "indigo" | "emerald" | "amber" | "rose";
 

--- a/demos/stats/app.tsx
+++ b/demos/stats/app.tsx
@@ -4,17 +4,13 @@
 // arranged tabs. The SYSTEMS tab uses a short staggered row reveal so rows never
 // flash through the style-table default before becoming white.
 //
-// Frame driving: statsFrame(buttons) is called once per frame by the
-// stats/main entry (it wraps globalThis.frame). It edge-detects LEFT/RIGHT for
-// the tab switch and steps capped frame-counter signals; after the current
-// choreography settles, steady-state JS work is zero. Content stays a pure
-// function of the frame index (byte-exact goldens).
+// Frame driving stays component-scoped through psp-ui hooks: button presses
+// switch tabs, while a capped frame hook advances deterministic counters.
 
-import { BTN, Text, View, createMemo, createSignal, Show } from "psp-ui";
-
-// ---------------------------------------------------------------------------
-// Frame driver (wired by stats/main.tsx)
-// ---------------------------------------------------------------------------
+import { Show, Text, View } from "psp-ui/components";
+import { useButtonPress, useFrame } from "psp-ui/hooks";
+import { createMemo, createSignal } from "psp-ui/reactivity";
+import { BTN } from "psp-ui/input";
 
 const COUNT_FRAMES = 75;
 const BAR_ANIM_FRAMES = 26;
@@ -22,25 +18,6 @@ const BAR_STAGGER_FRAMES = 4;
 const SYSTEMS_REVEAL_FRAMES = 12;
 const SYSTEMS_STAGGER_FRAMES = 5;
 const SYSTEMS_MAX_FRAMES = SYSTEMS_REVEAL_FRAMES + SYSTEMS_STAGGER_FRAMES * 3;
-const [frameN, setFrameN] = createSignal(0);
-const [tab, setTab] = createSignal(0);
-const [systemsFrame, setSystemsFrame] = createSignal(0);
-let prevButtons = 0;
-
-/** Once per frame, BEFORE the engine's own handler (stats-main wraps frame). */
-export function statsFrame(buttons: number): void {
-  const pressed = buttons & ~prevButtons;
-  prevButtons = buttons;
-  if (pressed & BTN.RIGHT) {
-    setTab(1);
-    setSystemsFrame(0);
-  }
-  if (pressed & BTN.LEFT) setTab(0);
-  if (frameN() < COUNT_FRAMES) setFrameN(frameN() + 1); // settles, then silence
-  if (tab() === 1 && systemsFrame() < SYSTEMS_MAX_FRAMES) {
-    setSystemsFrame(systemsFrame() + 1);
-  }
-}
 
 // ---------------------------------------------------------------------------
 // Data
@@ -104,9 +81,9 @@ function easeOutCubic(x: number): number {
 
 /** OVERVIEW tab: bars grow from the capped frame signal, not a stack of native
  *  width tweens, so there is no transition from default dark style values. */
-function Overview() {
+function Overview(props: { frame: () => number }) {
   const fillW = (bar: Bar, i: number) => {
-    const local = (frameN() - i * BAR_STAGGER_FRAMES) / BAR_ANIM_FRAMES;
+    const local = (props.frame() - i * BAR_STAGGER_FRAMES) / BAR_ANIM_FRAMES;
     return easeOutCubic(local) * (bar.pct / 100) * BAR_W;
   };
   return (
@@ -128,8 +105,8 @@ function Overview() {
 
 /** SYSTEMS tab: status board. Rows appear one after another with short delays;
  *  opacity starts at 0, so there is no visible flash from default gray. */
-function Systems() {
-  const rowT = (i: number) => easeOutCubic((systemsFrame() - i * SYSTEMS_STAGGER_FRAMES) / SYSTEMS_REVEAL_FRAMES);
+function Systems(props: { frame: () => number }) {
+  const rowT = (i: number) => easeOutCubic((props.frame() - i * SYSTEMS_STAGGER_FRAMES) / SYSTEMS_REVEAL_FRAMES);
   return (
     <View class="flex-col gap-1">
       {SYSTEMS.map((sys, i) => (
@@ -153,6 +130,22 @@ function Systems() {
 // ---------------------------------------------------------------------------
 
 export default function Stats() {
+  const [frameN, setFrameN] = createSignal(0);
+  const [tab, setTab] = createSignal(0);
+  const [systemsFrame, setSystemsFrame] = createSignal(0);
+
+  useButtonPress(BTN.RIGHT, () => {
+    setTab(1);
+    setSystemsFrame(0);
+  });
+  useButtonPress(BTN.LEFT, () => setTab(0));
+  useFrame(() => {
+    if (frameN() < COUNT_FRAMES) setFrameN(frameN() + 1);
+    if (tab() === 1 && systemsFrame() < SYSTEMS_MAX_FRAMES) {
+      setSystemsFrame(systemsFrame() + 1);
+    }
+  });
+
   // Count-up: eased share of the capped frame counter — pure per-frame math,
   // silent once frameN stops at COUNT_FRAMES.
   const t = createMemo(() => {
@@ -219,10 +212,10 @@ export default function Stats() {
 
       <View class="grow flex-col">
         <Show when={tab() === 0}>
-          <Overview />
+          <Overview frame={frameN} />
         </Show>
         <Show when={tab() === 1}>
-          <Systems />
+          <Systems frame={systemsFrame} />
         </Show>
       </View>
 

--- a/demos/stats/main.tsx
+++ b/demos/stats/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Mission Control
-import Stats, { statsFrame } from "./app.tsx";
+import Stats from "./app.tsx";
 import { mount } from "psp-ui";
 
-mount(() => <Stats />, { beforeFrame: statsFrame });
+mount(() => <Stats />);

--- a/package.json
+++ b/package.json
@@ -4,7 +4,12 @@
   "private": true,
   "type": "module",
   "exports": {
-    ".": "./src/index.ts"
+    ".": "./src/index.ts",
+    "./animation": "./src/animation.ts",
+    "./components": "./src/components.ts",
+    "./hooks": "./src/hooks.ts",
+    "./input": "./src/input-api.ts",
+    "./reactivity": "./src/reactivity.ts"
   },
   "description": "JSX UI stack for the Sony PSP (and beyond): Solid universal renderer over a no_std Rust core. See DESIGN.md.",
   "scripts": {

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -53,15 +53,25 @@ if (!appArg) {
 }
 
 function resolveEntry(arg: string): string {
-  const bare = arg.replace(/\.tsx?$/, "");
+  const normalized = arg.replace(/\\/g, "/").replace(/\.tsx?$/, "");
+  const bare = normalized.includes("/") ? normalized.slice(normalized.lastIndexOf("/") + 1) : normalized;
   const isBareName = !arg.includes("/") && !arg.startsWith(".");
-  const demoName = bare.endsWith("-main") ? bare.slice(0, -"-main".length) : bare;
+  const demoRel = normalized.replace(/^.*?demos\//, "");
+  const demoName =
+    demoRel.endsWith("/main")
+      ? demoRel.slice(0, -"/main".length)
+      : demoRel.endsWith("/app")
+        ? demoRel.slice(0, -"/app".length)
+        : bare.endsWith("-main")
+          ? bare.slice(0, -"-main".length)
+          : bare;
+  const wantsMain = demoRel.endsWith("/main") || bare.endsWith("-main");
   const tries = [
     resolvePath(arg),
     resolvePath(ROOT, arg),
-    isBareName && bare.endsWith("-main") ? resolvePath(ROOT, "demos", demoName, "main.tsx") : "",
-    isBareName && !bare.endsWith("-main") ? resolvePath(ROOT, "demos", demoName, "app.tsx") : "",
-    isBareName && !bare.endsWith("-main") ? resolvePath(ROOT, "demos", demoName, "main.tsx") : "",
+    wantsMain ? resolvePath(ROOT, "demos", demoName, "main.tsx") : "",
+    !wantsMain ? resolvePath(ROOT, "demos", demoName, "app.tsx") : "",
+    isBareName && !wantsMain ? resolvePath(ROOT, "demos", demoName, "main.tsx") : "",
     resolvePath(ROOT, "demos", arg),
     resolvePath(ROOT, "demos", arg + ".tsx"),
     resolvePath(ROOT, "demos", arg + ".ts"),

--- a/src/animation.ts
+++ b/src/animation.ts
@@ -1,0 +1,3 @@
+// Animation public API.
+
+export { animate, spring, cancelAnim, type AnimateOptions, type EasingName } from "./anim.ts";

--- a/src/components.ts
+++ b/src/components.ts
@@ -1,0 +1,5 @@
+// Component-facing public API.
+
+export { View, Text, Image, type ViewProps, type TextProps, type ImageProps } from "./primitives.ts";
+export { For, Show, Index, Switch, Match } from "solid-js";
+export type { NodeMirror } from "./renderer.ts";

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -1,0 +1,50 @@
+// App-facing frame hooks.
+//
+// Hosts still drive one low-level global frame callback per vblank/rAF tick,
+// but application code should register component-scoped hooks instead of
+// patching mount() with a global per-frame callback.
+
+import { createSignal, onCleanup, type Accessor } from "solid-js";
+
+type FrameCallback = (buttons: number) => void;
+
+const callbacks = new Set<FrameCallback>();
+
+export function resetFrameHooks(): void {
+  callbacks.clear();
+}
+
+export function runFrameHooks(buttons: number): void {
+  for (const cb of [...callbacks]) cb(buttons);
+}
+
+export function useFrame(callback: FrameCallback): void {
+  callbacks.add(callback);
+  onCleanup(() => callbacks.delete(callback));
+}
+
+export function useButtonPress(mask: number, callback: (pressed: number, buttons: number) => void): void {
+  let prevButtons = 0;
+  useFrame((buttons) => {
+    const pressed = buttons & ~prevButtons;
+    prevButtons = buttons;
+    if (pressed & mask) callback(pressed, buttons);
+  });
+}
+
+export interface SpriteAnimationOptions {
+  /** Number of host frames each sprite frame remains visible. */
+  frameStep?: number;
+}
+
+export function useSpriteAnimation(frames: readonly string[], opts: SpriteAnimationOptions = {}): Accessor<string> {
+  if (frames.length === 0) {
+    throw new Error("psp-ui: useSpriteAnimation() requires at least one frame");
+  }
+  const frameStep = Math.max(1, Math.floor(opts.frameStep ?? 1));
+  const [frame, setFrame] = createSignal(0);
+  useFrame(() => {
+    setFrame((frame() + 1) % (frames.length * frameStep));
+  });
+  return () => frames[Math.floor(frame() / frameStep) % frames.length];
+}

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -1,0 +1,3 @@
+// Hook-facing public API.
+
+export { useFrame, useButtonPress, useSpriteAnimation, type SpriteAnimationOptions } from "./frame.ts";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,10 @@
-// psp-ui public entry: render(<App/>) + the re-exported app-facing surface.
+// psp-ui runtime entry: render(<App/>) / mount(<App/>).
 //
 // Frame contract (every host): once per vblank/rAF tick the host calls
 // `globalThis.frame(buttons)` (spec BTN bitmask). render() installs that
-// handler as input edge-detection + focus + onPress, THEN the renderer's
-// end-of-frame sweep [R] — so Solid effects triggered by input run before
-// detached subtrees are destroyed.
+// handler as app frame hooks, input edge-detection + focus + onPress, THEN the
+// renderer's end-of-frame sweep [R] — so Solid effects triggered by input run
+// before detached subtrees are destroyed.
 
 // queueMicrotask polyfill (QuickJS lacks it; Solid's resource/transition paths
 // reference it lazily, so installing at module-eval time is early enough).
@@ -27,6 +27,7 @@ import {
 } from "./renderer.ts";
 import { registerStyles, resolveStyle } from "./styles.ts";
 import { handleFrame, setInputRoot } from "./input.ts";
+import { resetFrameHooks, runFrameHooks } from "./frame.ts";
 import { entries as dcpakEntries, get as dcpakGet, hasPack, loadPack } from "./dcpak.ts";
 import { STYLE_IDS as DEFAULT_STYLE_IDS } from "./styles.generated.ts";
 
@@ -39,10 +40,7 @@ export interface RenderOptions {
   dcpak?: ArrayBuffer;
 }
 
-export interface MountOptions extends RenderOptions {
-  /** Runs once per host frame before built-in focus/onPress/sweep handling. */
-  beforeFrame?: (buttons: number) => void;
-}
+export type MountOptions = RenderOptions;
 
 /** dcpak entry keys the runtime understands when it loads a pack JS-side.
  * Must match compiler/dcpak.ts (KEY_STYLES / keyFont). */
@@ -67,18 +65,6 @@ function uploadDcpakImages(ops: HostOps): void {
     const handle = ops.uploadTexture(blob.subarray(8), w, h, psm);
     if (handle >= 0) rendererRegisterTexture(key.slice(IMG_PREFIX.length), handle);
   }
-}
-
-function prependFrameHandler(fn: (buttons: number) => void): void {
-  const g = globalThis as { frame?: (buttons: number) => void };
-  const engineFrame = g.frame;
-  if (typeof engineFrame !== "function") {
-    throw new Error("psp-ui: mount() expected render() to install globalThis.frame");
-  }
-  g.frame = (buttons: number) => {
-    fn(buttons);
-    engineFrame(buttons);
-  };
 }
 
 /**
@@ -123,7 +109,9 @@ export function render(code: () => unknown, opts: RenderOptions = {}): () => voi
   }
 
   setInputRoot(rootMirror);
+  resetFrameHooks();
   installFrameHandler((buttons: number) => {
+    runFrameHooks(buttons); // app hooks: useFrame/useButtonPress/etc.
     handleFrame(buttons); // edge-detect, focus nav, onPress (runs effects)
     runSweep(); // then destroy subtrees still detached [R]
   });
@@ -143,8 +131,8 @@ export function render(code: () => unknown, opts: RenderOptions = {}): () => voi
 /**
  * App-level entry point for demo/application bundles. It mirrors a web-style
  * mount call: pick the current host, feed the current generated style table,
- * upload dcpak images for injected hosts, mount the component, and optionally
- * prepend app frame logic before the built-in input/focus/sweep frame.
+ * upload dcpak images for injected hosts, and mount the component. Per-frame
+ * app behavior belongs in component hooks such as useFrame/useButtonPress.
  */
 export function mount(code: () => unknown, opts: MountOptions = {}): () => void {
   const ops = opts.ops ?? globalOps();
@@ -158,34 +146,14 @@ export function mount(code: () => unknown, opts: MountOptions = {}): () => void 
     styles: opts.styles ?? DEFAULT_STYLE_IDS,
     dcpak: opts.dcpak,
   });
-  if (opts.beforeFrame) prependFrameHandler(opts.beforeFrame);
   return dispose;
 }
 
-// ---- app-facing re-exports ----------------------------------------------------
+// ---- runtime re-exports -------------------------------------------------------
 
-export {
-  createSignal,
-  createEffect,
-  createMemo,
-  onMount,
-  onCleanup,
-  batch,
-  untrack,
-  For,
-  Show,
-  Index,
-  Switch,
-  Match,
-} from "solid-js";
-
-export { animate, spring, cancelAnim, type AnimateOptions, type EasingName } from "./anim.ts";
-export { View, Text, Image, type ViewProps, type TextProps, type ImageProps } from "./primitives.ts";
-export { BTN, PROP, ENUMS, SCREEN_W, SCREEN_H } from "../spec/spec.ts";
 export type { HostOps, Host } from "./host.ts";
 export { detectHost, installHost, getOps } from "./host.ts";
 export type { NodeMirror } from "./renderer.ts";
 export { retain, release, runSweep, registerTexture, missCounters } from "./renderer.ts";
 export { registerStyles, resolveStyle } from "./styles.ts";
-export { handleFrame, focusNode, getFocused } from "./input.ts";
 export { entries as dcpakEntries, get as dcpakGet, loadPack, resetPack } from "./dcpak.ts";

--- a/src/input-api.ts
+++ b/src/input-api.ts
@@ -1,0 +1,4 @@
+// Input/focus public API.
+
+export { BTN } from "../spec/spec.ts";
+export { focusNode, getFocused } from "./input.ts";

--- a/src/reactivity.ts
+++ b/src/reactivity.ts
@@ -1,0 +1,11 @@
+// Solid reactivity public API.
+
+export {
+  createSignal,
+  createEffect,
+  createMemo,
+  onMount,
+  onCleanup,
+  batch,
+  untrack,
+} from "solid-js";

--- a/test/e2e-ppsspp.ts
+++ b/test/e2e-ppsspp.ts
@@ -143,7 +143,7 @@ const SPECS: Spec[] = [
   {
     // notifications: DOWN@10/16 focuses item 1 (FRIEND REQUEST), CIRCLE@24
     // dismisses it — an imperative 200ms fade+slide fired from onPress, then
-    // the beforeFrame timer splices it out of the <For> list at frame 40
+    // the local frame hook splices it out of the <For> list at frame 40
     // (focus repairs to the next sibling, BATTERY).
     app: "notifications",
     inputScript: "0:0,10:0x40,14:0,16:0x40,20:0,24:0x2000,28:0",

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -50,6 +50,7 @@ import {
   setInputRoot,
 } from "../src/input.ts";
 import { mount as publicMount, render as publicRender } from "../src/index.ts";
+import { useFrame } from "../src/hooks.ts";
 import { rootMirror } from "../src/renderer.ts";
 import { resetPack } from "../src/dcpak.ts";
 import { encodeImageEntry, pack } from "../compiler/dcpak.ts";
@@ -734,11 +735,11 @@ describe("public render() (index.ts)", () => {
     const before: number[] = [];
     const dispose = publicMount(
       () => {
+        useFrame((buttons) => before.push(buttons));
         const img = createElement("image");
         setProp(img, "src", "logo.png", undefined);
         return img;
       },
-      { beforeFrame: (buttons) => before.push(buttons) },
     );
 
     expect(host.of("uploadTexture")).toEqual([["uploadTexture"]]);


### PR DESCRIPTION
## Summary

- Add scoped public app API entry points: `psp-ui/components`, `psp-ui/reactivity`, `psp-ui/hooks`, `psp-ui/animation`, and `psp-ui/input`.
- Move per-frame demo behavior from `mount({ beforeFrame })` into component-scoped hooks such as `useFrame`, `useButtonPress`, and `useSpriteAnimation`.
- Keep the root `psp-ui` entry focused on runtime mounting/rendering and internal host/runtime re-exports.
- Update demos, README, and tests for the scoped import paths and hook-based frame model.

## Validation

- `bunx tsc --noEmit`
- `bun run test`
- explicit rebuild of all main demos via `bun scripts/build.ts <demo-main>`
- `bun test/golden.ts`
- `bun run e2e`
- `bun scripts/psp-all.ts --help && bun scripts/hw.ts --help`
