### PR TITLE
refactor: rename public hooks and imports for PocketJS

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ and everything is packed into `dist/<app>.dcpak`. Pass 2 bundles with Bun
 (iife, unminified) from the cached transforms.
 
 ```tsx
-import { Text, View } from "psp-ui/components";
-import { createSignal } from "psp-ui/reactivity";
+import { Text, View } from "@pocketjs/components";
+import { createSignal } from "@pocketjs/reactivity";
 
 const [count, setCount] = createSignal(0);
 
@@ -42,7 +42,7 @@ handles host detection, the generated style table, dcpak image uploads and the
 host frame callback:
 
 ```tsx
-import { mount } from "psp-ui";
+import { mount } from "@pocketjs";
 import App from "./app.tsx";
 
 mount(() => <App />);
@@ -54,7 +54,7 @@ dynamic styling is ternaries of full literals, `style={{...}}`, or `animate()`.
 `classList`, `hover:` and template-interpolated classes are compile errors.
 `rounded-full` requires `w-N h-N` in the same literal.
 
-`psp-ui/components` also exposes small app-shell primitives used by
+`@pocketjs/components` also exposes small app-shell primitives used by
 `demos/launcher`: `Screen`, `Focusable`, `FocusScope`, `ActionHandler`,
 `FocusGrid`, `Portal`, `Modal`, and `ActionBar`. `FocusGrid` gives a subtree
 explicit row/column d-pad traversal today; a virtualized grid can sit behind the

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ explicit row/column d-pad traversal today; a virtualized grid can sit behind the
 same focus contract later. `Portal` mounts into the runtime overlay root, so
 modal/action-bar UI never participates in the active screen's flex layout.
 `Modal` owns a focus scope and blocks background button handlers while leaving
-frame animation hooks running; route switching is still ordinary app state, not
+frame animation lifecycle callbacks running; route switching is still ordinary app state, not
 a required router package.
 
 ## Commands

--- a/compiler/solid-plugin.ts
+++ b/compiler/solid-plugin.ts
@@ -31,6 +31,12 @@ import tsPresetPkg from "@babel/preset-typescript/package.json";
 /** Absolute path of the universal renderer module — babel-preset-solid emits
  *  this verbatim into every import it generates, so it MUST be absolute [R]. */
 export const RENDERER_PATH = new URL("../src/renderer.ts", import.meta.url).pathname;
