### PR TITLE
chore: rename imports to framework subpaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ and everything is packed into `dist/<app>.dcpak`. Pass 2 bundles with Bun
 (iife, unminified) from the cached transforms.
 
 ```tsx
-import { Text, View } from "@pocketjs/components";
-import { createSignal } from "@pocketjs/reactivity";
+import { Text, View } from "@pocketjs/framework/components";
+import { createSignal } from "@pocketjs/framework/reactivity";
 
 const [count, setCount] = createSignal(0);
 
@@ -42,7 +42,7 @@ handles host detection, the generated style table, dcpak image uploads and the
 host frame callback:
 
 ```tsx
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 import App from "./app.tsx";
 
 mount(() => <App />);
@@ -54,7 +54,7 @@ dynamic styling is ternaries of full literals, `style={{...}}`, or `animate()`.
 `classList`, `hover:` and template-interpolated classes are compile errors.
 `rounded-full` requires `w-N h-N` in the same literal.
 
-`@pocketjs/components` also exposes small app-shell primitives used by
+`@pocketjs/framework/components` also exposes small app-shell primitives used by
 `demos/launcher`: `Screen`, `Focusable`, `FocusScope`, `ActionHandler`,
 `FocusGrid`, `Portal`, `Modal`, and `ActionBar`. `FocusGrid` gives a subtree
 explicit row/column d-pad traversal today; a virtualized grid can sit behind the

