### PR TITLE
chore: update repository links

### DIFF
--- a/site/home.html
+++ b/site/home.html
@@ -14,7 +14,7 @@
       <nav class="lp-nav__links" aria-label="Primary">
         <a class="lp-nav__link" href="/docs/overview/">Docs</a>
         <a class="lp-nav__link" href="/playground/">Playground</a>
-        <a class="lp-nav__link lp-nav__gh" href="https://github.com/doodlewind/pocketjs" target="_blank" rel="noreferrer">
+        <a class="lp-nav__link lp-nav__gh" href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 4.7 18 5 18 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
           <span class="lp-nav__ghlabel">GitHub</span>
         </a>
@@ -264,7 +264,7 @@
         <div>
           <h4>Project</h4>
           <ul>
-            <li><a href="https://github.com/doodlewind/pocketjs" target="_blank" rel="noreferrer">GitHub</a></li>
+            <li><a href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">GitHub</a></li>
             <li><a href="/docs/native-contract/">Native contract</a></li>
             <li><a href="/docs/build-pipeline/">Build pipeline</a></li>
           </ul>

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -3,7 +3,7 @@
 // Tailwind (utilities inline + a few component classes in assets/tailwind.css).
 
 const YEAR = 2026;
-const GH = "https://github.com/doodlewind/pocketjs";
+const GH = "https://github.com/pocket-stack/pocketjs";
 
 export interface PageOpts {
   title: string | null; // null uses the bare wordmark (homepage)


### PR DESCRIPTION
## Summary
- update PocketJS site GitHub links to the pocket-stack organization
- keep user-facing repository references aligned after the transfer

## Validation
- git diff --check
- rg -n "doodlewind/pocketjs|github\.com/doodlewind/pocketjs" -g "!node_modules" -g "!dist" -g "!target"