+const INDEX_PATH = new URL("../src/index.ts", import.meta.url).pathname;
+const ANIMATION_PATH = new URL("../src/animation.ts", import.meta.url).pathname;
+const COMPONENTS_PATH = new URL("../src/components.ts", import.meta.url).pathname;
+const INPUT_API_PATH = new URL("../src/input-api.ts", import.meta.url).pathname;
+const LIFECYCLE_PATH = new URL("../src/lifecycle.ts", import.meta.url).pathname;
+const REACTIVITY_PATH = new URL("../src/reactivity.ts", import.meta.url).pathname;
 
 const CACHE_DIR = new URL("../.cache/transforms/", import.meta.url).pathname;
 /** Bump to invalidate every cached transform (changes to this file's
@@ -168,6 +174,32 @@ interface CacheEntry {
   textCodepoints: number[];
 }
 
+function resolvePackageSubpath(spec: string): string | null {
+  if (spec === "psp-ui" || spec === "@pocketjs") return "";
+  if (spec.startsWith("psp-ui/")) return spec.slice("psp-ui/".length);
+  if (spec.startsWith("@pocketjs/")) return spec.slice("@pocketjs/".length);
+  return null;
+}
+
+function packagePath(spec: string): string | null {
+  switch (resolvePackageSubpath(spec)) {
+    case "":
+      return INDEX_PATH;
+    case "animation":
+      return ANIMATION_PATH;
+    case "components":
+      return COMPONENTS_PATH;
+    case "input":
+      return INPUT_API_PATH;
+    case "lifecycle":
+      return LIFECYCLE_PATH;
+    case "reactivity":
+      return REACTIVITY_PATH;
+    default:
+      return null;
+  }
+}
+
 /**
  * Transform one source file (content-hash cached). Throws on lint violations
  * and syntax errors; the error message carries file + code frame.
@@ -220,6 +252,10 @@ export function solidUniversalPlugin(): BunPlugin {
   return {
     name: "psp-ui-solid-universal",
     setup(build) {
+      build.onResolve({ filter: /^(?:psp-ui|@pocketjs)(?:\/.*)?$/ }, (args) => {
+        const path = packagePath(args.path);
+        return path ? { path } : undefined;
+      });
       build.onLoad({ filter: /\.tsx?$/ }, async (args) => {
         if (args.path.includes("/node_modules/") || args.path.endsWith(".d.ts")) return undefined;
         const src = await Bun.file(args.path).text();

--- a/demos/cards/app.tsx
+++ b/demos/cards/app.tsx
@@ -9,9 +9,9 @@
 // focus emphasis = translate-y lift + bg/border color (never scale — glyphs
 // don't scale), all text single-line, every class a FULL literal.
 
-import { Show, Text, View, type NodeMirror } from "psp-ui/components";
-import { animate, spring } from "psp-ui/animation";
-import { createSignal, onMount } from "psp-ui/reactivity";
+import { Show, Text, View, type NodeMirror } from "@pocketjs/components";
+import { animate, spring } from "@pocketjs/animation";
+import { createSignal, onMount } from "@pocketjs/reactivity";
 
 interface Card {
   title: string;

--- a/demos/cards/main.tsx
+++ b/demos/cards/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Feature Cards
 import Cards from "./app.tsx";
-import { mount } from "psp-ui";
+import { mount } from "@pocketjs";
 
 mount(() => <Cards />);

--- a/demos/hero/app.tsx
+++ b/demos/hero/app.tsx
@@ -4,7 +4,7 @@
 
 import { Image, Show, Text, View, type NodeMirror } from "psp-ui/components";
 import { animate } from "psp-ui/animation";
-import { useSpriteAnimation } from "psp-ui/hooks";
+import { createSpriteAnimation } from "psp-ui/lifecycle";
 import { createSignal, onMount } from "psp-ui/reactivity";
 
 const SPINNER_FRAME_STEP = 3;
@@ -30,7 +30,7 @@ function Stat(props: { label: string; value: string; cls: string }) {
 
 export default function Hero() {
   const [count, setCount] = createSignal(0);
-  const spinnerSrc = useSpriteAnimation(SPINNER_FRAMES, { frameStep: SPINNER_FRAME_STEP });
+  const spinnerSrc = createSpriteAnimation(SPINNER_FRAMES, { frameStep: SPINNER_FRAME_STEP });
   let underline: NodeMirror | undefined;
   onMount(() => {
     // Underline sweeps in once on mount — native tween, zero steady-state JS.

--- a/demos/hero/app.tsx
+++ b/demos/hero/app.tsx
@@ -2,10 +2,10 @@
 // Uses all three public primitives, class literals, a dynamic style object,
 // focus + onPress, and a signal in text — the exact surface phase v1 supports.
 
-import { Image, Show, Text, View, type NodeMirror } from "psp-ui/components";
-import { animate } from "psp-ui/animation";
-import { createSpriteAnimation } from "psp-ui/lifecycle";
-import { createSignal, onMount } from "psp-ui/reactivity";
+import { Image, Show, Text, View, type NodeMirror } from "@pocketjs/components";
+import { animate } from "@pocketjs/animation";
+import { createSpriteAnimation } from "@pocketjs/lifecycle";
+import { createSignal, onMount } from "@pocketjs/reactivity";
 
 const SPINNER_FRAME_STEP = 3;
 const SPINNER_FRAMES = [

--- a/demos/hero/main.tsx
+++ b/demos/hero/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Hero
 import Hero from "./app.tsx";
-import { mount } from "psp-ui";
+import { mount } from "@pocketjs";
 
 mount(() => <Hero />);

--- a/demos/launcher/app.tsx
+++ b/demos/launcher/app.tsx
@@ -8,10 +8,10 @@ import {
   Text,
   View,
   type NodeMirror,
-} from "psp-ui/components";
-import { animate } from "psp-ui/animation";
-import { BTN } from "psp-ui/input";
-import { createEffect, createSignal } from "psp-ui/reactivity";
+} from "@pocketjs/components";
+import { animate } from "@pocketjs/animation";
+import { BTN } from "@pocketjs/input";
+import { createEffect, createSignal } from "@pocketjs/reactivity";
 
 import Cards from "../cards/app.tsx";
 import Hero from "../hero/app.tsx";

--- a/demos/launcher/main.tsx
+++ b/demos/launcher/main.tsx
@@ -1,6 +1,6 @@
 // @title psp-ui: Demo Launcher
 
-import { mount } from "psp-ui";
+import { mount } from "@pocketjs";
 import Launcher from "./app.tsx";
 
 mount(() => <Launcher />);

--- a/demos/library/app.tsx
+++ b/demos/library/app.tsx
@@ -13,7 +13,7 @@
 
 import { Image, Show, Text, View, type NodeMirror } from "psp-ui/components";
 import { spring } from "psp-ui/animation";
-import { useButtonPress, useFrame } from "psp-ui/hooks";
+import { onButtonPress, onFrame } from "psp-ui/lifecycle";
 import { createMemo, createSignal, onMount } from "psp-ui/reactivity";
 import { BTN, focusNode } from "psp-ui/input";
 
@@ -204,10 +204,10 @@ export default function Library() {
     }
   };
 
-  useButtonPress(BTN.TRIANGLE, () => {
+  onButtonPress(BTN.TRIANGLE, () => {
     if (screen() === "detail") setScreen("library");
   });
-  useFrame(() => {
+  onFrame(() => {
     if (screen() !== "loading") return;
     const n = loadFrame() + 1;
     setLoadFrame(n);

--- a/demos/library/app.tsx
+++ b/demos/library/app.tsx
@@ -11,11 +11,11 @@
 // pre-split into <Text> lines), every class a FULL literal (the per-tile accent
 // border/gradient is baked per entry, never synthesized).
 
-import { Image, Show, Text, View, type NodeMirror } from "psp-ui/components";
-import { spring } from "psp-ui/animation";
-import { onButtonPress, onFrame } from "psp-ui/lifecycle";
-import { createMemo, createSignal, onMount } from "psp-ui/reactivity";
-import { BTN, focusNode } from "psp-ui/input";
+import { Image, Show, Text, View, type NodeMirror } from "@pocketjs/components";
+import { spring } from "@pocketjs/animation";
+import { onButtonPress, onFrame } from "@pocketjs/lifecycle";
+import { createMemo, createSignal, onMount } from "@pocketjs/reactivity";
+import { BTN, focusNode } from "@pocketjs/input";
 
 type Screen = "library" | "loading" | "detail";
 

--- a/demos/library/main.tsx
+++ b/demos/library/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Game Library
 import Library from "./app.tsx";
-import { mount } from "psp-ui";
+import { mount } from "@pocketjs";
 
 mount(() => <Library />);

--- a/demos/music/app.tsx
+++ b/demos/music/app.tsx
@@ -11,10 +11,10 @@
 // Design notes: every class a FULL literal (per-track cover accent baked per
 // entry); text single-line.
 
-import { Text, View } from "psp-ui/components";
-import { onButtonPress, onFrame } from "psp-ui/lifecycle";
-import { createSignal } from "psp-ui/reactivity";
-import { BTN } from "psp-ui/input";
+import { Text, View } from "@pocketjs/components";
+import { onButtonPress, onFrame } from "@pocketjs/lifecycle";
+import { createSignal } from "@pocketjs/reactivity";
+import { BTN } from "@pocketjs/input";
 
 interface Track {
   title: string;

--- a/demos/music/app.tsx
+++ b/demos/music/app.tsx
@@ -12,7 +12,7 @@
 // entry); text single-line.
 
 import { Text, View } from "psp-ui/components";
-import { useButtonPress, useFrame } from "psp-ui/hooks";
+import { onButtonPress, onFrame } from "psp-ui/lifecycle";
 import { createSignal } from "psp-ui/reactivity";
 import { BTN } from "psp-ui/input";
 
@@ -73,9 +73,9 @@ export default function Music() {
     setPosition(0);
   };
 
-  useButtonPress(BTN.LTRIGGER, prevTrack);
-  useButtonPress(BTN.RTRIGGER, nextTrack);
-  useFrame(() => {
+  onButtonPress(BTN.LTRIGGER, prevTrack);
+  onButtonPress(BTN.RTRIGGER, nextTrack);
+  onFrame(() => {
     if (!playing()) return;
     setBarsFrame(barsFrame() + 1);
     const p = position() + 1;

--- a/demos/music/main.tsx
+++ b/demos/music/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Now Playing
 import Music from "./app.tsx";
-import { mount } from "psp-ui";
+import { mount } from "@pocketjs";
 
 mount(() => <Music />);

--- a/demos/notifications/app.tsx
+++ b/demos/notifications/app.tsx
@@ -11,10 +11,10 @@
 // 480x272 (DESIGN.md punts kinetic scroll, so the list can't overflow the
 // screen); every class a FULL literal.
 
-import { For, Show, Text, View, type NodeMirror } from "psp-ui/components";
-import { animate } from "psp-ui/animation";
-import { onFrame } from "psp-ui/lifecycle";
-import { createSignal, onMount } from "psp-ui/reactivity";
+import { For, Show, Text, View, type NodeMirror } from "@pocketjs/components";
+import { animate } from "@pocketjs/animation";
+import { onFrame } from "@pocketjs/lifecycle";
+import { createSignal, onMount } from "@pocketjs/reactivity";
 
 interface Notice {
   id: string;

--- a/demos/notifications/app.tsx
+++ b/demos/notifications/app.tsx
@@ -13,7 +13,7 @@
 
 import { For, Show, Text, View, type NodeMirror } from "psp-ui/components";
 import { animate } from "psp-ui/animation";
-import { useFrame } from "psp-ui/hooks";
+import { onFrame } from "psp-ui/lifecycle";
 import { createSignal, onMount } from "psp-ui/reactivity";
 
 interface Notice {
@@ -76,7 +76,7 @@ export default function Notifications() {
 
   const hasRise = () => Object.keys(riseOffsets()).length > 0 || riseQueued().length > 0;
 
-  useFrame(() => {
+  onFrame(() => {
     const queued = riseQueued();
     if (queued.length > 0) {
       for (const id of queued) {

--- a/demos/notifications/main.tsx
+++ b/demos/notifications/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Notifications
 import Notifications from "./app.tsx";
-import { mount } from "psp-ui";
+import { mount } from "@pocketjs";
 
 mount(() => <Notifications />);

--- a/demos/settings/app.tsx
+++ b/demos/settings/app.tsx
@@ -10,9 +10,9 @@
 // press, entirely covered by the engine's default input pass (src/input.ts)
 // — unlike continuous demos, this entry needs no frame hook.
 
-import { Show, Text, View, type NodeMirror } from "psp-ui/components";
-import { animate } from "psp-ui/animation";
-import { createEffect, createSignal } from "psp-ui/reactivity";
+import { Show, Text, View, type NodeMirror } from "@pocketjs/components";
+import { animate } from "@pocketjs/animation";
+import { createEffect, createSignal } from "@pocketjs/reactivity";
 
 type ThemeName = "indigo" | "emerald" | "amber" | "rose";
 

--- a/demos/settings/main.tsx
+++ b/demos/settings/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Settings
 import Settings from "./app.tsx";
-import { mount } from "psp-ui";
+import { mount } from "@pocketjs";
 
 mount(() => <Settings />);

--- a/demos/stats/app.tsx
+++ b/demos/stats/app.tsx
@@ -4,12 +4,12 @@
 // arranged tabs. The SYSTEMS tab uses a short staggered row reveal so rows
 // never flash through the style-table default before becoming white.
 //
-// Frame driving stays component-scoped through psp-ui hooks: button presses
+// Frame driving stays component-scoped through psp-ui lifecycle callbacks: button presses
 // switch tabs, while a capped frame hook advances deterministic counters.
 
 import { Show, Text, View, type NodeMirror } from "psp-ui/components";
 import { animate } from "psp-ui/animation";
-import { useButtonPress, useFrame } from "psp-ui/hooks";
+import { onButtonPress, onFrame } from "psp-ui/lifecycle";
 import { createMemo, createSignal, onMount } from "psp-ui/reactivity";
 import { BTN } from "psp-ui/input";
 
@@ -160,12 +160,12 @@ export default function Stats() {
   const [tab, setTab] = createSignal(0);
   const [systemsFrame, setSystemsFrame] = createSignal(0);
 
-  useButtonPress(BTN.RIGHT, () => {
+  onButtonPress(BTN.RIGHT, () => {
     setTab(1);
     setSystemsFrame(0);
   });
-  useButtonPress(BTN.LEFT, () => setTab(0));
-  useFrame(() => {
+  onButtonPress(BTN.LEFT, () => setTab(0));
+  onFrame(() => {
     if (frameN() < COUNT_FRAMES) setFrameN(frameN() + 1);
     if (tab() === 1 && systemsFrame() < SYSTEMS_MAX_FRAMES) {
       setSystemsFrame(systemsFrame() + 1);

--- a/demos/stats/app.tsx
+++ b/demos/stats/app.tsx
@@ -4,14 +4,14 @@
 // arranged tabs. The SYSTEMS tab uses a short staggered row reveal so rows
 // never flash through the style-table default before becoming white.
 //
-// Frame driving stays component-scoped through psp-ui lifecycle callbacks: button presses
+// Frame driving stays component-scoped through PocketJS lifecycle callbacks: button presses
 // switch tabs, while a capped frame hook advances deterministic counters.
 
-import { Show, Text, View, type NodeMirror } from "psp-ui/components";
-import { animate } from "psp-ui/animation";
-import { onButtonPress, onFrame } from "psp-ui/lifecycle";
-import { createMemo, createSignal, onMount } from "psp-ui/reactivity";
-import { BTN } from "psp-ui/input";
+import { Show, Text, View, type NodeMirror } from "@pocketjs/components";
+import { animate } from "@pocketjs/animation";
+import { onButtonPress, onFrame } from "@pocketjs/lifecycle";
+import { createMemo, createSignal, onMount } from "@pocketjs/reactivity";
+import { BTN } from "@pocketjs/input";
 
 const COUNT_FRAMES = 75;
 const BAR_ANIM_FRAMES = 26;

--- a/demos/stats/main.tsx
+++ b/demos/stats/main.tsx
@@ -1,5 +1,5 @@
 // @title psp-ui: Mission Control
 import Stats from "./app.tsx";
-import { mount } from "psp-ui";
+import { mount } from "@pocketjs";
 
 mount(() => <Stats />);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     ".": "./src/index.ts",
     "./animation": "./src/animation.ts",
     "./components": "./src/components.ts",
-    "./hooks": "./src/hooks.ts",
+    "./lifecycle": "./src/lifecycle.ts",
     "./input": "./src/input-api.ts",
     "./reactivity": "./src/reactivity.ts"
   },

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -128,8 +128,18 @@ function importSpecifiers(src: string): string[] {
  *  remapping like `./card.js` -> card.tsx included), so the two passes agree
  *  on the module graph by construction. */
 function resolveImport(fromFile: string, spec: string): string | null {
-  if (spec === "psp-ui" || spec.startsWith("psp-ui/")) {
-    const subpath = spec === "psp-ui" ? "" : spec.slice("psp-ui/".length);
+  if (
+    spec === "psp-ui" ||
+    spec.startsWith("psp-ui/") ||
+    spec === "@pocketjs" ||
+    spec.startsWith("@pocketjs/")
+  ) {
+    const subpath =
+      spec === "psp-ui" || spec === "@pocketjs"
+        ? ""
+        : spec.startsWith("psp-ui/")
+          ? spec.slice("psp-ui/".length)
+          : spec.slice("@pocketjs/".length);
     const exported = packageExports.get(subpath);
     return exported && /\.tsx?$/.test(exported) ? ROOT + exported : null;
   }

--- a/src/components.ts
+++ b/src/components.ts
@@ -3,7 +3,7 @@
 import type { JSX as SolidJSX } from "solid-js";
 import { createEffect, onCleanup, onMount, splitProps } from "solid-js";
 import { ENUMS, SCREEN_H, SCREEN_W } from "../spec/spec.ts";
-import { pushButtonHandlerBlock, useButtonPress, type ButtonPressOptions } from "./frame.ts";
+import { pushButtonHandlerBlock, onButtonPress, type ButtonPressOptions } from "./frame.ts";
 import { pushFocusGrid, pushFocusScope, type FocusGridOptions, type FocusScopeOptions } from "./input.ts";
 import { getOverlayRoot } from "./overlay.ts";
 import { View, type ViewProps } from "./primitives.ts";
@@ -103,7 +103,7 @@ export interface ActionHandlerProps extends ButtonPressOptions {
 }
 
 export function ActionHandler(props: ActionHandlerProps): SolidJSX.Element {
-  useButtonPress(props.button, props.onPress, {
+  onButtonPress(props.button, props.onPress, {
     allowWhenBlocked: props.allowWhenBlocked,
     active: props.active,
   });

--- a/src/frame.ts
+++ b/src/frame.ts
@@ -1,7 +1,7 @@
-// App-facing frame hooks.
+// App-facing lifecycle callbacks.
 //
 // Hosts still drive one low-level global frame callback per vblank/rAF tick,
-// but application code should register component-scoped hooks instead of
+// but application code should register component-scoped lifecycle callbacks instead of
 // patching mount() with a global per-frame callback.
 
 import { createSignal, onCleanup, type Accessor } from "solid-js";
@@ -20,7 +20,7 @@ export function runFrameHooks(buttons: number): void {
   for (const cb of [...callbacks]) cb(buttons);
 }
 
-export function useFrame(callback: FrameCallback): void {
+export function onFrame(callback: FrameCallback): void {
   callbacks.add(callback);
   onCleanup(() => callbacks.delete(callback));
 }
@@ -44,13 +44,13 @@ export function pushButtonHandlerBlock(): () => void {
   };
 }
 
-export function useButtonPress(
+export function onButtonPress(
   mask: number,
   callback: (pressed: number, buttons: number) => void,
   opts: ButtonPressOptions = {},
 ): void {
   let prevButtons = 0;
-  useFrame((buttons) => {
+  onFrame((buttons) => {
     const pressed = buttons & ~prevButtons;
     prevButtons = buttons;
     const active = typeof opts.active === "function" ? opts.active() : opts.active ?? true;
@@ -65,13 +65,13 @@ export interface SpriteAnimationOptions {
   frameStep?: number;
 }
 
-export function useSpriteAnimation(frames: readonly string[], opts: SpriteAnimationOptions = {}): Accessor<string> {
+export function createSpriteAnimation(frames: readonly string[], opts: SpriteAnimationOptions = {}): Accessor<string> {
   if (frames.length === 0) {
-    throw new Error("psp-ui: useSpriteAnimation() requires at least one frame");
+    throw new Error("psp-ui: createSpriteAnimation() requires at least one frame");
   }
   const frameStep = Math.max(1, Math.floor(opts.frameStep ?? 1));
   const [frame, setFrame] = createSignal(0);
-  useFrame(() => {
+  onFrame(() => {
     setFrame((frame() + 1) % (frames.length * frameStep));
   });
   return () => frames[Math.floor(frame() / frameStep) % frames.length];

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,7 +141,7 @@ export function render(code: () => unknown, opts: RenderOptions = {}): () => voi
   setInputRoot(appRoot);
   resetFrameHooks();
   installFrameHandler((buttons: number) => {
-    runFrameHooks(buttons); // app hooks: useFrame/useButtonPress/etc.
+    runFrameHooks(buttons); // app lifecycle callbacks: onFrame/onButtonPress/etc.
     handleFrame(buttons); // edge-detect, focus nav, onPress (runs effects)
     runSweep(); // then destroy subtrees still detached [R]
   });
@@ -163,7 +163,7 @@ export function render(code: () => unknown, opts: RenderOptions = {}): () => voi
  * App-level entry point for demo/application bundles. It mirrors a web-style
  * mount call: pick the current host, feed the current generated style table,
  * upload dcpak images for injected hosts, and mount the component. Per-frame
- * app behavior belongs in component hooks such as useFrame/useButtonPress.
+ * app behavior belongs in component lifecycle callbacks such as onFrame/onButtonPress.
  */
 export function mount(code: () => unknown, opts: MountOptions = {}): () => void {
   const ops = opts.ops ?? globalOps();

--- a/src/lifecycle.ts
+++ b/src/lifecycle.ts
@@ -1,10 +1,10 @@
-// Hook-facing public API.
+// Lifecycle-facing public API.
 
 export {
   pushButtonHandlerBlock,
-  useFrame,
-  useButtonPress,
-  useSpriteAnimation,
+  onFrame,
+  onButtonPress,
+  createSpriteAnimation,
   type ButtonPressOptions,
   type SpriteAnimationOptions,
 } from "./frame.ts";

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -53,7 +53,7 @@ import {
   setInputRoot,
 } from "../src/input.ts";
 import { mount as publicMount, render as publicRender } from "../src/index.ts";
-import { pushButtonHandlerBlock, useButtonPress, useFrame } from "../src/hooks.ts";
+import { pushButtonHandlerBlock, onButtonPress, onFrame } from "../src/lifecycle.ts";
 import { rootMirror } from "../src/renderer.ts";
 import { ActionBar, ActionHandler, FocusGrid, Modal, Portal, Text, View } from "../src/components.ts";
 import { resetPack } from "../src/dcpak.ts";
@@ -998,7 +998,7 @@ describe("public render() (index.ts)", () => {
     const before: number[] = [];
     const dispose = publicMount(
       () => {
-        useFrame((buttons) => before.push(buttons));
+        onFrame((buttons) => before.push(buttons));
         const img = createElement("image");
         setProp(img, "src", "logo.png", undefined);
         return img;
@@ -1023,9 +1023,9 @@ describe("public render() (index.ts)", () => {
 
     const dispose = publicMount(
       () => {
-        useFrame(() => frames++);
-        useButtonPress(BTN.SELECT, () => backgroundPresses++);
-        useButtonPress(BTN.SELECT, () => systemPresses++, { allowWhenBlocked: true });
+        onFrame(() => frames++);
+        onButtonPress(BTN.SELECT, () => backgroundPresses++);
+        onButtonPress(BTN.SELECT, () => systemPresses++, { allowWhenBlocked: true });
         return createElement("view");
       },
     );

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,16 @@
     "allowImportingTsExtensions": true,
     "verbatimModuleSyntax": true,
     "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "forceConsistentCasingInFileNames": true,
+    "baseUrl": ".",
+    "paths": {
+      "@pocketjs": ["./src/index.ts"],
+      "@pocketjs/animation": ["./src/animation.ts"],
+      "@pocketjs/components": ["./src/components.ts"],
+      "@pocketjs/input": ["./src/input-api.ts"],
+      "@pocketjs/lifecycle": ["./src/lifecycle.ts"],
+      "@pocketjs/reactivity": ["./src/reactivity.ts"]
+    }
   },
   "include": ["src", "compiler", "demos", "test", "spec", "host-web"]
 }


### PR DESCRIPTION
## Summary

This PR independently reimplements the naming cleanup from a clean `main` branch. It is intentionally separate from the renderer experiment branch and does not include the React/Vue renderer work.

## Related Issue

- #8

## Changes

- Renames the public frame hooks module from `psp-ui/hooks` to `psp-ui/lifecycle`.
- Renames the app-facing lifecycle APIs:
  - `useFrame` -> `onFrame`
  - `useButtonPress` -> `onButtonPress`
  - `useSpriteAnimation` -> `createSpriteAnimation`
- Updates demos, README snippets, and renderer tests to use the lifecycle names.
- Adds app-facing `@pocketjs/*` import aliases for demos and docs.
- Teaches the build graph, Bun resolver plugin, and TypeScript paths to resolve `@pocketjs`, `@pocketjs/components`, `@pocketjs/animation`, `@pocketjs/input`, `@pocketjs/lifecycle`, and `@pocketjs/reactivity`.

## Scope Notes

The package name, internal `psp-ui` build/error prefixes, PSP packaging names, and generated-file comments are intentionally unchanged in this PR. This keeps the change focused on public app imports and lifecycle callback naming only.

## Validation

- `for app in cards hero launcher library music notifications settings stats; do bun scripts/build.ts "$app"; done`
- `bun run test`
- `bunx tsc --noEmit`