--- a/bun.lock
+++ b/bun.lock
@@ -3,7 +3,7 @@
   "configVersion": 1,
   "workspaces": {
     "": {
-      "name": "@pocketjs/core",
+      "name": "@pocketjs/framework",
       "dependencies": {
         "solid-js": "^1.9",
       },

--- a/compiler/solid-plugin.ts
+++ b/compiler/solid-plugin.ts
@@ -37,6 +37,7 @@ const COMPONENTS_PATH = new URL("../src/components.ts", import.meta.url).pathnam
 const INPUT_API_PATH = new URL("../src/input-api.ts", import.meta.url).pathname;
 const LIFECYCLE_PATH = new URL("../src/lifecycle.ts", import.meta.url).pathname;
 const REACTIVITY_PATH = new URL("../src/reactivity.ts", import.meta.url).pathname;
+const PACKAGE_NAME = "@pocketjs/framework";
 
 const CACHE_DIR = new URL("../.cache/transforms/", import.meta.url).pathname;
 /** Bump to invalidate every cached transform (changes to this file's
@@ -175,8 +176,8 @@ interface CacheEntry {
 }
 
 function resolvePackageSubpath(spec: string): string | null {
-  if (spec === "@pocketjs") return "";
-  if (spec.startsWith("@pocketjs/")) return spec.slice("@pocketjs/".length);
+  if (spec === PACKAGE_NAME) return "";
+  if (spec.startsWith(PACKAGE_NAME + "/")) return spec.slice(PACKAGE_NAME.length + 1);
   return null;
 }
 
@@ -251,7 +252,7 @@ export function solidUniversalPlugin(): BunPlugin {
   return {
     name: "pocketjs-solid-universal",
     setup(build) {
-      build.onResolve({ filter: /^@pocketjs(?:\/.*)?$/ }, (args) => {
+      build.onResolve({ filter: /^@pocketjs\/framework(?:\/.*)?$/ }, (args) => {
         const path = packagePath(args.path);
         return path ? { path } : undefined;
       });

--- a/demos/cards/app.tsx
+++ b/demos/cards/app.tsx
@@ -9,9 +9,9 @@
 // focus emphasis = translate-y lift + bg/border color (never scale — glyphs
 // don't scale), all text single-line, every class a FULL literal.
 
-import { Show, Text, View, type NodeMirror } from "@pocketjs/components";
-import { animate, spring } from "@pocketjs/animation";
-import { createSignal, onMount } from "@pocketjs/reactivity";
+import { Show, Text, View, type NodeMirror } from "@pocketjs/framework/components";
+import { animate, spring } from "@pocketjs/framework/animation";
+import { createSignal, onMount } from "@pocketjs/framework/reactivity";
 
 interface Card {
   title: string;

--- a/demos/cards/main.tsx
+++ b/demos/cards/main.tsx
@@ -1,5 +1,5 @@
 // @title PocketJS: Feature Cards
 import Cards from "./app.tsx";
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 
 mount(() => <Cards />);

--- a/demos/hero/app.tsx
+++ b/demos/hero/app.tsx
@@ -2,10 +2,10 @@
 // Uses all three public primitives, class literals, a dynamic style object,
 // focus + onPress, and a signal in text — the exact surface phase v1 supports.
 
-import { Image, Show, Text, View, type NodeMirror } from "@pocketjs/components";
-import { animate } from "@pocketjs/animation";
-import { createSpriteAnimation } from "@pocketjs/lifecycle";
-import { createSignal, onMount } from "@pocketjs/reactivity";
+import { Image, Show, Text, View, type NodeMirror } from "@pocketjs/framework/components";
+import { animate } from "@pocketjs/framework/animation";
+import { createSpriteAnimation } from "@pocketjs/framework/lifecycle";
+import { createSignal, onMount } from "@pocketjs/framework/reactivity";
 
 const SPINNER_FRAME_STEP = 3;
 const SPINNER_FRAMES = [

--- a/demos/hero/main.tsx
+++ b/demos/hero/main.tsx
@@ -1,5 +1,5 @@
 // @title PocketJS: Hero
 import Hero from "./app.tsx";
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 
 mount(() => <Hero />);

--- a/demos/launcher/app.tsx
+++ b/demos/launcher/app.tsx
@@ -8,10 +8,10 @@ import {
   Text,
   View,
   type NodeMirror,
-} from "@pocketjs/components";
-import { animate } from "@pocketjs/animation";
-import { BTN } from "@pocketjs/input";
-import { createEffect, createSignal } from "@pocketjs/reactivity";
+} from "@pocketjs/framework/components";
+import { animate } from "@pocketjs/framework/animation";
+import { BTN } from "@pocketjs/framework/input";
+import { createEffect, createSignal } from "@pocketjs/framework/reactivity";
 
 import Cards from "../cards/app.tsx";
 import Hero from "../hero/app.tsx";

--- a/demos/launcher/main.tsx
+++ b/demos/launcher/main.tsx
@@ -1,6 +1,6 @@
 // @title PocketJS: Demo Launcher
 
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 import Launcher from "./app.tsx";
 
 mount(() => <Launcher />);

--- a/demos/library/app.tsx
+++ b/demos/library/app.tsx
@@ -11,11 +11,11 @@
 // pre-split into <Text> lines), every class a FULL literal (the per-tile accent
 // border/gradient is baked per entry, never synthesized).
 
-import { Image, Show, Text, View, type NodeMirror } from "@pocketjs/components";
-import { spring } from "@pocketjs/animation";
-import { onButtonPress, onFrame } from "@pocketjs/lifecycle";
-import { createMemo, createSignal, onMount } from "@pocketjs/reactivity";
-import { BTN, focusNode } from "@pocketjs/input";
+import { Image, Show, Text, View, type NodeMirror } from "@pocketjs/framework/components";
+import { spring } from "@pocketjs/framework/animation";
+import { onButtonPress, onFrame } from "@pocketjs/framework/lifecycle";
+import { createMemo, createSignal, onMount } from "@pocketjs/framework/reactivity";
+import { BTN, focusNode } from "@pocketjs/framework/input";
 
 type Screen = "library" | "loading" | "detail";
 

--- a/demos/library/main.tsx
+++ b/demos/library/main.tsx
@@ -1,5 +1,5 @@
 // @title PocketJS: Game Library
 import Library from "./app.tsx";
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 
 mount(() => <Library />);

--- a/demos/music/app.tsx
+++ b/demos/music/app.tsx
@@ -11,10 +11,10 @@
 // Design notes: every class a FULL literal (per-track cover accent baked per
 // entry); text single-line.
 
-import { Text, View } from "@pocketjs/components";
-import { onButtonPress, onFrame } from "@pocketjs/lifecycle";
-import { createSignal } from "@pocketjs/reactivity";
-import { BTN } from "@pocketjs/input";
+import { Text, View } from "@pocketjs/framework/components";
+import { onButtonPress, onFrame } from "@pocketjs/framework/lifecycle";
+import { createSignal } from "@pocketjs/framework/reactivity";
+import { BTN } from "@pocketjs/framework/input";
 
 interface Track {
   title: string;

--- a/demos/music/main.tsx
+++ b/demos/music/main.tsx
@@ -1,5 +1,5 @@
 // @title PocketJS: Now Playing
 import Music from "./app.tsx";
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 
 mount(() => <Music />);

--- a/demos/notifications/app.tsx
+++ b/demos/notifications/app.tsx
@@ -11,10 +11,10 @@
 // 480x272 (DESIGN.md punts kinetic scroll, so the list can't overflow the
 // screen); every class a FULL literal.
 
-import { For, Show, Text, View, type NodeMirror } from "@pocketjs/components";
-import { animate } from "@pocketjs/animation";
-import { onFrame } from "@pocketjs/lifecycle";
-import { createSignal, onMount } from "@pocketjs/reactivity";
+import { For, Show, Text, View, type NodeMirror } from "@pocketjs/framework/components";
+import { animate } from "@pocketjs/framework/animation";
+import { onFrame } from "@pocketjs/framework/lifecycle";
+import { createSignal, onMount } from "@pocketjs/framework/reactivity";
 
 interface Notice {
   id: string;

--- a/demos/notifications/main.tsx
+++ b/demos/notifications/main.tsx
@@ -1,5 +1,5 @@
 // @title PocketJS: Notifications
 import Notifications from "./app.tsx";
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 
 mount(() => <Notifications />);

--- a/demos/settings/app.tsx
+++ b/demos/settings/app.tsx
@@ -10,9 +10,9 @@
 // press, entirely covered by the engine's default input pass (src/input.ts)
 // — unlike continuous demos, this entry needs no frame hook.
 
-import { Show, Text, View, type NodeMirror } from "@pocketjs/components";
-import { animate } from "@pocketjs/animation";
-import { createEffect, createSignal } from "@pocketjs/reactivity";
+import { Show, Text, View, type NodeMirror } from "@pocketjs/framework/components";
+import { animate } from "@pocketjs/framework/animation";
+import { createEffect, createSignal } from "@pocketjs/framework/reactivity";
 
 type ThemeName = "indigo" | "emerald" | "amber" | "rose";
 

--- a/demos/settings/main.tsx
+++ b/demos/settings/main.tsx
@@ -1,5 +1,5 @@
 // @title PocketJS: Settings
 import Settings from "./app.tsx";
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 
 mount(() => <Settings />);

--- a/demos/stats/app.tsx
+++ b/demos/stats/app.tsx
@@ -7,11 +7,11 @@
 // Frame driving stays component-scoped through PocketJS lifecycle callbacks: button presses
 // switch tabs, while a capped frame hook advances deterministic counters.
 
-import { Show, Text, View, type NodeMirror } from "@pocketjs/components";
-import { animate } from "@pocketjs/animation";
-import { onButtonPress, onFrame } from "@pocketjs/lifecycle";
-import { createMemo, createSignal, onMount } from "@pocketjs/reactivity";
-import { BTN } from "@pocketjs/input";
+import { Show, Text, View, type NodeMirror } from "@pocketjs/framework/components";
+import { animate } from "@pocketjs/framework/animation";
+import { onButtonPress, onFrame } from "@pocketjs/framework/lifecycle";
+import { createMemo, createSignal, onMount } from "@pocketjs/framework/reactivity";
+import { BTN } from "@pocketjs/framework/input";
 
 const COUNT_FRAMES = 75;
 const BAR_ANIM_FRAMES = 26;

--- a/demos/stats/main.tsx
+++ b/demos/stats/main.tsx
@@ -1,5 +1,5 @@
 // @title PocketJS: Mission Control
 import Stats from "./app.tsx";
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 
 mount(() => <Stats />);

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@pocketjs/core",
+  "name": "@pocketjs/framework",
   "version": "0.1.0",
   "private": true,
   "type": "module",

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -38,10 +38,12 @@ const DIST = ROOT + "dist/";
 
 type PackageExportTarget = string | { default?: string; browser?: string; import?: string };
 interface PackageJson {
+  name?: string;
   exports?: Record<string, PackageExportTarget>;
 }
 
 const packageJson = await Bun.file(ROOT + "package.json").json() as PackageJson;
+const packageName = packageJson.name ?? "@pocketjs/framework";
 const packageExports = new Map<string, string>();
 for (const [key, target] of Object.entries(packageJson.exports ?? {})) {
   const file =
@@ -128,8 +130,8 @@ function importSpecifiers(src: string): string[] {
  *  remapping like `./card.js` -> card.tsx included), so the two passes agree
  *  on the module graph by construction. */
 function resolveImport(fromFile: string, spec: string): string | null {
-  if (spec === "@pocketjs" || spec.startsWith("@pocketjs/")) {
-    const subpath = spec === "@pocketjs" ? "" : spec.slice("@pocketjs/".length);
+  if (spec === packageName || spec.startsWith(packageName + "/")) {
+    const subpath = spec === packageName ? "" : spec.slice(packageName.length + 1);
     const exported = packageExports.get(subpath);
     return exported && /\.tsx?$/.test(exported) ? ROOT + exported : null;
   }

--- a/site/build.ts
+++ b/site/build.ts
@@ -222,16 +222,16 @@ async function compileCss() {
   console.log(`  assets/site.css  (${(bytes / 1024).toFixed(0)} KiB)`);
 }
 
-// import-map so compiled apps + the homepage resolve @pocketjs/* to the one runtime
+// import-map so compiled apps + the homepage resolve @pocketjs/framework/* to the one runtime
 const IMPORT_MAP = `<script type="importmap">
 {"imports":{
-  "@pocketjs":"/pg/runtime.js",
-  "@pocketjs/components":"/pg/runtime.js",
-  "@pocketjs/reactivity":"/pg/runtime.js",
-  "@pocketjs/animation":"/pg/runtime.js",
-  "@pocketjs/lifecycle":"/pg/runtime.js",
-  "@pocketjs/input":"/pg/runtime.js",
-  "@pocketjs/renderer":"/pg/runtime.js"
+  "@pocketjs/framework":"/pg/runtime.js",
+  "@pocketjs/framework/components":"/pg/runtime.js",
+  "@pocketjs/framework/reactivity":"/pg/runtime.js",
+  "@pocketjs/framework/animation":"/pg/runtime.js",
+  "@pocketjs/framework/lifecycle":"/pg/runtime.js",
+  "@pocketjs/framework/input":"/pg/runtime.js",
+  "@pocketjs/framework/renderer":"/pg/runtime.js"
 }}
 </script>`;
 

--- a/site/content/docs/animation.md
+++ b/site/content/docs/animation.md
@@ -5,7 +5,7 @@ PocketJS has two ways to move things:
 - **Declarative motion utilities** — Tailwind-subset classes (`transition`, `duration-N`,
   `ease-*`, `delay-N`) that tween a node whenever its style is swapped.
 - **The imperative API** — `animate()`, `spring()` and `cancelAnim()` from
-  [`@pocketjs/animation`](/docs/api/), for one-off tweens you kick off from code.
+  [`@pocketjs/framework/animation`](/docs/api/), for one-off tweens you kick off from code.
 
 Both compile down to the same native machinery. **You declare motion once in JS; the
 Rust core owns the tween from there.**
@@ -27,7 +27,7 @@ That has two consequences worth internalizing:
 ## Imperative: `animate()`
 
 ```ts
-import { animate } from "@pocketjs/animation";
+import { animate } from "@pocketjs/framework/animation";
 
 animate(node, prop, to, { dur, easing, delay }): number
 ```
@@ -64,9 +64,9 @@ Give any component a `ref` and Solid assigns the underlying `NodeMirror` to your
 variable. Kick the tween off in `onMount`, once the node exists:
 
 ```tsx
-import { View, type NodeMirror } from "@pocketjs/components";
-import { animate } from "@pocketjs/animation";
-import { onMount } from "@pocketjs/reactivity";
+import { View, type NodeMirror } from "@pocketjs/framework/components";
+import { animate } from "@pocketjs/framework/animation";
+import { onMount } from "@pocketjs/framework/reactivity";
 
 function Underline() {
   let el: NodeMirror | undefined;
@@ -107,7 +107,7 @@ For non-color props you pass the raw native value:
 ## Imperative: `spring()`
 
 ```ts
-import { spring } from "@pocketjs/animation";
+import { spring } from "@pocketjs/framework/animation";
 
 spring(node, prop, to, preset): number
 ```
@@ -121,9 +121,9 @@ then springs into place on mount. Because the panel is a keyed `<Show>` child it
 remounts per card, so the spring replays on every open:
 
 ```tsx
-import { View, Text, type NodeMirror } from "@pocketjs/components";
-import { spring } from "@pocketjs/animation";
-import { onMount } from "@pocketjs/reactivity";
+import { View, Text, type NodeMirror } from "@pocketjs/framework/components";
+import { spring } from "@pocketjs/framework/animation";
+import { onMount } from "@pocketjs/framework/reactivity";
 
 function Detail(props: { title: string; detail: string }) {
   let el: NodeMirror | undefined;
@@ -147,7 +147,7 @@ mount is the canonical "enter" pattern.
 Stop a running tween with the id `animate()` / `spring()` returned:
 
 ```ts
-import { animate, cancelAnim } from "@pocketjs/animation";
+import { animate, cancelAnim } from "@pocketjs/framework/animation";
 
 const id = animate(streak, "translateX", 300, { dur: 20000, easing: "linear" });
 // …later:

--- a/site/content/docs/api.md
+++ b/site/content/docs/api.md
@@ -1,19 +1,19 @@
 # API reference
 
-Every public export of `@pocketjs`, grouped by import path. Signatures are TypeScript-style; defaults are noted in parentheses. For conceptual walkthroughs see [Components](/docs/components/), [Reactivity](/docs/reactivity/), [Animation](/docs/animation/), and [Input & focus](/docs/input-focus/).
+Every public export of `@pocketjs/framework`, grouped by import path. Signatures are TypeScript-style; defaults are noted in parentheses. For conceptual walkthroughs see [Components](/docs/components/), [Reactivity](/docs/reactivity/), [Animation](/docs/animation/), and [Input & focus](/docs/input-focus/).
 
 | Import path | Exports |
 | --- | --- |
-| `@pocketjs` | `mount`, `render`, host/runtime helpers, types |
-| `@pocketjs/components` | `View`, `Text`, `Image`, `Show`, `For`, `Index`, `Switch`, `Match`, `Screen`, `Focusable`, `FocusScope`, `FocusGrid`, `ActionHandler`, `Portal`, `Modal`, `ActionBar` |
-| `@pocketjs/reactivity` | `createSignal`, `createEffect`, `createMemo`, `onMount`, `onCleanup`, `batch`, `untrack` |
-| `@pocketjs/animation` | `animate`, `spring`, `cancelAnim` |
-| `@pocketjs/lifecycle` | `onFrame`, `onButtonPress`, `createSpriteAnimation`, `pushButtonHandlerBlock` |
-| `@pocketjs/input` | `BTN`, `focusNode`, `getFocused`, `pushFocusScope`, `pushFocusGrid` |
+| `@pocketjs/framework` | `mount`, `render`, host/runtime helpers, types |
+| `@pocketjs/framework/components` | `View`, `Text`, `Image`, `Show`, `For`, `Index`, `Switch`, `Match`, `Screen`, `Focusable`, `FocusScope`, `FocusGrid`, `ActionHandler`, `Portal`, `Modal`, `ActionBar` |
+| `@pocketjs/framework/reactivity` | `createSignal`, `createEffect`, `createMemo`, `onMount`, `onCleanup`, `batch`, `untrack` |
+| `@pocketjs/framework/animation` | `animate`, `spring`, `cancelAnim` |
+| `@pocketjs/framework/lifecycle` | `onFrame`, `onButtonPress`, `createSpriteAnimation`, `pushButtonHandlerBlock` |
+| `@pocketjs/framework/input` | `BTN`, `focusNode`, `getFocused`, `pushFocusScope`, `pushFocusGrid` |
 
 ---
 
-## `@pocketjs`
+## `@pocketjs/framework`
 
 The runtime entry point: mount an app, tear it down, and reach the lower-level host, sweep, style, and pack utilities.
 
@@ -151,7 +151,7 @@ The JS mirror of a native node. A `ref` receives one; `animate`, `spring`, `focu
 
 ---
 
-## `@pocketjs/components`
+## `@pocketjs/framework/components`
 
 Platform primitives and higher-level components. Control-flow components (`Show`, `For`, `Index`, `Switch`, `Match`) are re-exported from Solid unchanged.
 
@@ -275,7 +275,7 @@ See the [Solid control-flow docs](https://www.solidjs.com/docs/latest/api#contro
 
 ---
 
-## `@pocketjs/reactivity`
+## `@pocketjs/framework/reactivity`
 
 Solid's reactivity, re-exported unchanged. Full docs live at [solidjs.com](https://www.solidjs.com/docs/latest/api); summary below.
 
@@ -293,7 +293,7 @@ See [Reactivity](/docs/reactivity/).
 
 ---
 
-## `@pocketjs/animation`
+## `@pocketjs/framework/animation`
 
 Typed motion over `ops.animate`. JS declares the tween once; the Rust core ticks it per vblank at a fixed `dt = 1/60 s`. `prop` is a spec `PROP` name and must be animatable (e.g. `opacity`, `translateY`, `scale`, and color props) — non-animatable props throw. See [Animation](/docs/animation/).
 
@@ -343,7 +343,7 @@ Stops a running animation by the id `animate`/`spring` returned.
 
 ---
 
-## `@pocketjs/lifecycle`
+## `@pocketjs/framework/lifecycle`
 
 Component-scoped per-frame hooks. Each cleans up on owner disposal via `onCleanup`. See [Reactivity](/docs/reactivity/) and [Input & focus](/docs/input-focus/).
 
@@ -395,7 +395,7 @@ Pushes a global block so background `onButtonPress` handlers (those without `all
 
 ---
 
-## `@pocketjs/input`
+## `@pocketjs/framework/input`
 
 Programmatic focus, the button bitmask, and the imperative focus-scope/grid stack. Prefer the `FocusScope` / `FocusGrid` components in app code. See [Input & focus](/docs/input-focus/).
 

--- a/site/content/docs/app-shell.md
+++ b/site/content/docs/app-shell.md
@@ -2,7 +2,7 @@
 
 Screens, focus regions, and floating UI (modals, action bars) are the pieces you
 assemble a whole app out of. PocketJS ships these as small, unopinionated
-primitives from `@pocketjs/components` — thin wrappers over the same
+primitives from `@pocketjs/framework/components` — thin wrappers over the same
 [`View`](/docs/components/), [focus manager](/docs/input-focus/), and frame
 hooks you already use. Nothing here is a framework-within-a-framework: there is
 no router, no navigation stack, no global store. Screen switching is ordinary
@@ -18,7 +18,7 @@ import {
   Portal,
   Modal,
   ActionBar,
-} from "@pocketjs/components";
+} from "@pocketjs/framework/components";
 ```
 
 ## The primitives at a glance
@@ -112,7 +112,7 @@ right edge, LEFT to `i - 1` unless at the left edge, DOWN to `i + columns`, UP t
 row/column instead of clamping.
 
 ```tsx
-import { FocusGrid, Focusable, Text, For } from "@pocketjs/components";
+import { FocusGrid, Focusable, Text, For } from "@pocketjs/framework/components";
 
 <FocusGrid class="flex-row flex-wrap gap-2 w-[440]" columns={3} wrap>
   <For each={games()}>
@@ -149,8 +149,8 @@ value on a shoulder button.
 It renders its `children` (or nothing), so drop it anywhere in the tree.
 
 ```tsx
-import { ActionHandler } from "@pocketjs/components";
-import { BTN } from "@pocketjs/input";
+import { ActionHandler } from "@pocketjs/framework/components";
+import { BTN } from "@pocketjs/framework/input";
 
 <ActionHandler button={BTN.SELECT} onPress={() => setMenuOpen((v) => !v)} />;
 
@@ -164,7 +164,7 @@ import { BTN } from "@pocketjs/input";
 />;
 ```
 
-`BTN` is imported from [`@pocketjs/input`](/docs/input-focus/) and covers
+`BTN` is imported from [`@pocketjs/framework/input`](/docs/input-focus/) and covers
 every PSP button (`SELECT`, `START`, `UP`/`DOWN`/`LEFT`/`RIGHT`, `LTRIGGER`,
 `RTRIGGER`, `TRIANGLE`, `CIRCLE`, `CROSS`, `SQUARE`).
 
@@ -177,7 +177,7 @@ portalled UI never pushes your layout around: a modal or action bar floats on
 top regardless of what the page underneath is doing.
 
 ```tsx
-import { Portal, View, Text } from "@pocketjs/components";
+import { Portal, View, Text } from "@pocketjs/framework/components";
 
 <Portal>
   <View class="absolute top-3 right-3 px-2 py-1 rounded-md bg-white border-slate-200">
@@ -207,8 +207,8 @@ closes, so the page behind can't react to input it can't see.
 | `children`   | `Element`                     | The panel contents.                                                         |
 
 ```tsx
-import { Modal, Focusable, Text, View } from "@pocketjs/components";
-import { createSignal } from "@pocketjs/reactivity";
+import { Modal, Focusable, Text, View } from "@pocketjs/framework/components";
+import { createSignal } from "@pocketjs/framework/reactivity";
 
 function DeletePrompt(props: { onConfirm: () => void }) {
   const [open, setOpen] = createSignal(false);
@@ -256,7 +256,7 @@ default class is
 override `class` for a different look. It takes ordinary `ViewProps` children.
 
 ```tsx
-import { ActionBar, Text, View } from "@pocketjs/components";
+import { ActionBar, Text, View } from "@pocketjs/framework/components";
 
 <ActionBar>
   <View class="flex-row gap-3">
@@ -284,9 +284,9 @@ import {
   Screen,
   Switch,
   View,
-} from "@pocketjs/components";
-import { BTN } from "@pocketjs/input";
-import { createSignal } from "@pocketjs/reactivity";
+} from "@pocketjs/framework/components";
+import { BTN } from "@pocketjs/framework/input";
+import { createSignal } from "@pocketjs/framework/reactivity";
 
 export default function Launcher() {
   const [active, setActive] = createSignal<number | null>(null);

--- a/site/content/docs/architecture.md
+++ b/site/content/docs/architecture.md
@@ -44,8 +44,8 @@ and why each choice was made.
 Reading it top to bottom:
 
 1. **`app.tsx`** is ordinary Solid JSX — components from
-   [`@pocketjs/components`](/docs/components/), signals from
-   [`@pocketjs/reactivity`](/docs/reactivity/), and `className` strings from
+   [`@pocketjs/framework/components`](/docs/components/), signals from
+   [`@pocketjs/framework/reactivity`](/docs/reactivity/), and `className` strings from
    the Tailwind subset.
 2. The **build** (`bun scripts/build.ts <app>`) runs `babel-preset-solid` in
    *universal* mode, compiles the class strings to a binary style table
@@ -136,7 +136,7 @@ reimplemented per platform.
 
 Tweens and springs tick inside Rust, once per vblank, at a **fixed
 `dt = 1/60 s`**. JavaScript only *declares* motion (via
-[`@pocketjs/animation`](/docs/animation/) or `transition-*` classes); it
+[`@pocketjs/framework/animation`](/docs/animation/) or `transition-*` classes); it
 never drives it frame by frame.
 
 The fixed timestep has a powerful consequence: **frame content is a pure
@@ -238,7 +238,7 @@ pocketjs/
     anim.ts             animate() / spring() implementation
     primitives.ts       lower-case host tags → View/Text/Image primitives
     components.ts        ┐
-    reactivity.ts        ├ the public @pocketjs/* subpath modules
+    reactivity.ts        ├ the public @pocketjs/framework/* subpath modules
     animation.ts         │
     hooks.ts, input-api.ts, overlay.ts, index.ts  ┘
 

--- a/site/content/docs/components.md
+++ b/site/content/docs/components.md
@@ -7,7 +7,7 @@ all imported from a single entry point:
 import {
   View, Text, Image,
   Show, For, Index, Switch, Match,
-} from "@pocketjs/components";
+} from "@pocketjs/framework/components";
 ```
 
 There are exactly **three host primitives** — `View`, `Text`, and `Image` —
@@ -111,7 +111,7 @@ the texture in place (via `setImage`), which is exactly how sprite animation
 works:
 
 ```tsx
-import { createSpriteAnimation } from "@pocketjs/lifecycle";
+import { createSpriteAnimation } from "@pocketjs/framework/lifecycle";
 
 const frame = createSpriteAnimation(
   ["spinner-00.svg", "spinner-01.svg", "spinner-02.svg"],
@@ -127,7 +127,7 @@ how images become dcpak textures.
 ## Props
 
 Each primitive has a small, explicit prop interface. `ViewProps`, `TextProps`,
-and `ImageProps` are exported from `@pocketjs/components` for typing your
+and `ImageProps` are exported from `@pocketjs/framework/components` for typing your
 own wrapper components.
 
 | Prop        | `View` | `Text` | `Image` | Type                                       | Notes |
@@ -164,9 +164,9 @@ APIs like [`animate()`](/docs/animation/). Both Solid ref forms work — a plain
 variable (Solid assigns it) or a callback:
 
 ```tsx
-import { animate } from "@pocketjs/animation";
-import { onMount } from "@pocketjs/reactivity";
-import type { NodeMirror } from "@pocketjs/components";
+import { animate } from "@pocketjs/framework/animation";
+import { onMount } from "@pocketjs/framework/reactivity";
+import type { NodeMirror } from "@pocketjs/framework/components";
 
 let underline: NodeMirror | undefined;
 onMount(() => {
@@ -251,7 +251,7 @@ renders.
 
 ## App-shell primitives
 
-`@pocketjs/components` also exports a layer of higher-level primitives that
+`@pocketjs/framework/components` also exports a layer of higher-level primitives that
 compose `View` with focus and overlay behavior:
 
 | Primitive        | Purpose                                                  |

--- a/site/content/docs/getting-started.md
+++ b/site/content/docs/getting-started.md
@@ -33,8 +33,8 @@ bun install
 
 That pulls `solid-js` plus the build-time tooling (the Babel + Tailwind-subset
 compiler, the font baker, and the dev host). There is no separate runtime to
-install — the framework is the `@pocketjs` package in this repo, exposed
-through subpath imports like `@pocketjs/components`.
+install — the framework is the `@pocketjs/framework` package in this repo, exposed
+through subpath imports like `@pocketjs/framework/components`.
 
 ## Write your first component
 
@@ -45,8 +45,8 @@ runtime CSS. State comes from `createSignal`, exactly like Solid.
 Here's a focusable counter. Put it in `demos/hero/app.tsx`:
 
 ```tsx
-import { Show, Text, View } from "@pocketjs/components";
-import { createSignal } from "@pocketjs/reactivity";
+import { Show, Text, View } from "@pocketjs/framework/components";
+import { createSignal } from "@pocketjs/framework/reactivity";
 
 export default function App() {
   const [count, setCount] = createSignal(0);
@@ -96,12 +96,12 @@ entry** does that. Keep it tiny — this is just app bootstrap. Put it in
 ```tsx
 // @title PocketJS: Hero
 import App from "./app.tsx";
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 
 mount(() => <App />);
 ```
 
-`mount` is imported from the package root, `@pocketjs`. It handles host
+`mount` is imported from the package root, `@pocketjs/framework`. It handles host
 detection (PSP vs. PPSSPP vs. browser vs. Bun), wiring the generated style table,
 uploading images from the packed asset file, and installing the per-frame host
 callback — you don't manage any of that yourself. (`mount` builds on the

--- a/site/content/docs/input-focus.md
+++ b/site/content/docs/input-focus.md
@@ -16,7 +16,7 @@ Every host reports the controller as one integer per frame: a bitmask of the but
 currently held. The bit values live in the spec and never change across hosts.
 
 ```ts
-import { BTN } from "@pocketjs/input";
+import { BTN } from "@pocketjs/framework/input";
 ```
 
 | Member | Bit | Notes |
@@ -73,7 +73,7 @@ with `onPress`. The [`Focusable`](/docs/app-shell/) component is just a `View` w
 `focusable` preset to `true`.
 
 ```tsx
-import { Focusable, Text } from "@pocketjs/components";
+import { Focusable, Text } from "@pocketjs/framework/components";
 
 function PlayButton(props: { onStart: () => void }) {
   return (
@@ -111,9 +111,9 @@ variants and how they compile.
 Grab a node with `ref` (refs hand you the `NodeMirror`) and move focus imperatively.
 
 ```tsx
-import { focusNode, getFocused } from "@pocketjs/input";
-import { onMount } from "@pocketjs/reactivity";
-import { Focusable, type NodeMirror } from "@pocketjs/components";
+import { focusNode, getFocused } from "@pocketjs/framework/input";
+import { onMount } from "@pocketjs/framework/reactivity";
+import { Focusable, type NodeMirror } from "@pocketjs/framework/components";
 
 function Menu() {
   let first: NodeMirror | undefined;
@@ -138,8 +138,8 @@ The declarative [`FocusScope`](/docs/app-shell/) component (and
 primitive underneath is `pushFocusScope`.
 
 ```ts
-import { pushFocusScope } from "@pocketjs/input";
-import { onCleanup } from "@pocketjs/reactivity";
+import { pushFocusScope } from "@pocketjs/framework/input";
+import { onCleanup } from "@pocketjs/framework/reactivity";
 
 // `panel` is a NodeMirror captured from a ref.
 const dispose = pushFocusScope(panel, { autoFocus: true, restoreFocus: true });
@@ -164,8 +164,8 @@ semantics on a subtree: `LEFT`/`RIGHT` move within a row, `UP`/`DOWN` move betwe
 Use the [`FocusGrid`](/docs/app-shell/) component, or the primitive:
 
 ```ts
-import { pushFocusGrid } from "@pocketjs/input";
-import { onCleanup } from "@pocketjs/reactivity";
+import { pushFocusGrid } from "@pocketjs/framework/input";
+import { onCleanup } from "@pocketjs/framework/reactivity";
 
 const dispose = pushFocusGrid(gridRoot, { columns: 4, wrap: true });
 onCleanup(dispose);
@@ -204,9 +204,9 @@ bitmask. It cleans itself up when the owning component unmounts. Use it for held
 behavior (movement, charging) or anything that must sample input every frame.
 
 ```tsx
-import { onFrame } from "@pocketjs/lifecycle";
-import { BTN } from "@pocketjs/input";
-import { createSignal } from "@pocketjs/reactivity";
+import { onFrame } from "@pocketjs/framework/lifecycle";
+import { BTN } from "@pocketjs/framework/input";
+import { createSignal } from "@pocketjs/framework/reactivity";
 
 function Player() {
   const [x, setX] = createSignal(0);
@@ -225,8 +225,8 @@ presses. It fires your callback on the frame a matching button transitions from 
 down.
 
 ```tsx
-import { onButtonPress } from "@pocketjs/lifecycle";
-import { BTN } from "@pocketjs/input";
+import { onButtonPress } from "@pocketjs/framework/lifecycle";
+import { BTN } from "@pocketjs/framework/input";
 
 // Fires once per press of TRIANGLE.
 onButtonPress(BTN.TRIANGLE, () => openMenu());
@@ -258,8 +258,8 @@ The declarative equivalent is the [`ActionHandler`](/docs/app-shell/) component,
 wraps `onButtonPress`:
 
 ```tsx
-import { ActionHandler } from "@pocketjs/components";
-import { BTN } from "@pocketjs/input";
+import { ActionHandler } from "@pocketjs/framework/components";
+import { BTN } from "@pocketjs/framework/input";
 
 <ActionHandler button={BTN.START} onPress={() => togglePause()} />;
 ```
@@ -273,8 +273,8 @@ When a modal or overlay owns input, the buttons behind it should go quiet.
 the depth.
 
 ```ts
-import { pushButtonHandlerBlock } from "@pocketjs/lifecycle";
-import { onCleanup } from "@pocketjs/reactivity";
+import { pushButtonHandlerBlock } from "@pocketjs/framework/lifecycle";
+import { onCleanup } from "@pocketjs/framework/reactivity";
 
 const release = pushButtonHandlerBlock();
 onCleanup(release);

--- a/site/content/docs/native-contract.md
+++ b/site/content/docs/native-contract.md
@@ -169,7 +169,7 @@ If the same node is inserted again before the frame ends, `insertNode` removes i
 Sometimes you want to detach a subtree and keep it alive across frames — cache an offscreen panel, hold a pooled row. That opts out of the sweep:
 
 ```ts
-import { retain, release } from "@pocketjs";
+import { retain, release } from "@pocketjs/framework";
 
 retain(node);   // detached but preserved; the sweep skips it (and any subtree containing it)
 // ... later ...

--- a/site/content/docs/overview.md
+++ b/site/content/docs/overview.md
@@ -76,8 +76,8 @@ A complete app: a counter you bump by pressing a focusable button.
 
 ```tsx
 // app.tsx
-import { Text, View } from "@pocketjs/components";
-import { createSignal } from "@pocketjs/reactivity";
+import { Text, View } from "@pocketjs/framework/components";
+import { createSignal } from "@pocketjs/framework/reactivity";
 
 export default function App() {
   const [count, setCount] = createSignal(0);
@@ -101,7 +101,7 @@ callback:
 
 ```tsx
 // main.tsx
-import { mount } from "@pocketjs";
+import { mount } from "@pocketjs/framework";
 import App from "./app.tsx";
 
 mount(() => <App />);

--- a/site/content/docs/reactivity.md
+++ b/site/content/docs/reactivity.md
@@ -8,7 +8,7 @@ FFI boundary into the Rust core.
 
 Everything in this section is re-exported from `solid-js` with no wrapping —
 PocketJS just curates *which* primitives are safe on the target hosts. Import
-them from `@pocketjs/reactivity`:
+them from `@pocketjs/framework/reactivity`:
 
 ```ts
 import {
@@ -19,7 +19,7 @@ import {
   onCleanup,
   batch,
   untrack,
-} from "@pocketjs/reactivity";
+} from "@pocketjs/framework/reactivity";
 ```
 
 If you already know Solid, you know this API. If you're coming from React: these
@@ -52,8 +52,8 @@ A signal is a getter/setter pair. Call the getter to read (and, inside a trackin
 scope, subscribe); call the setter to write.
 
 ```tsx
-import { View, Text } from "@pocketjs/components";
-import { createSignal } from "@pocketjs/reactivity";
+import { View, Text } from "@pocketjs/framework/components";
+import { createSignal } from "@pocketjs/framework/reactivity";
 
 function Counter() {
   const [count, setCount] = createSignal(0);
@@ -91,7 +91,7 @@ of them changes. Use it for side effects — driving an animation, logging, impe
 work — not for producing values you render (use a signal or memo for that).
 
 ```tsx
-import { createSignal, createEffect } from "@pocketjs/reactivity";
+import { createSignal, createEffect } from "@pocketjs/framework/reactivity";
 
 const [level, setLevel] = createSignal(0);
 
@@ -112,7 +112,7 @@ changes, and downstream readers only re-run when the memo's *result* actually
 changes. Reach for it when a derivation is expensive or read in several places.
 
 ```tsx
-import { createSignal, createMemo } from "@pocketjs/reactivity";
+import { createSignal, createMemo } from "@pocketjs/framework/reactivity";
 
 const [items, setItems] = createSignal<string[]>([]);
 const total = createMemo(() => items().length);
@@ -127,9 +127,9 @@ to do one-time imperative setup. It's exactly where the hero demo starts its
 underline sweep:
 
 ```tsx
-import { View, type NodeMirror } from "@pocketjs/components";
-import { animate } from "@pocketjs/animation";
-import { onMount } from "@pocketjs/reactivity";
+import { View, type NodeMirror } from "@pocketjs/framework/components";
+import { animate } from "@pocketjs/framework/animation";
+import { onMount } from "@pocketjs/framework/reactivity";
 
 function Underline() {
   let underline: NodeMirror | undefined;
@@ -146,8 +146,8 @@ a component unmounting, or an effect re-running. Use it to release anything you
 acquired imperatively.
 
 ```tsx
-import { createEffect, onCleanup } from "@pocketjs/reactivity";
-import { animate, cancelAnim } from "@pocketjs/animation";
+import { createEffect, onCleanup } from "@pocketjs/framework/reactivity";
+import { animate, cancelAnim } from "@pocketjs/framework/animation";
 
 createEffect(() => {
   const anim = animate(node, "opacity", 1, { dur: 300 });
@@ -162,7 +162,7 @@ instead of after each write — useful when you update several related signals
 together.
 
 ```tsx
-import { batch } from "@pocketjs/reactivity";
+import { batch } from "@pocketjs/framework/reactivity";
 
 batch(() => {
   setX(10);
@@ -174,7 +174,7 @@ batch(() => {
 memo won't re-run when that signal later changes.
 
 ```tsx
-import { untrack } from "@pocketjs/reactivity";
+import { untrack } from "@pocketjs/framework/reactivity";
 
 createEffect(() => {
   const live = trigger();           // tracked: re-runs when trigger() changes

--- a/site/content/docs/styling.md
+++ b/site/content/docs/styling.md
@@ -107,8 +107,8 @@ There are exactly three ways to make styling dynamic:
 the compiler can see:
 
 ```tsx
-import { View } from "@pocketjs/components";
-import { createSignal } from "@pocketjs/reactivity";
+import { View } from "@pocketjs/framework/components";
+import { createSignal } from "@pocketjs/framework/reactivity";
 
 const [armed, setArmed] = createSignal(false);
 

--- a/site/content/docs/tailwind.md
+++ b/site/content/docs/tailwind.md
@@ -10,7 +10,7 @@ For how styling fits into the pipeline, see [/docs/styling/](/docs/styling/) and
 [/docs/build-pipeline/](/docs/build-pipeline/).
 
 ```tsx
-import { View, Text } from "@pocketjs/components";
+import { View, Text } from "@pocketjs/framework/components";
 
 function Card() {
   return (

--- a/site/home.html
+++ b/site/home.html
@@ -192,8 +192,8 @@
               <span class="lp-dot" aria-hidden="true"></span><span class="lp-dot" aria-hidden="true"></span><span class="lp-dot" aria-hidden="true"></span>
               <span class="lp-codecard__name">Counter.tsx</span>
             </div>
-            <pre class="lp-code"><code><span class="lp-k">import</span> { <span class="lp-t">Text</span>, <span class="lp-t">View</span> } <span class="lp-k">from</span> <span class="lp-s">"@pocketjs/components"</span>;
-<span class="lp-k">import</span> { <span class="lp-f">createSignal</span> } <span class="lp-k">from</span> <span class="lp-s">"@pocketjs/reactivity"</span>;
+            <pre class="lp-code"><code><span class="lp-k">import</span> { <span class="lp-t">Text</span>, <span class="lp-t">View</span> } <span class="lp-k">from</span> <span class="lp-s">"@pocketjs/framework/components"</span>;
+<span class="lp-k">import</span> { <span class="lp-f">createSignal</span> } <span class="lp-k">from</span> <span class="lp-s">"@pocketjs/framework/reactivity"</span>;
 
 <span class="lp-k">export</span> <span class="lp-k">default</span> <span class="lp-k">function</span> <span class="lp-t">Counter</span>() {
   <span class="lp-k">const</span> [n, setN] = <span class="lp-f">createSignal</span>(<span class="lp-n">0</span>);

--- a/site/playground/compiler-entry.ts
+++ b/site/playground/compiler-entry.ts
@@ -31,7 +31,7 @@ import { PSM } from "../../spec/spec.ts";
 
 /** babel `moduleName` — the specifier the universal transform imports its
  *  runtime helpers from. The playground import-map points it at runtime.js. */
-const RENDERER_MODULE = "@pocketjs/renderer";
+const RENDERER_MODULE = "@pocketjs/framework/renderer";
 
 export interface CompileResult {
   /** ESM: JSX compiled to universal-renderer calls, default export = the app. */

--- a/site/playground/playground.js
+++ b/site/playground/playground.js
@@ -6,10 +6,10 @@
 //   host.reset()                    fresh wasm core + globalThis.ui
 //   blob module A = transformed app (default export = the component)
 //   blob module B = `import App from A; mount(() => App(), {styles, dcpak})`
-//   import(B) via the page import-map (@pocketjs -> /pg/runtime.js)
+//   import(B) via the page import-map (@pocketjs/framework -> /pg/runtime.js)
 //   host.begin()                    grab globalThis.frame, drive 60 Hz
 //
-// runtime.js is a singleton (import-map points every @pocketjs specifier at the
+// runtime.js is a singleton (import-map points every @pocketjs/framework specifier at the
 // one URL), so between runs the bootstrap calls __resetAll() to wipe it.
 
 import { EditorView, basicSetup } from "codemirror";
@@ -127,7 +127,7 @@ async function main() {
       const appUrl = URL.createObjectURL(new Blob([result.code], { type: "text/javascript" }));
       const boot =
         `import App from ${JSON.stringify(appUrl)};\n` +
-        `import { mount, __resetAll } from "@pocketjs";\n` +
+        `import { mount, __resetAll } from "@pocketjs/framework";\n` +
         `__resetAll();\n` +
         `globalThis.__pgDispose = mount(() => App(), ` +
         `{ styles: globalThis.__pgStyles, dcpak: globalThis.__pgDcpak });\n`;

--- a/site/playground/runtime-entry.ts
+++ b/site/playground/runtime-entry.ts
@@ -3,9 +3,9 @@
 // site/dist/pg/runtime.js, and the playground import-map points EVERY PocketJS
 // specifier at that one file:
 //
-//   "@pocketjs"            -> /pg/runtime.js
-//   "@pocketjs/components" -> /pg/runtime.js   (etc.)
-//   "@pocketjs/renderer"   -> /pg/runtime.js   (babel `moduleName` target)
+//   "@pocketjs/framework"            -> /pg/runtime.js
+//   "@pocketjs/framework/components" -> /pg/runtime.js   (etc.)
+//   "@pocketjs/framework/renderer"   -> /pg/runtime.js   (babel `moduleName` target)
 //
 // Because all specifiers resolve to the SAME module URL, the compiled app and
 // its bootstrap share ONE runtime instance — one renderer mirror tree, one

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,12 +16,12 @@
     "forceConsistentCasingInFileNames": true,
     "baseUrl": ".",
     "paths": {
-      "@pocketjs": ["./src/index.ts"],
-      "@pocketjs/animation": ["./src/animation.ts"],
-      "@pocketjs/components": ["./src/components.ts"],
-      "@pocketjs/input": ["./src/input-api.ts"],
-      "@pocketjs/lifecycle": ["./src/lifecycle.ts"],
-      "@pocketjs/reactivity": ["./src/reactivity.ts"]
+      "@pocketjs/framework": ["./src/index.ts"],
+      "@pocketjs/framework/animation": ["./src/animation.ts"],
+      "@pocketjs/framework/components": ["./src/components.ts"],
+      "@pocketjs/framework/input": ["./src/input-api.ts"],
+      "@pocketjs/framework/lifecycle": ["./src/lifecycle.ts"],
+      "@pocketjs/framework/reactivity": ["./src/reactivity.ts"]
     }
   },
   "include": ["src", "compiler", "demos", "test", "spec", "host-web"]


### PR DESCRIPTION
## Summary

Renames the public package surface from `@pocketjs` / `@pocketjs/*` to `@pocketjs/framework` / `@pocketjs/framework/*` on top of the latest `main`.

This covers the runtime package name, TypeScript path aliases, demo imports, build resolver, Solid transform resolver, README examples, pocketjs.dev docs, homepage snippets, and playground import-map/moduleName wiring.

## Impact

Consumers should now use imports such as:

```ts
import { mount } from "@pocketjs/framework";
import { View, Text } from "@pocketjs/framework/components";
import { createSignal } from "@pocketjs/framework/reactivity";
```

The build pipeline now resolves only `@pocketjs/framework` and its subpaths for framework-local modules, so stale `@pocketjs/*` imports are no longer accepted by the local resolver.

## Validation

- `bun install`
- `bunx tsc --noEmit`
- `bun scripts/wasm.ts`
- `bun run test`
- `bun scripts/build.ts hero-main`
- `bun site/build.ts`
- `bun site/verify.ts`
- `git diff --check`
- Residual scan for old `@pocketjs` imports not under `/framework`, `@pocketjs/core`, `@pocketjs/framework/framework`, `psp-ui`, and `PSPUI`