### PR TITLE
Rename dcpak assets to pak

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -19,7 +19,7 @@ finding is folded in below and marked **[R]**.
         app.tsx  (Solid + Tailwind classes)
            │  babel-preset-solid {generate:'universal'}  (two-pass build)
            ▼
-        bundle.js      styles.bin + font atlases + images ──► app.dcpak
+        bundle.js      styles.bin + font atlases + images ──► app.pak
            │
    ┌── QuickJS (PSP) ──────────┐   ┌── browser / Bun ────────┐
    │ Solid runtime             │   │ Solid runtime           │
@@ -81,7 +81,7 @@ PocketJS/
   spec/
     spec.ts            SINGLE SOURCE OF TRUTH: op codes, prop ids, enums,
                        style-table format, atlas format, DrawList format,
-                       dcpak container constants (magic/header/entry/align/fnv1a) [R]
+                       pak container constants (magic/header/entry/align/fnv1a) [R]
     gen-rust.ts        codegen → core/src/spec.rs (committed)
   core/                Rust lib `pocketjs-core` — #![no_std] + alloc
     src/lib.rs         pub struct Ui: apply-ops, tick(1/60), draw() → &DrawList
@@ -102,7 +102,7 @@ PocketJS/
   native/              Rust bin `pocketjs-psp` — the EBOOT (standalone dir, lone bin)
     Cargo.toml         psp {external-c-heap, abort-only, external-global-alloc},
                        libquickjs-sys, pocketjs-core (path)
-    build.rs           embeds $POCKETJS_APP js + app.dcpak (PSPJS_GAME pattern);
+    build.rs           embeds $POCKETJS_APP js + app.pak (PSPJS_GAME pattern);
                        [features] capture = [] for the E2E frame-dump
     targets/mipsel-sony-psp.json  copied from runtime/ (self-contained)
     src/main.rs        boot (2MB USER|VFPU worker), vblank loop, job pump
@@ -114,7 +114,7 @@ PocketJS/
     src/ge.rs          DrawList → sceGu; PER-FRAME BUMP VERTEX ARENA (Vec<Chunk16>
                        pool allocated at boot, reset after sceGuSync — never reuse
                        a region within a frame; GE reads async in Direct mode) [R]
-    src/dcpak.rs       native read-only .dcpak walker: styles + atlases + images
+    src/pak.rs       native read-only .pak walker: styles + atlases + images
                        are fed to core DIRECTLY from include_bytes! before JS eval
                        (zero QuickJS-heap transit) [R]
   wasm/                Rust cdylib `pocketjs-wasm` — core + rasterizer, no wasm-bindgen
@@ -129,7 +129,7 @@ PocketJS/
                        removed and not re-attached during the frame; retain()/release()
                        escape hatch; FinalizationRegistry as backstop tier.
     host.ts            HostOps interface + PSP(globalThis.ui) / wasm bindings
-    dcpak.ts           QuickJS-safe reader (fromCharCode, NO TextDecoder) — web/test
+    pak.ts           QuickJS-safe reader (fromCharCode, NO TextDecoder) — web/test
                        hosts load styles/atlases through ops; PSP does it natively [R]
     styles.ts          class-string → styleId map (imports generated table)
     input.ts           edge-detect, focus manager (refocus on removal:
@@ -147,7 +147,7 @@ PocketJS/
                        token parses as a supported utility (else ignored) [R]
     bake-font.ts       atlas baker (charset from AST scan + ASCII always + extraChars
                        option [R]; gid 0 = tofu box)
-    dcpak.ts           writer (standalone; constants imported from spec/spec.ts)
+    pak.ts           writer (standalone; constants imported from spec/spec.ts)
   host-web/
     index.html         480×272 canvas playground, virtual buttons, demo picker
     engine.js          loads wasm, HostOps, rAF loop (fixed-step), keyboard map
@@ -179,12 +179,12 @@ PocketJS/
 2. **Compile styles & fonts.** `tailwind.ts` validates tokens (all-or-nothing
    per literal), assigns styleIds, writes `styles.bin` + `styles.generated.ts`
    (excluded from future scans). `bake-font.ts` bakes atlas slots for the
-   collected charset. `dcpak.ts` packs styles.bin + atlases + images →
-   `<app>.dcpak`.
+   collected charset. `pak.ts` packs styles.bin + atlases + images →
+   `<app>.pak`.
 3. **Pass 2 — bundle.** `Bun.build` with an onLoad plugin that serves the
    *cached* pass-1 transforms (styles.generated.ts now exists), `format:
    "iife"`, `minify:false`, `target:"browser"`. Output `<app>.js` next to the
-   dcpak.
+   pak.
 
 The PSP build (`scripts/psp.ts`) then runs `rustup run nightly-2026-05-28
 cargo psp` with the exact env block from `runtime/build.ts` (LLVM PATH,
@@ -212,7 +212,7 @@ children[], …}`) so reconciler *reads* never cross the FFI. Handles are `i32`
 | animate | `(id, propId, to:f64, durMs, easing, delayMs) → animId` | from = current |
 | cancelAnim | `(animId)` | |
 | setFocus | `(idOr0)` | applies `focus:` variant natively |
-| loadStyles / loadFontAtlas | `(buf …)` | **web/test hosts only** — on PSP, native/src/dcpak.rs feeds core directly from include_bytes! **[R]** |
+| loadStyles / loadFontAtlas | `(buf …)` | **web/test hosts only** — on PSP, native/src/pak.rs feeds core directly from include_bytes! **[R]** |
 | measureText | `(str, fontSlot) → width` | JS convenience; layout measures natively |
 
 **Text model [R].** A `<text>` element lays out its text-node children as one
@@ -311,7 +311,7 @@ One FFI crossing per steady-state frame; DrawList ≤ ~40 sceGuDrawArray calls,
 ≤ ~2000 quads; per-frame vertex bytes ≈48 KB from the bump pool; layout-prop
 animations relayout that frame (prefer transforms); Solid effects only on
 interaction. Boot: unminified but tree-shaken bundle; all binary assets in the
-dcpak (base64-in-JS is the known QuickJS boot killer).
+pak (base64-in-JS is the known QuickJS boot killer).
 
 ## What v1 explicitly punts
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Full design + contracts: [DESIGN.md](./DESIGN.md).
 
 ```sh
 bun install
-bun scripts/build.ts hero             # -> dist/hero.js + dist/hero.dcpak
+bun scripts/build.ts hero             # -> dist/hero.js + dist/hero.pak
 ```
 
 The build is two-pass: pass 1 babel-transforms every module reachable from the
@@ -22,7 +22,7 @@ entry (babel-preset-solid `generate:'universal'`, content-hash cached in
 `.cache/`) while collecting class strings + text codepoints from the AST; then
 the Tailwind compiler writes `styles.bin` + `src/styles.generated.ts`, the font
 baker rasterizes Inter atlas slots for exactly the characters your app uses,
-and everything is packed into `dist/<app>.dcpak`. Pass 2 bundles with Bun
+and everything is packed into `dist/<app>.pak`. Pass 2 bundles with Bun
 (iife, unminified) from the cached transforms.
 
 ```tsx
@@ -42,7 +42,7 @@ const [count, setCount] = createSignal(0);
 ```
 
 Mounting entries should look like ordinary app bootstrap code; the framework
-handles host detection, the generated style table, dcpak image uploads and the
+handles host detection, the generated style table, pak image uploads and the
 host frame callback:
 
 ```tsx

--- a/compiler/bake-svg.ts
+++ b/compiler/bake-svg.ts
@@ -1,11 +1,11 @@
 // compiler/bake-svg.ts — tiny offline SVG rasterizer for baked UI icons.
 //
-// This is deliberately scoped to the assets we want to ship in dcpak today:
+// This is deliberately scoped to the assets we want to ship in pak today:
 // pow2-sized SVGs containing filled <circle> elements. Edges are supersampled
 // before being written as straight-alpha RGBA, so icons keep subpixel coverage
 // on both the wasm rasterizer and the PSP texture path.
 
-import type { DecodedImage } from "./dcpak.ts";
+import type { DecodedImage } from "./pak.ts";
 
 export const SVG_SUPERSAMPLE = 4;
 

--- a/compiler/pak.ts
+++ b/compiler/pak.ts
@@ -1,7 +1,7 @@
-// compiler/dcpak.ts — standalone .dcpak writer (dreamcart-container-compatible).
+// compiler/pak.ts — standalone .pak writer (dreamcart-container-compatible).
 //
-// Byte-for-byte the dreamcart format (docs/dcpak-format.md v1; constants
-// pinned in spec/spec.ts DCPAK_*), so existing tooling opens PocketJS packs.
+// Byte-for-byte the dreamcart format (docs/pak-format.md v1; constants
+// pinned in spec/spec.ts PAK_*), so existing tooling opens PocketJS packs.
 // PocketJS entries:
 //   ui:styles        styles.bin (compiler/tailwind.ts)
 //   ui:font.<slot>   one FONT ATLAS blob per baked slot (compiler/bake-font.ts)
@@ -22,49 +22,49 @@
 
 import { inflateSync } from "node:zlib";
 import {
-  DCPAK_ALIGN,
-  DCPAK_DTYPE,
-  DCPAK_ENTRY_SIZE,
-  DCPAK_FNV1A_OFFSET_BASIS,
-  DCPAK_FNV1A_PRIME,
-  DCPAK_HEADER_SIZE,
-  DCPAK_MAGIC,
-  DCPAK_VERSION,
+  PAK_ALIGN,
+  PAK_DTYPE,
+  PAK_ENTRY_SIZE,
+  PAK_FNV1A_OFFSET_BASIS,
+  PAK_FNV1A_PRIME,
+  PAK_HEADER_SIZE,
+  PAK_MAGIC,
+  PAK_VERSION,
   PSM,
   TEX_MAX_DIM,
 } from "../spec/spec.ts";
 
 export interface PakBlob {
   key: string;
-  /** DCPAK_DTYPE code (advisory element type). */
+  /** PAK_DTYPE code (advisory element type). */
   dtype: number;
   data: Uint8Array;
 }
 
 export function fnv1a(s: string): number {
-  let h = DCPAK_FNV1A_OFFSET_BASIS;
+  let h = PAK_FNV1A_OFFSET_BASIS;
   for (let i = 0; i < s.length; i++) {
     h ^= s.charCodeAt(i);
-    h = Math.imul(h, DCPAK_FNV1A_PRIME);
+    h = Math.imul(h, PAK_FNV1A_PRIME);
   }
   return h >>> 0;
 }
 
-const align = (n: number): number => (n + (DCPAK_ALIGN - 1)) & ~(DCPAK_ALIGN - 1);
+const align = (n: number): number => (n + (PAK_ALIGN - 1)) & ~(PAK_ALIGN - 1);
 
-/** Pack blobs into .dcpak bytes. Entries sorted by key; blobs 16-aligned. */
+/** Pack blobs into .pak bytes. Entries sorted by key; blobs 16-aligned. */
 export function pack(blobsIn: PakBlob[]): Uint8Array {
   const blobs = [...blobsIn].sort((a, b) => (a.key < b.key ? -1 : a.key > b.key ? 1 : 0));
   const seen = new Set<string>();
   for (const b of blobs) {
-    if (seen.has(b.key)) throw new Error("dcpak: duplicate key " + b.key);
+    if (seen.has(b.key)) throw new Error("pak: duplicate key " + b.key);
     seen.add(b.key);
   }
 
   const enc = new TextEncoder();
   const names = blobs.map((b) => enc.encode(b.key));
-  const dirOffset = DCPAK_HEADER_SIZE;
-  const namesOffset = dirOffset + blobs.length * DCPAK_ENTRY_SIZE;
+  const dirOffset = PAK_HEADER_SIZE;
+  const namesOffset = dirOffset + blobs.length * PAK_ENTRY_SIZE;
   let nameCursor = 0;
   const nameOffsets = names.map((n) => {
     const o = nameCursor;
@@ -81,8 +81,8 @@ export function pack(blobsIn: PakBlob[]): Uint8Array {
 
   const out = new Uint8Array(blobCursor);
   const dv = new DataView(out.buffer);
-  dv.setUint32(0, DCPAK_MAGIC, true);
-  dv.setUint16(4, DCPAK_VERSION, true);
+  dv.setUint32(0, PAK_MAGIC, true);
+  dv.setUint16(4, PAK_VERSION, true);
   dv.setUint16(6, 0, true);
   dv.setUint32(8, blobs.length, true);
   dv.setUint32(12, dirOffset, true);
@@ -92,7 +92,7 @@ export function pack(blobsIn: PakBlob[]): Uint8Array {
   dv.setUint32(28, 0, true);
 
   for (let i = 0; i < blobs.length; i++) {
-    const e = dirOffset + i * DCPAK_ENTRY_SIZE;
+    const e = dirOffset + i * PAK_ENTRY_SIZE;
     dv.setUint32(e + 0, fnv1a(blobs[i].key), true);
     dv.setUint32(e + 4, blobOffsets[i], true);
     dv.setUint32(e + 8, blobs[i].data.length, true);
@@ -107,18 +107,18 @@ export function pack(blobsIn: PakBlob[]): Uint8Array {
   return out;
 }
 
-/** Parse .dcpak bytes back into blobs (round-trips pack(); build-side only). */
+/** Parse .pak bytes back into blobs (round-trips pack(); build-side only). */
 export function unpack(file: Uint8Array): PakBlob[] {
   const dv = new DataView(file.buffer, file.byteOffset, file.byteLength);
-  if (dv.getUint32(0, true) !== DCPAK_MAGIC) throw new Error("dcpak: bad magic");
-  if (dv.getUint16(4, true) !== DCPAK_VERSION) throw new Error("dcpak: unsupported version");
+  if (dv.getUint32(0, true) !== PAK_MAGIC) throw new Error("pak: bad magic");
+  if (dv.getUint16(4, true) !== PAK_VERSION) throw new Error("pak: unsupported version");
   const entryCount = dv.getUint32(8, true);
   const dirOff = dv.getUint32(12, true);
   const namesOff = dv.getUint32(16, true);
   const dec = new TextDecoder();
   const blobs: PakBlob[] = [];
   for (let i = 0; i < entryCount; i++) {
-    const e = dirOff + i * DCPAK_ENTRY_SIZE;
+    const e = dirOff + i * PAK_ENTRY_SIZE;
     const blobOff = dv.getUint32(e + 4, true);
     const byteLen = dv.getUint32(e + 8, true);
     const nameOff = dv.getUint32(e + 12, true);
@@ -145,9 +145,9 @@ export function encodeImageEntry(img: DecodedImage, psm: number = PSM.PSM_8888):
   const { width: w, height: h, rgba } = img;
   const pow2 = (n: number) => n > 0 && (n & (n - 1)) === 0;
   if (!pow2(w) || !pow2(h) || w > TEX_MAX_DIM || h > TEX_MAX_DIM) {
-    throw new Error(`dcpak image: dims must be pow2 <= ${TEX_MAX_DIM}, got ${w}x${h}`);
+    throw new Error(`pak image: dims must be pow2 <= ${TEX_MAX_DIM}, got ${w}x${h}`);
   }
-  if (rgba.length !== w * h * 4) throw new Error("dcpak image: rgba length mismatch");
+  if (rgba.length !== w * h * 4) throw new Error("pak image: rgba length mismatch");
   const bpp = psm === PSM.PSM_8888 ? 4 : 2;
   const out = new Uint8Array(8 + w * h * bpp);
   const dv = new DataView(out.buffer);
@@ -165,7 +165,7 @@ export function encodeImageEntry(img: DecodedImage, psm: number = PSM.PSM_8888):
       dv.setUint16(8 + i * 2, (a << 12) | (b << 8) | (g << 4) | r, true);
     }
   } else {
-    throw new Error(`dcpak image: unsupported psm ${psm}`);
+    throw new Error(`pak image: unsupported psm ${psm}`);
   }
   return out;
 }
@@ -284,4 +284,4 @@ export function decodePng(bytes: Uint8Array): DecodedImage {
 export const KEY_STYLES = "ui:styles";
 export const keyFont = (slot: number): string => `ui:font.${slot}`;
 export const keyImage = (name: string): string => `ui:img.${name}`;
-export { DCPAK_DTYPE };
+export { PAK_DTYPE };

--- a/compiler/solid-plugin.ts
+++ b/compiler/solid-plugin.ts
@@ -42,7 +42,7 @@ const PACKAGE_NAME = "@pocketjs/framework";
 const CACHE_DIR = new URL("../.cache/transforms/", import.meta.url).pathname;
 /** Bump to invalidate every cached transform (changes to this file's
  *  collector/lints/options — dependency versions are hashed separately). */
-const CACHE_VERSION = "5";
+const CACHE_VERSION = "7";
 
 const BANNED_SOLID_IMPORTS = new Set(["createResource", "useTransition", "startTransition"]);
 
@@ -220,11 +220,13 @@ export async function transformFile(path: string, src: string): Promise<Transfor
   const res = await transformAsync(src, {
     filename: path,
     // presets run last-to-first: preset-typescript strips types first, then
-    // babel-preset-solid compiles the (still present, isTSX) JSX [R].
+    // babel-preset-solid compiles JSX [R]. parserOpts enables JSX parsing
+    // without the removed Babel 8 isTSX/allExtensions preset options.
     presets: [
       [solidPreset, { generate: "universal", moduleName: RENDERER_PATH }],
-      [tsPreset, { isTSX: true, allExtensions: true }],
+      [tsPreset, {}],
     ],
+    parserOpts: { plugins: ["jsx"] },
     plugins: [makeCollector(collected)],
     babelrc: false,
     configFile: false,

--- a/compiler/tailwind.ts
+++ b/compiler/tailwind.ts
@@ -534,7 +534,7 @@ export function generateStylesModule(c: CompiledStyles): string {
   L.push("/** Number of records in styles.bin (valid styleIds are 0..COUNT-1). */");
   L.push(`export const STYLE_COUNT = ${c.records.length};`);
   L.push("");
-  L.push("/** Baked font-atlas slots shipped in the dcpak: slot -> metrics. */");
+  L.push("/** Baked font-atlas slots shipped in the pak: slot -> metrics. */");
   L.push("export const FONT_SLOTS: Record<number, { px: number; bold: boolean }> = {");
   for (const slot of c.usedFontSlots) {
     const { px, bold } = fontSlotInfo(slot);

--- a/core/src/spec.rs
+++ b/core/src/spec.rs
@@ -309,9 +309,9 @@ pub mod draw_op {
     pub const TRI: u32 = 7;
 }
 
-/// .dcpak container constants (byte-compatible with dreamcart's format;
-/// copied from framework/bake/dcpak.ts + docs/dcpak-format.md).
-pub mod dcpak {
+/// .pak container constants (byte-compatible with dreamcart's format;
+/// copied from framework/bake/pak.ts + docs/pak-format.md).
+pub mod pak {
     pub const MAGIC: u32 = 0x4b504344; // 'DCPK' LE
     pub const VERSION: u16 = 1;
     pub const HEADER_SIZE: usize = 32;

--- a/host-web/engine.js
+++ b/host-web/engine.js
@@ -2,7 +2,7 @@
 //
 // Loads pocketjs.wasm (core + software rasterizer), installs the HostOps
 // binding (wasm-ops.js — shared with test/golden.ts) as globalThis.ui,
-// installs the demo's .dcpak as globalThis.__dcpak, evals the demo bundle
+// installs the demo's .pak as globalThis.__pak, evals the demo bundle
 // (which mounts the app and installs globalThis.frame), then drives a
 // fixed-timestep 60 Hz loop: frame(buttons) -> ui_tick -> ui_render ->
 // putImageData onto a 480x272 canvas (CSS-scaled, pixelated).
@@ -155,7 +155,7 @@ export async function mount(theCanvas, opts = {}) {
 }
 
 /**
- * Load (or reload) a demo: fresh core, __dcpak + globalThis.ui BEFORE eval,
+ * Load (or reload) a demo: fresh core, __pak + globalThis.ui BEFORE eval,
  * fresh function scope per reload, then start the loop. Returns null on
  * success, the error otherwise.
  */
@@ -169,8 +169,8 @@ export async function load(name) {
   globalThis.ui = wasm.ops;
   globalThis.frame = undefined;
   try {
-    const pak = await fetch("dist/" + name + ".dcpak");
-    globalThis.__dcpak = pak.ok ? await pak.arrayBuffer() : undefined;
+    const pak = await fetch("dist/" + name + ".pak");
+    globalThis.__pak = pak.ok ? await pak.arrayBuffer() : undefined;
     const srcRes = await fetch("dist/" + name + ".js");
     if (!srcRes.ok) throw new Error("dist/" + name + ".js not found — run: bun scripts/build.ts " + name);
     const src = await srcRes.text();

--- a/host-web/serve.ts
+++ b/host-web/serve.ts
@@ -23,7 +23,7 @@ const MIME: Record<string, string> = {
   json: "application/json",
   wasm: "application/wasm",
   png: "image/png",
-  dcpak: "application/octet-stream",
+  pak: "application/octet-stream",
 };
 
 function fileResponse(path: string): Response {
@@ -49,7 +49,7 @@ function demoManifest(): { name: string; hasPak: boolean; mounts: boolean }[] {
       const src = readFileSync(DIST_DIR + f, "utf8");
       return {
         name,
-        hasPak: existsSync(DIST_DIR + name + ".dcpak"),
+        hasPak: existsSync(DIST_DIR + name + ".pak"),
         mounts: src.includes("installFrameHandler"),
       };
     });

--- a/host-web/wasm-ops.js
+++ b/host-web/wasm-ops.js
@@ -2,7 +2,7 @@
 // the browser dev host (engine.js) and the headless golden harness
 // (test/golden.ts). Plain ES module, zero dependencies; needs only
 // WebAssembly + TextEncoder (both exist in every browser and in Bun — the
-// QuickJS "no TextEncoder" constraint applies only to src/dcpak.ts, which
+// QuickJS "no TextEncoder" constraint applies only to src/pak.ts, which
 // this file is not).
 //
 // ABI (see wasm/src/lib.rs): one export per ui.* op; strings/buffers cross
@@ -82,11 +82,11 @@ export async function createWasmUi(wasm) {
 }
 
 /**
- * Upload every `ui:img.*` dcpak entry through ops.uploadTexture and return a
+ * Upload every `ui:img.*` pak entry through ops.uploadTexture and return a
  * Map of image name (the JSX `src` key) -> texture handle. Blob layout is the
- * compiler/dcpak.ts IMG entry: 8-byte header {u16 w, u16 h, u8 psm, 3B pad} +
+ * compiler/pak.ts IMG entry: 8-byte header {u16 w, u16 h, u8 psm, 3B pad} +
  * raw pixels. `getEntry(key)` / `listEntries(prefix)` come from the runtime's
- * dcpak reader (or any equivalent).
+ * pak reader (or any equivalent).
  */
 export function uploadPackImages(ops, listEntries, getEntry) {
   const IMG_PREFIX = "ui:img.";

--- a/native/build.rs
+++ b/native/build.rs
@@ -3,7 +3,7 @@
 //! PSPJS_GAME pattern), renamed to POCKETJS_APP.
 //!
 //! Set `POCKETJS_APP` to an app name whose build outputs exist in ../dist/
-//! (written by scripts/build.ts as `<app>.js` + `<app>.dcpak`):
+//! (written by scripts/build.ts as `<app>.js` + `<app>.pak`):
 //!   POCKETJS_APP=hero bun scripts/psp.ts
 //!
 //! Both embeds have EMPTY fallbacks so include_str!/include_bytes! in main.rs
@@ -30,14 +30,14 @@ fn main() {
     code.push('\0');
     fs::write(Path::new(&out_dir).join("game.js"), code).unwrap();
 
-    // Asset pack (styles.bin + font atlases + images; .dcpak container) ->
-    // $OUT_DIR/app.dcpak. Empty when absent; main.rs skips an empty pack.
-    let dcpak = if app.is_empty() {
+    // Asset pack (styles.bin + font atlases + images; .pak container) ->
+    // $OUT_DIR/app.pak. Empty when absent; main.rs skips an empty pack.
+    let pak = if app.is_empty() {
         Vec::new()
     } else {
-        fs::read(dist.join(format!("{app}.dcpak"))).unwrap_or_default()
+        fs::read(dist.join(format!("{app}.pak"))).unwrap_or_default()
     };
-    fs::write(Path::new(&out_dir).join("app.dcpak"), dcpak).unwrap();
+    fs::write(Path::new(&out_dir).join("app.pak"), pak).unwrap();
 
     // Scripted input for deterministic capture builds (test/e2e-ppsspp.ts):
     // "frame:mask,frame:mask" baked into the EBOOT, consumed by main.rs only

--- a/native/src/ffi.rs
+++ b/native/src/ffi.rs
@@ -10,8 +10,8 @@
 //! tree so reconciler reads never cross this boundary.
 //!
 //! Extra (not a spec op): `ui.__textures` — a plain JS object mapping the
-//! dcpak image names (`ui:img.<name>` -> `<name>`) to their upload_texture
-//! handles, built at boot from dcpak::feed's table. src/index.ts's PSP branch
+//! pak image names (`ui:img.<name>` -> `<name>`) to their upload_texture
+//! handles, built at boot from pak::feed's table. src/index.ts's PSP branch
 //! walks it and calls renderer.registerTexture(name, handle) so JSX
 //! `src="<name>"` resolves.
 
@@ -277,7 +277,7 @@ unsafe extern "C" fn js_set_focus(
     JS_UNDEFINED
 }
 
-/// Not used on PSP (dcpak.rs feeds the core natively before eval), but
+/// Not used on PSP (pak.rs feeds the core natively before eval), but
 /// registered so the full HostOps surface exists. Returns bool.
 unsafe extern "C" fn js_load_styles(
     ctx: *mut JSContext,
@@ -350,7 +350,7 @@ unsafe fn add_fn(
 }
 
 /// Install `globalThis.ui` (full HostOps surface + `__textures`).
-/// `textures` comes from dcpak::feed.
+/// `textures` comes from pak::feed.
 pub unsafe fn register(ctx: *mut JSContext, global: JSValue, textures: &[(String, i32)]) {
     let ui_obj = JS_NewObject(ctx);
 
@@ -371,7 +371,7 @@ pub unsafe fn register(ctx: *mut JSContext, global: JSValue, textures: &[(String
     add_fn(ctx, ui_obj, b"loadFontAtlas\0", js_load_font_atlas, 1);
     add_fn(ctx, ui_obj, b"measureText\0", js_measure_text, 2);
 
-    // ui.__textures: dcpak image name -> texture handle (see module docs).
+    // ui.__textures: pak image name -> texture handle (see module docs).
     let tex_obj = JS_NewObject(ctx);
     for (name, handle) in textures {
         let mut cname: Vec<u8> = Vec::with_capacity(name.len() + 1);

--- a/native/src/main.rs
+++ b/native/src/main.rs
@@ -11,7 +11,7 @@
 //! Boot skeleton COPIED from the proven dreamcart runtime/src/main.rs with the
 //! gfx/gfx3d/bridge registrations replaced by the PocketJS stack:
 //!   - allocator.rs (src/alloc.rs): arena-backed #[global_allocator] [R]
-//!   - dcpak.rs: feeds styles/atlases/images to the core BEFORE JS eval
+//!   - pak.rs: feeds styles/atlases/images to the core BEFORE JS eval
 //!   - ffi.rs: globalThis.ui — the HostOps surface over the single core Ui
 //!   - ge.rs: DrawList -> sceGu with a per-frame bump vertex arena [R]
 //!
@@ -39,7 +39,7 @@ use psp::{Align16, BUF_WIDTH, SCREEN_HEIGHT, SCREEN_WIDTH};
 mod allocator;
 mod arena;
 mod c_heap;
-mod dcpak;
+mod pak;
 mod ffi;
 mod ge;
 mod qjs_alloc;
@@ -52,10 +52,10 @@ static mut LIST: Align16<[u32; 0x40000]> = Align16([0; 0x40000]);
 // App bundle selected by POCKETJS_APP (see build.rs), NUL-terminated there for
 // JS_Eval (which wants input[len] == '\0'). Empty when built with no app.
 static APP_JS: &str = include_str!(concat!(env!("OUT_DIR"), "/game.js"));
-// Asset pack: styles.bin + font atlases + images (.dcpak container). Fed to
-// the core natively (dcpak.rs) BEFORE JS eval; also exposed read-only to JS
-// as __dcpak. Aliases .rodata — JS must never write through it.
-static APP_DCPAK: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/app.dcpak"));
+// Asset pack: styles.bin + font atlases + images (.pak container). Fed to
+// the core natively (pak.rs) BEFORE JS eval; also exposed read-only to JS
+// as __pak. Aliases .rodata — JS must never write through it.
+static APP_PAK: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "/app.pak"));
 static POCKETJS_TRACE: &str = env!("POCKETJS_TRACE");
 
 // Build-time scripted input for deterministic PPSSPPHeadless captures
@@ -217,9 +217,9 @@ unsafe fn run() {
     trace("run: init ui ok");
     // Feed styles.bin + font atlases + images straight from .rodata to the
     // core BEFORE any JS runs (zero QuickJS-heap transit) [R].
-    trace("run: dcpak feed begin");
-    let textures = dcpak::feed(ui, APP_DCPAK);
-    trace("run: dcpak feed ok");
+    trace("run: pak feed begin");
+    let textures = pak::feed(ui, APP_PAK);
+    trace("run: pak feed ok");
 
     // ---- QuickJS ----
     trace("run: JS_NewRuntime begin");
@@ -242,20 +242,20 @@ unsafe fn run() {
     ffi::register(ctx, global, &textures);
     trace("run: register ui ok");
 
-    // Expose the asset pack read-only as globalThis.__dcpak (zero-copy over
+    // Expose the asset pack read-only as globalThis.__pak (zero-copy over
     // .rodata; free_func = None). Web/test hosts feed core through loadStyles/
-    // loadFontAtlas ops instead — on PSP dcpak.rs already did it natively.
-    if !APP_DCPAK.is_empty() {
+    // loadFontAtlas ops instead — on PSP pak.rs already did it natively.
+    if !APP_PAK.is_empty() {
         let ab = JS_NewArrayBuffer(
             ctx,
-            APP_DCPAK.as_ptr() as *mut u8,
-            APP_DCPAK.len(),
+            APP_PAK.as_ptr() as *mut u8,
+            APP_PAK.len(),
             None,
             core::ptr::null_mut(),
             0,
         );
-        JS_SetPropertyStr(ctx, global, b"__dcpak\0".as_ptr() as *const _, ab);
-        trace("run: __dcpak installed");
+        JS_SetPropertyStr(ctx, global, b"__pak\0".as_ptr() as *const _, ab);
+        trace("run: __pak installed");
     }
 
     trace("run: JS_Eval begin");

--- a/native/src/pak.rs
+++ b/native/src/pak.rs
@@ -1,10 +1,10 @@
-//! Read-only .dcpak walker: feeds the embedded asset pack (APP_DCPAK,
+//! Read-only .pak walker: feeds the embedded asset pack (APP_PAK,
 //! include_bytes! over .rodata) STRAIGHT to the Rust core BEFORE any JS runs
 //! — zero QuickJS-heap transit [R].
 //!
-//! Container format: spec.ts "DCPAK container constants" (generated into
-//! core spec::dcpak; byte-compatible with dreamcart .dcpak). Entry keys
-//! written by compiler/dcpak.ts:
+//! Container format: spec.ts "PAK container constants" (generated into
+//! core spec::pak; byte-compatible with dreamcart .pak). Entry keys
+//! written by compiler/pak.ts:
 //!   ui:styles        -> Ui::load_styles (styles.bin)
 //!   ui:font.<slot>   -> Ui::load_font_atlas (slot is in the blob header)
 //!   ui:img.<name>    -> decode the 8-byte IMG header {u16 w, u16 h, u8 psm,
@@ -42,7 +42,7 @@ fn rd_u32(b: &[u8], off: usize) -> Option<u32> {
 pub fn feed(ui: &mut Ui, pak: &[u8]) -> Vec<(String, i32)> {
     let mut textures: Vec<(String, i32)> = Vec::new();
     let Some(()) = (|| {
-        if rd_u32(pak, 0)? != spec::dcpak::MAGIC || rd_u16(pak, 4)? != spec::dcpak::VERSION {
+        if rd_u32(pak, 0)? != spec::pak::MAGIC || rd_u16(pak, 4)? != spec::pak::VERSION {
             return None;
         }
         Some(())
@@ -58,9 +58,9 @@ pub fn feed(ui: &mut Ui, pak: &[u8]) -> Vec<(String, i32)> {
     // must not stall boot for ~4.3e9 iterations (or overflow `i * ENTRY_SIZE`
     // on 32-bit) — "malformed packs are skipped, never fatal".
     let count = (count as usize)
-        .min(pak.len().saturating_sub(dir_off as usize) / spec::dcpak::ENTRY_SIZE);
+        .min(pak.len().saturating_sub(dir_off as usize) / spec::pak::ENTRY_SIZE);
     for i in 0..count {
-        let e = dir_off as usize + i * spec::dcpak::ENTRY_SIZE;
+        let e = dir_off as usize + i * spec::pak::ENTRY_SIZE;
         let (Some(blob_off), Some(blob_len), Some(name_off), Some(name_len)) =
             (rd_u32(pak, e + 4), rd_u32(pak, e + 8), rd_u32(pak, e + 12), rd_u16(pak, e + 16))
         else {
@@ -76,15 +76,15 @@ pub fn feed(ui: &mut Ui, pak: &[u8]) -> Vec<(String, i32)> {
         let Ok(key) = core::str::from_utf8(name_bytes) else { continue };
         if key == "ui:styles" {
             if !ui.load_styles(blob) {
-                psp::dprintln!("[PocketJS dcpak] bad styles.bin");
+                psp::dprintln!("[PocketJS pak] bad styles.bin");
             }
         } else if key.starts_with("ui:font.") {
             if !ui.load_font_atlas(blob) {
-                psp::dprintln!("[PocketJS dcpak] bad font atlas {}", key);
+                psp::dprintln!("[PocketJS pak] bad font atlas {}", key);
             }
         } else if let Some(name) = key.strip_prefix("ui:img.") {
             // IMG entry: 8-byte header {u16 w, u16 h, u8 psm, 3B pad} + pixels
-            // (compiler/dcpak.ts encodeImageEntry).
+            // (compiler/pak.ts encodeImageEntry).
             let (Some(w), Some(h), Some(&psm)) = (rd_u16(blob, 0), rd_u16(blob, 2), blob.get(4))
             else {
                 continue;
@@ -104,7 +104,7 @@ pub fn feed(ui: &mut Ui, pak: &[u8]) -> Vec<(String, i32)> {
                 }
                 textures.push((String::from(name), handle));
             } else {
-                psp::dprintln!("[PocketJS dcpak] bad image {} ({}x{} psm {})", key, w, h, psm);
+                psp::dprintln!("[PocketJS pak] bad image {} ({}x{} psm {})", key, w, h, psm);
             }
         }
         // unknown keys: ignored (forward compatible)

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -8,7 +8,7 @@
 //         collecting candidate class strings + text codepoints from the AST.
 // compile tailwind.ts -> styles.bin + src/styles.generated.ts;
 //         bake-font.ts -> font atlas per used slot; demo images (PNG/SVG or a
-//         placeholder); dcpak.ts packs it all -> dist/<app>.dcpak.
+//         placeholder); pak.ts packs it all -> dist/<app>.pak.
 // pass 2  Bun.build (plugin serves the CACHED pass-1 transforms, iife,
 //         target browser, minify false) -> dist/<app>.js.
 //
@@ -22,7 +22,7 @@ import { compileClasses, generateStylesModule } from "../compiler/tailwind.ts";
 import { bakeAtlases } from "../compiler/bake-font.ts";
 import { bakeSvg } from "../compiler/bake-svg.ts";
 import {
-  DCPAK_DTYPE,
+  PAK_DTYPE,
   KEY_STYLES,
   decodePng,
   encodeImageEntry,
@@ -31,7 +31,7 @@ import {
   pack,
   placeholderImage,
   type PakBlob,
-} from "../compiler/dcpak.ts";
+} from "../compiler/pak.ts";
 
 const ROOT = new URL("..", import.meta.url).pathname; // pocketjs/
 const DIST = ROOT + "dist/";
@@ -197,8 +197,8 @@ for (const a of atlases) {
 
 // demo images: any collected literal ending .png/.svg is a candidate asset name
 const blobs: PakBlob[] = [
-  { key: KEY_STYLES, dtype: DCPAK_DTYPE.u8, data: styles.bin },
-  ...atlases.map((a) => ({ key: keyFont(a.slot), dtype: DCPAK_DTYPE.u8, data: a.bytes })),
+  { key: KEY_STYLES, dtype: PAK_DTYPE.u8, data: styles.bin },
+  ...atlases.map((a) => ({ key: keyFont(a.slot), dtype: PAK_DTYPE.u8, data: a.bytes })),
 ];
 const appDir = entry.slice(0, entry.lastIndexOf("/") + 1);
 const imageNames = classStrings.filter((s) => /^[\w./-]+\.(?:png|svg)$/i.test(s));
@@ -218,12 +218,12 @@ for (const name of imageNames) {
     img = placeholderImage();
     console.log(`  image: ${name} not found (tried ${candidates.join(", ")}) — baking a 32x32 placeholder`);
   }
-  blobs.push({ key: keyImage(name), dtype: DCPAK_DTYPE.u8, data: encodeImageEntry(img, PSM.PSM_8888) });
+  blobs.push({ key: keyImage(name), dtype: PAK_DTYPE.u8, data: encodeImageEntry(img, PSM.PSM_8888) });
 }
 
 const pak = pack(blobs);
-await Bun.write(DIST + appName + ".dcpak", pak);
-console.log(`  dcpak: ${blobs.length} entries, ${pak.length} bytes -> dist/${appName}.dcpak`);
+await Bun.write(DIST + appName + ".pak", pak);
+console.log(`  pak: ${blobs.length} entries, ${pak.length} bytes -> dist/${appName}.pak`);
 
 // ---------------------------------------------------------------------------
 // pass 2 — bundle (served from the pass-1 cache)

--- a/scripts/psp.ts
+++ b/scripts/psp.ts
@@ -1,4 +1,4 @@
-// scripts/psp.ts <app> [cargo args…] — build the app JS+dcpak (scripts/
+// scripts/psp.ts <app> [cargo args…] — build the app JS+pak (scripts/
 // build.ts), then the EBOOT:
 //   POCKETJS_APP=<app> rustup run nightly-2026-05-28 cargo psp
 // inside native/, with the exact env block from dreamcart runtime/build.ts
@@ -87,7 +87,7 @@ function mountedAppName(arg: string): string {
 const app = mountedAppName(appArg);
 
 // ---------------------------------------------------------------------------
-// 1. Build the app bundle + dcpak -> dist/<app>.js + dist/<app>.dcpak
+// 1. Build the app bundle + pak -> dist/<app>.js + dist/<app>.pak
 // ---------------------------------------------------------------------------
 
 console.log(`PocketJS psp: building app "${app}"`);

--- a/site/assets/home.js
+++ b/site/assets/home.js
@@ -23,7 +23,7 @@ async function boot() {
 
   const [js, pak] = await Promise.all([
     fetch(PG + "demo-bundles/" + SHOWCASE + ".js").then((r) => r.text()),
-    fetch(PG + "demo-bundles/" + SHOWCASE + ".dcpak").then((r) => r.arrayBuffer()),
+    fetch(PG + "demo-bundles/" + SHOWCASE + ".pak").then((r) => r.arrayBuffer()),
   ]);
   loadEl?.remove();
   host.runIIFE(js, pak);

--- a/site/build.ts
+++ b/site/build.ts
@@ -129,9 +129,9 @@ async function main() {
   const showcase = ["settings-main", "launcher-main", "music-main"];
   for (const s of showcase) {
     const js = ROOT + "dist/" + s + ".js";
-    const pak = ROOT + "dist/" + s + ".dcpak";
+    const pak = ROOT + "dist/" + s + ".pak";
     if (existsSync(js)) copy(js, "pg/demo-bundles/" + s + ".js");
-    if (existsSync(pak)) copy(pak, "pg/demo-bundles/" + s + ".dcpak");
+    if (existsSync(pak)) copy(pak, "pg/demo-bundles/" + s + ".pak");
   }
 
   // 5. static assets + Tailwind CSS (compiled AFTER pages exist so the content

--- a/site/content/docs/api.md
+++ b/site/content/docs/api.md
@@ -23,7 +23,7 @@ The runtime entry point: mount an app, tear it down, and reach the lower-level h
 function mount(code: () => unknown, opts?: MountOptions): () => void
 ```
 
-App-level entry point for demo/application bundles. Resolves ops from `opts.ops` or `globalThis.ui`, loads `opts.dcpak` (when given), uploads the pack's images on injected hosts, feeds the default generated style table (`opts.styles` ?? `STYLE_IDS`), and mounts `code`. Returns a disposer that unmounts and destroys the app subtree. Throws if neither `opts.ops` nor `globalThis.ui` is present.
+App-level entry point for demo/application bundles. Resolves ops from `opts.ops` or `globalThis.ui`, loads `opts.pak` (when given), uploads the pack's images on injected hosts, feeds the default generated style table (`opts.styles` ?? `STYLE_IDS`), and mounts `code`. Returns a disposer that unmounts and destroys the app subtree. Throws if neither `opts.ops` nor `globalThis.ui` is present.
 
 ### `render`
 
@@ -41,7 +41,7 @@ Lower-level mount: detects and installs the host, wires the style resolver, regi
 | --- | --- | --- |
 | `ops` | `HostOps` | web/wasm/test hosts inject their op surface here; omit on PSP (`globalThis.ui`). |
 | `styles` | `Record<string, number>` | class-literal → styleId table (`styles.generated.ts`). |
-| `dcpak` | `ArrayBuffer` | app pack; defaults to `globalThis.__dcpak` when present. |
+| `pak` | `ArrayBuffer` | app pack; defaults to `globalThis.__pak` when present. |
 
 ### Host helpers
 
@@ -122,16 +122,16 @@ function resolveStyle(cls: string): number | undefined
 
 `registerStyles` loads a class-literal → styleId table (the compiler's `STYLE_IDS`); it also registers a token-sorted alias so `"a b"` resolves the id for `"b a"`. `resolveStyle` returns the styleId for a class string, or `undefined` if the compiler never saw it (or the token reordering is ambiguous). See [Styling](/docs/styling/) and [Tailwind subset](/docs/tailwind/).
 
-### Data pack (dcpak)
+### Data pack (pak)
 
 ```ts
-function dcpakEntries(prefix?: string): string[]
-function dcpakGet(key: string): Uint8Array
+function pakEntries(prefix?: string): string[]
+function pakGet(key: string): Uint8Array
 function loadPack(ab: ArrayBuffer): void
 function resetPack(): void
 ```
 
-`dcpakEntries` lists entry keys starting with `prefix` (default: all keys), sorted. `dcpakGet` returns a fresh copy of a blob's bytes, throwing on a missing key. `loadPack` explicitly loads a pack (web host after fetch, or tests), replacing any prior. `resetPack` drops the cached parsed pack. See [Build pipeline](/docs/build-pipeline/).
+`pakEntries` lists entry keys starting with `prefix` (default: all keys), sorted. `pakGet` returns a fresh copy of a blob's bytes, throwing on a missing key. `loadPack` explicitly loads a pack (web host after fetch, or tests), replacing any prior. `resetPack` drops the cached parsed pack. See [Build pipeline](/docs/build-pipeline/).
 
 ### `NodeMirror`
 

--- a/site/content/docs/architecture.md
+++ b/site/content/docs/architecture.md
@@ -22,7 +22,7 @@ and why each choice was made.
    ┌────────────────────────────────────────────────┐
    │  bundle.js   +   styles.bin + atlases + images  │
    │      │                     │                     │
-   │      │                     └──► app.dcpak        │
+   │      │                     └──► app.pak        │
    └──────┼──────────────────────────────────────────┘
           │
    ┌──────┴──────────────────┐   ┌──────────────────────────┐
@@ -50,7 +50,7 @@ Reading it top to bottom:
 2. The **build** (`bun scripts/build.ts <app>`) runs `babel-preset-solid` in
    *universal* mode, compiles the class strings to a binary style table
    (`styles.bin`), bakes the exact glyphs the app uses into font atlases, and
-   packs the styles + atlases + images into a single container, `app.dcpak`. The
+   packs the styles + atlases + images into a single container, `app.pak`. The
    JS is bundled to `bundle.js`. See [Build pipeline](/docs/build-pipeline/) for
    the two-pass details.
 3. At **runtime**, the Solid runtime executes on whichever JS engine the host
@@ -203,7 +203,7 @@ pocketjs/
 
   spec/
     spec.ts             SINGLE SOURCE OF TRUTH: op codes, prop ids, enums,
-                        style-table / atlas / DrawList / dcpak formats
+                        style-table / atlas / DrawList / pak formats
     gen-rust.ts         codegen → core/src/spec.rs (committed)
 
   core/                 Rust lib `pocketjs-core` — #![no_std] + alloc
@@ -218,13 +218,13 @@ pocketjs/
 
   native/               Rust bin `pocketjs-psp` — the PSP EBOOT
     Cargo.toml          psp, libquickjs-sys, pocketjs-core (path)
-    build.rs            embeds the app JS + app.dcpak
+    build.rs            embeds the app JS + app.pak
     src/main.rs         boot, vblank loop, job pump
     src/alloc.rs        #[global_allocator] backed by the arena
     src/arena.rs        single-kernel-block allocator (see Memory)
     src/ffi.rs          QuickJS ui.* bindings → core ops
     src/ge.rs           DrawList → sceGu; per-frame bump vertex arena
-    src/dcpak.rs        native read-only .dcpak walker (styles/atlases/images)
+    src/pak.rs        native read-only .pak walker (styles/atlases/images)
 
   wasm/                 Rust cdylib `pocketjs-wasm` — core + rasterizer
     src/lib.rs          extern "C" op mirror + render() → RGBA8 480×272
@@ -233,7 +233,7 @@ pocketjs/
   src/                  TS/JS runtime shared by all hosts
     renderer.ts         Solid universal renderer; JS mirror tree; dispatch table
     host.ts             HostOps interface + PSP / wasm bindings
-    dcpak.ts            QuickJS-safe reader (web/test hosts)
+    pak.ts            QuickJS-safe reader (web/test hosts)
     input.ts            edge-detect + focus manager
     anim.ts             animate() / spring() implementation
     primitives.ts       lower-case host tags → View/Text/Image primitives
@@ -246,7 +246,7 @@ pocketjs/
     solid-plugin.ts     babel transform + per-file class/codepoint collection
     tailwind.ts         token parser → styles.bin + styles.generated.ts
     bake-font.ts        atlas baker (charset from AST scan + ASCII)
-    dcpak.ts            container writer
+    pak.ts            container writer
 
   host-web/             480×272 canvas playground + Bun dev server
   demos/                hero, cards, stats, library, settings, notifications, music

--- a/site/content/docs/build-pipeline.md
+++ b/site/content/docs/build-pipeline.md
@@ -6,7 +6,7 @@ One command turns a PocketJS app into two files:
 bun scripts/build.ts hero
 ```
 
-produces `dist/hero.js` (the bundle) and `dist/hero.dcpak` (styles, font
+produces `dist/hero.js` (the bundle) and `dist/hero.pak` (styles, font
 atlases, and images packed into a single binary container). Those two artifacts
 are everything a host needs — the same pair loads on real PSP hardware, in
 PPSSPP, in the browser dev host, and in headless Bun.
@@ -44,9 +44,9 @@ The output name is derived from the entry path, and both artifacts share it:
 
 | Entry | `dist/` outputs | Notes |
 |---|---|---|
-| `demos/hero/app.tsx` | `hero.js`, `hero.dcpak` | the app component |
-| `demos/hero/main.tsx` | `hero-main.js`, `hero-main.dcpak` | the mounted entry — calls `mount()` |
-| `foo/bar.tsx` | `bar.js`, `bar.dcpak` | non‑demo path: basename |
+| `demos/hero/app.tsx` | `hero.js`, `hero.pak` | the app component |
+| `demos/hero/main.tsx` | `hero-main.js`, `hero-main.pak` | the mounted entry — calls `mount()` |
+| `foo/bar.tsx` | `bar.js`, `bar.pak` | non‑demo path: basename |
 
 A demo typically has `app.tsx` (the exported UI) and `main.tsx` (a tiny file
 that imports the app and mounts it). You build `hero-main` when you want a
@@ -68,15 +68,17 @@ last‑to‑first, so TypeScript strips types first, then Solid compiles the JSX
 ```ts
 presets: [
   [solidPreset, { generate: "universal", moduleName: RENDERER_PATH }],
-  [tsPreset,    { isTSX: true, allExtensions: true }],
-]
+  [tsPreset,    {}],
+],
+parserOpts: { plugins: ["jsx"] },
 ```
 
 `babel-preset-solid` with `generate: "universal"` compiles JSX into calls
 against the universal renderer (`createElement`, `insertNode`, `setProp`, …)
 rather than DOM operations. `moduleName` is the **absolute** path to
 `src/renderer.ts` — the preset emits it verbatim into every generated import, so
-it must be absolute. `@babel/preset-typescript` handles the type stripping.
+it must be absolute. `@babel/preset-typescript` handles type stripping;
+`parserOpts` enables JSX parsing without relying on Babel 7-only preset flags.
 
 ### What it collects
 
@@ -137,7 +139,7 @@ Two literals that produce byte‑identical records share a single styleId, so
 `class="p-2 bg-slate-700"` and `class="bg-slate-700 p-2"` cost one record. The
 compiler emits:
 
-- **`styles.bin`** — the encoded style table, packed into the dcpak as
+- **`styles.bin`** — the encoded style table, packed into the pak as
   `ui:styles`.
 - **`src/styles.generated.ts`** — a TypeScript module the renderer imports,
   mapping each source class literal to its styleId, plus the font‑slot metadata
@@ -185,7 +187,7 @@ The charset baked into every slot is the union of:
 Codepoints the font doesn't map are left out; the core resolves a cmap miss to
 glyph 0 (a hollow "tofu" box) at runtime. Each atlas is horizontally
 supersampled 8‑bit coverage cells plus proportional advances and a cmap, and is
-packed into the dcpak as `ui:font.<slot>`.
+packed into the pak as `ui:font.<slot>`.
 
 ```
   font: slot 2 (16px) 96 glyphs, cell 10x19, 18240 bytes
@@ -213,10 +215,10 @@ limit.
   image: logo.png <- /…/demos/hero/logo.png (128x64)
 ```
 
-## Pack the dcpak
+## Pack the pak
 
-All the binary output is written to one container, `dist/<app>.dcpak`. It is
-byte‑for‑byte the dreamcart `.dcpak` format, so existing tooling can open it.
+All the binary output is written to one container, `dist/<app>.pak`. It is
+byte‑for‑byte the dreamcart `.pak` format, so existing tooling can open it.
 PocketJS uses three families of entry keys:
 
 | Key | Contents |
@@ -230,7 +232,7 @@ and how the PSP feeds them straight into the Rust core from `include_bytes!`
 without touching the JS heap — is covered in the [Native contract](/docs/native-contract/).
 
 ```
-  dcpak: 4 entries, 20480 bytes -> dist/hero.dcpak
+  pak: 4 entries, 20480 bytes -> dist/hero.pak
 ```
 
 ## Pass 2 — bundle
@@ -267,7 +269,7 @@ A few settings are deliberate:
   Solid's dev builds and duplicate the runtimes.
 - **`minify: false`** — the bundle ships unminified but tree‑shaken; base64 blobs
   in JS are the known QuickJS boot killer, which is why all binary assets live in
-  the dcpak instead.
+  the pak instead.
 
 ```
   pass 2: dist/hero.js (128000 bytes)
@@ -278,14 +280,14 @@ PocketJS build: done
 
 The [Playground](/playground/) runs this exact pipeline **live in the browser**:
 it transforms and collects, compiles the Tailwind subset, bakes atlases, packs a
-dcpak, and bundles — then loads the result into the WebAssembly build of the
+pak, and bundles — then loads the result into the WebAssembly build of the
 core and renders to a canvas. There is no separate web toolchain; edit the code,
-rebuild, and the same `.js` + `.dcpak` a PSP would run is what draws in the
+rebuild, and the same `.js` + `.pak` a PSP would run is what draws in the
 preview.
 
 ## Related
 
 - [Styling](/docs/styling/) and [Tailwind subset](/docs/tailwind/) — what the class compiler accepts.
-- [Native contract](/docs/native-contract/) — how a host consumes the dcpak and drives the core.
+- [Native contract](/docs/native-contract/) — how a host consumes the pak and drives the core.
 - [Architecture](/docs/architecture/) — where the renderer, core, and hosts fit together.
 - [Getting started](/docs/getting-started/) — install, scaffold, and run your first build.

--- a/site/content/docs/components.md
+++ b/site/content/docs/components.md
@@ -98,7 +98,7 @@ phantom gap where the hidden element used to be.
 
 `Image` draws a baked texture. Its `src` is a **name**, not a path or URL: at
 build time the pipeline scans your `src` strings, packs the referenced images
-into the app's `.dcpak`, and the renderer resolves the name to the uploaded
+into the app's `.pak`, and the renderer resolves the name to the uploaded
 texture at runtime.
 
 ```tsx
@@ -122,7 +122,7 @@ const frame = createSpriteAnimation(
 ```
 
 `Image` takes no children. See the [Build pipeline](/docs/build-pipeline/) for
-how images become dcpak textures.
+how images become pak textures.
 
 ## Props
 

--- a/site/content/docs/getting-started.md
+++ b/site/content/docs/getting-started.md
@@ -122,7 +122,7 @@ This produces two files in `dist/`:
 | File              | What it is                                                                 |
 | ----------------- | ------------------------------------------------------------------------- |
 | `dist/hero.js`    | Your app bundled to a single IIFE (unminified) that any host loads        |
-| `dist/hero.dcpak` | The packed asset file: the compiled style table, font atlases, and images |
+| `dist/hero.pak` | The packed asset file: the compiled style table, font atlases, and images |
 
 A few notes on the command:
 
@@ -179,14 +179,14 @@ local project.
    AST. The Tailwind-subset compiler turns the collected classes into
    `styles.bin`, the font baker rasterizes an Inter atlas containing *only* the
    characters your app uses, images are decoded, and it's all packed into
-   `dist/<app>.dcpak`.
+   `dist/<app>.pak`.
 2. **Bundle.** Bun bundles the app (IIFE, targeting the browser, unminified) from
    the cached pass-1 transforms into `dist/<app>.js`.
 
 Because styles and fonts are derived from your source, a class literal only
 compiles if *every* token is a supported utility, and the atlas only holds glyphs
 you reference. The full mechanics — caching, the class/codepoint collection, the
-dcpak format — are in [Build pipeline](/docs/build-pipeline/).
+pak format — are in [Build pipeline](/docs/build-pipeline/).
 
 ## Next steps
 

--- a/site/content/docs/native-contract.md
+++ b/site/content/docs/native-contract.md
@@ -33,7 +33,7 @@ Signatures are authoritative from `src/host.ts` (`HostOps`) and `spec/spec.ts`. 
 | 11 | `animate` | `(id, propId, to: f64, durMs, easing, delayMs) → animId` | `from` is the current value. `easing` is an `ENUMS.Easing` ordinal. Returns an anim id. |
 | 12 | `cancelAnim` | `(animId) → void` | Stops the track. |
 | 13 | `setFocus` | `(idOr0) → void` | Applies the `focus:` style variant natively. `0` clears focus. |
-| 14 | `loadStyles` | `(buf) → void` | **web/test hosts only.** Optional. Feeds the compiled `styles.bin`. On PSP the native binary feeds core from the dcpak. |
+| 14 | `loadStyles` | `(buf) → void` | **web/test hosts only.** Optional. Feeds the compiled `styles.bin`. On PSP the native binary feeds core from the pak. |
 | 15 | `loadFontAtlas` | `(buf) → void` | **web/test hosts only.** Optional. One call per baked font atlas blob. |
 | 16 | `measureText` | `(str, fontSlot) → width` | JS-side convenience returning width in px. Layout still measures natively. |
 
@@ -109,7 +109,7 @@ None of those touch the host. Structural mutations (`insertNode`, `removeNode`, 
 
 The reasoning is asymmetric on purpose. On real hardware a thrown error is a black screen; a missing style is a slightly-wrong box. So the PSP host counts misses (`missCounters.unknownClass` / `unknownTexture`) and renders on. The web, wasm, and headless-Bun hosts are development and CI surfaces, where a silent wrong-color pixel is worse than a stack trace — so they throw the moment a class isn't in the compiled table or a `src` key has no registered texture.
 
-Resolution order: an injected `HostOps` wins; otherwise `globalThis.ui`; if neither exists, `render()` throws (PocketJS cannot run without a native tree). One special case: the PSP demo entries pass `globalThis.ui` *explicitly*. That object carries a `__textures` marker set only by native `ffi.rs`, so it is still detected as kind `psp` / non-strict — and `render()` skips re-feeding `loadStyles`/`loadFontAtlas`, because the native dcpak walker already fed core directly.
+Resolution order: an injected `HostOps` wins; otherwise `globalThis.ui`; if neither exists, `render()` throws (PocketJS cannot run without a native tree). One special case: the PSP demo entries pass `globalThis.ui` *explicitly*. That object carries a `__textures` marker set only by native `ffi.rs`, so it is still detected as kind `psp` / non-strict — and `render()` skips re-feeding `loadStyles`/`loadFontAtlas`, because the native pak walker already fed core directly.
 
 Every host drives frames the same way: once per tick it calls `globalThis.frame(buttons)` with the PSP button bitmask (`BTN` in the spec). `index.ts` composes input edge-detection and the end-of-frame sweep into that entry point via `installFrameHandler`. See [Input & focus](/docs/input-focus/) for the button model and [Architecture](/docs/architecture/) for how the hosts fit together. The [playground](/playground/) runs the injected web host in the browser.
 

--- a/site/content/docs/overview.md
+++ b/site/content/docs/overview.md
@@ -96,7 +96,7 @@ export default function App() {
 ```
 
 The mount entry is ordinary bootstrap code — the framework detects the host,
-loads the generated style table and dcpak assets, and wires up the frame
+loads the generated style table and pak assets, and wires up the frame
 callback:
 
 ```tsx
@@ -110,7 +110,7 @@ mount(() => <App />);
 Build it with Bun:
 
 ```sh
-bun scripts/build.ts hero      # -> dist/hero.js + dist/hero.dcpak
+bun scripts/build.ts hero      # -> dist/hero.js + dist/hero.pak
 ```
 
 A few things worth noticing in that example:

--- a/site/content/docs/reactivity.md
+++ b/site/content/docs/reactivity.md
@@ -211,7 +211,7 @@ runtime on hardware:
   tick in Rust at a fixed 1/60 s, so animation is a pure function of frame index
   (which is what makes byte-exact goldens possible) and costs the JS side nothing
   per frame.
-- **For "async" data:** load it at build time into the app bundle / dcpak, or
+- **For "async" data:** load it at build time into the app bundle / pak, or
   drive it from host input. There is no runtime fetch on the PSP.
 
 Everything you need for interactive UI — derive with memos, react with effects,

--- a/site/content/docs/styling.md
+++ b/site/content/docs/styling.md
@@ -3,7 +3,7 @@
 PocketJS styling is a **build-time Tailwind subset**. The classes you write are
 not CSS: at build time the compiler parses each class literal, turns it into a
 binary style record, and packs the whole table into `styles.bin` inside your
-app's `.dcpak`. At runtime the renderer looks a class attribute up **verbatim**,
+app's `.pak`. At runtime the renderer looks a class attribute up **verbatim**,
 gets back a numeric `styleId`, and hands that to the Rust core via `setStyle`.
 
 There is **zero runtime CSS**: no CSS parser, no cascade, no string matching on
@@ -29,7 +29,7 @@ The Tailwind compiler runs in pass 1 of `bun scripts/build.ts <app>` (see
    module (`STYLE_IDS`: the class-literal → `styleId` map, plus the font-slot
    metadata) that the renderer imports.
 
-`styles.bin` is shipped in the `.dcpak`. On PSP the native dcpak walker feeds it
+`styles.bin` is shipped in the `.pak`. On PSP the native pak walker feeds it
 straight into the core; on the browser and headless Bun hosts it is loaded
 through the `loadStyles` op ([/docs/native-contract/](/docs/native-contract/)).
 

--- a/site/home.html
+++ b/site/home.html
@@ -165,8 +165,8 @@
       <div class="lp-container">
         <div class="lp-split">
           <div class="lp-split__copy lp-reveal">
-            <span class="lp-kicker">Looks like Solid</span>
-            <h2 class="lp-h2">If you can write a component, you can write for the metal.</h2>
+            <span class="lp-kicker">Real Solid, native pixels</span>
+            <h2 class="lp-h2">Write a component. Ship it to the metal.</h2>
             <p>You already know the surface: <span class="lp-mono">View</span>, <span class="lp-mono">Text</span>, signals and class strings. <span class="lp-mono">focusable</span> and <span class="lp-mono">onPress</span> map straight to the d-pad and face buttons.</p>
             <ul class="lp-checklist">
               <li>
@@ -179,7 +179,7 @@
               </li>
               <li>
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m20 6-11 11-5-5"/></svg>
-                <span>One codebase compiles to a <span class="lp-mono">.dcpak</span> for a real PSP and runs unchanged right here in your browser.</span>
+                <span>One codebase compiles to a <span class="lp-mono">.pak</span> for a real PSP and runs unchanged right here in your browser.</span>
               </li>
             </ul>
             <a class="lp-btn lp-btn--primary" href="/playground/">

--- a/site/playground/compiler-entry.ts
+++ b/site/playground/compiler-entry.ts
@@ -4,7 +4,7 @@
 // lazy-loads. compileApp(source) does exactly what scripts/build.ts does — the
 // SAME @babel/core + babel-preset-solid transform, the SAME compiler/tailwind.ts
 // class compiler, the SAME compiler/bake-font.ts atlas baker, the SAME
-// compiler/dcpak.ts packer — so a playground app compiles byte-identically to a
+// compiler/pak.ts packer — so a playground app compiles byte-identically to a
 // real `bun scripts/build.ts` run. Only two build-time-only pieces are swapped
 // for browser equivalents: fonts/images are fetched (not read from disk) and
 // images are rasterized with a <canvas> instead of the node PNG/SVG decoders.
@@ -17,7 +17,7 @@ import { parse as parseFont, type Font } from "opentype.js";
 import { compileClasses, fontSlotInfo } from "../../compiler/tailwind.ts";
 import { bakeSlot } from "../../compiler/bake-font.ts";
 import {
-  DCPAK_DTYPE,
+  PAK_DTYPE,
   KEY_STYLES,
   encodeImageEntry,
   keyFont,
@@ -26,7 +26,7 @@ import {
   placeholderImage,
   type DecodedImage,
   type PakBlob,
-} from "../../compiler/dcpak.ts";
+} from "../../compiler/pak.ts";
 import { PSM } from "../../spec/spec.ts";
 
 /** babel `moduleName` — the specifier the universal transform imports its
@@ -38,8 +38,8 @@ export interface CompileResult {
   code: string;
   /** class literal → styleId (index.ts mount() takes this as opts.styles). */
   styleMap: Record<string, number>;
-  /** styles.bin + font atlases + images (mount() takes this as opts.dcpak). */
-  dcpak: ArrayBuffer;
+  /** styles.bin + font atlases + images (mount() takes this as opts.pak). */
+  pak: ArrayBuffer;
   classCount: number;
   slotCount: number;
   imageNames: string[];
@@ -142,8 +142,9 @@ async function transform(source: string): Promise<{ code: string; collected: Col
     filename: "app.tsx",
     presets: [
       [solidPreset, { generate: "universal", moduleName: RENDERER_MODULE }],
-      [tsPreset, { isTSX: true, allExtensions: true }],
+      [tsPreset, {}],
     ],
+    parserOpts: { plugins: ["jsx"] },
     plugins: [collectorPlugin(collected)],
     babelrc: false,
     configFile: false,
@@ -251,24 +252,24 @@ export async function compileApp(
   const atlases = await bakeAtlases(collected.codepoints, styles.usedFontSlots, opts.extraChars ?? "");
 
   const blobs: PakBlob[] = [
-    { key: KEY_STYLES, dtype: DCPAK_DTYPE.u8, data: styles.bin },
-    ...atlases.map((a) => ({ key: keyFont(a.slot), dtype: DCPAK_DTYPE.u8, data: a.bytes })),
+    { key: KEY_STYLES, dtype: PAK_DTYPE.u8, data: styles.bin },
+    ...atlases.map((a) => ({ key: keyFont(a.slot), dtype: PAK_DTYPE.u8, data: a.bytes })),
   ];
 
   const imageNames = [...new Set(collected.classStrings.filter((s) => IMAGE_RE.test(s)))];
   for (const name of imageNames) {
     const img = await rasterizeImage(name);
-    blobs.push({ key: keyImage(name), dtype: DCPAK_DTYPE.u8, data: encodeImageEntry(img, PSM.PSM_8888) });
+    blobs.push({ key: keyImage(name), dtype: PAK_DTYPE.u8, data: encodeImageEntry(img, PSM.PSM_8888) });
   }
 
   const packed = pack(blobs);
-  // Fresh, offset-0 ArrayBuffer so mount()'s dcpak reader sees exactly the pack.
-  const dcpak = packed.buffer.slice(packed.byteOffset, packed.byteOffset + packed.byteLength);
+  // Fresh, offset-0 ArrayBuffer so mount()'s pak reader sees exactly the pack.
+  const pak = packed.buffer.slice(packed.byteOffset, packed.byteOffset + packed.byteLength);
 
   return {
     code,
     styleMap: styles.ids,
-    dcpak,
+    pak,
     classCount: styles.records.length,
     slotCount: atlases.length,
     imageNames,

--- a/site/playground/host.js
+++ b/site/playground/host.js
@@ -4,8 +4,8 @@
 // 480x272 canvas, and drives the fixed-timestep 60 Hz loop (dt clamp 250 ms,
 // max 4 catch-up steps — the proven dreamcart driver shape). Two ways to run an
 // app on it:
-//   • runIIFE(jsText, dcpak)  — a prebuilt `bun scripts/build.ts` bundle
-//     (globalThis.ui/__dcpak in, globalThis.frame out). Used by the homepage.
+//   • runIIFE(jsText, pak)  — a prebuilt `bun scripts/build.ts` bundle
+//     (globalThis.ui/__pak in, globalThis.frame out). Used by the homepage.
 //   • reset() → (caller imports an ES module that calls mount()) → begin()
 //     — the live-compiled playground path.
 // Both end up driving the same globalThis.frame(buttons) contract.
@@ -95,7 +95,7 @@ export class PocketHost {
     this.wasm.init();
     globalThis.ui = this.wasm.ops;
     globalThis.frame = undefined;
-    globalThis.__dcpak = undefined;
+    globalThis.__pak = undefined;
   }
 
   /** After the caller has mounted an app (globalThis.frame installed), start the
@@ -112,10 +112,10 @@ export class PocketHost {
     this._start();
   }
 
-  /** Run a prebuilt IIFE bundle (dist/<app>.js + <app>.dcpak). */
-  runIIFE(jsText, dcpakBuffer) {
+  /** Run a prebuilt IIFE bundle (dist/<app>.js + <app>.pak). */
+  runIIFE(jsText, pakBuffer) {
     this.reset();
-    globalThis.__dcpak = dcpakBuffer;
+    globalThis.__pak = pakBuffer;
     // Fresh function scope per load so top-level vars can't collide.
     new Function(jsText + "\n//# sourceURL=pocketjs-demo.js")();
     this.begin();

--- a/site/playground/page.html
+++ b/site/playground/page.html
@@ -42,7 +42,7 @@
       </div>
       <pre id="pg-error" class="pg-error" hidden></pre>
       <p class="pg-hint">
-        Edit the code — the preview recompiles live (Solid + Tailwind + baked fonts → a <code>.dcpak</code>,
+        Edit the code — the preview recompiles live (Solid + Tailwind + baked fonts → a <code>.pak</code>,
         rendered by the Rust core in WebAssembly). Click the screen, then use the on-screen controls, or the
         keyboard: arrows = d-pad · Z/Enter = ◯ · X = ✕ · A = ▢ · S = △.
       </p>

--- a/site/playground/playground.js
+++ b/site/playground/playground.js
@@ -2,10 +2,10 @@
 // site/build.ts with CodeMirror into /pg/playground.bundle.js).
 //
 // Flow on every (debounced) edit:
-//   compile.js  compileApp(source) -> { code, styleMap, dcpak }   [may throw]
+//   compile.js  compileApp(source) -> { code, styleMap, pak }   [may throw]
 //   host.reset()                    fresh wasm core + globalThis.ui
 //   blob module A = transformed app (default export = the component)
-//   blob module B = `import App from A; mount(() => App(), {styles, dcpak})`
+//   blob module B = `import App from A; mount(() => App(), {styles, pak})`
 //   import(B) via the page import-map (@pocketjs/framework -> /pg/runtime.js)
 //   host.begin()                    grab globalThis.frame, drive 60 Hz
 //
@@ -122,7 +122,7 @@ async function main() {
       globalThis.__pgDispose = null;
       host.reset();
       globalThis.__pgStyles = result.styleMap;
-      globalThis.__pgDcpak = result.dcpak;
+      globalThis.__pgPak = result.pak;
 
       const appUrl = URL.createObjectURL(new Blob([result.code], { type: "text/javascript" }));
       const boot =
@@ -130,7 +130,7 @@ async function main() {
         `import { mount, __resetAll } from "@pocketjs/framework";\n` +
         `__resetAll();\n` +
         `globalThis.__pgDispose = mount(() => App(), ` +
-        `{ styles: globalThis.__pgStyles, dcpak: globalThis.__pgDcpak });\n`;
+        `{ styles: globalThis.__pgStyles, pak: globalThis.__pgPak });\n`;
       const bootUrl = URL.createObjectURL(new Blob([boot], { type: "text/javascript" }));
       try {
         await import(/* @vite-ignore */ bootUrl);

--- a/site/playground/runtime-entry.ts
+++ b/site/playground/runtime-entry.ts
@@ -78,11 +78,11 @@ export {
 // ---- reset between live-recompiles -----------------------------------------
 import { resetRendererState, resetTextures } from "../../src/renderer.ts";
 import { resetStyles } from "../../src/styles.ts";
-import { resetPack } from "../../src/dcpak.ts";
+import { resetPack } from "../../src/pak.ts";
 
 /** Wipe every runtime singleton so the NEXT mount() starts from a blank slate:
  *  the renderer mirror tree, retained/sweep sets, the class→styleId registry,
- *  the texture registry, and the cached dcpak. The wasm core is reset
+ *  the texture registry, and the cached pak. The wasm core is reset
  *  separately by the host (ui_init). Call BEFORE each recompiled mount(). */
 export function __resetAll(): void {
   resetRendererState();

--- a/site/serve.ts
+++ b/site/serve.ts
@@ -8,7 +8,7 @@ const MIME: Record<string, string> = {
   html: "text/html; charset=utf-8", js: "text/javascript; charset=utf-8",
   css: "text/css; charset=utf-8", json: "application/json", wasm: "application/wasm",
   svg: "image/svg+xml", png: "image/png", ttf: "font/ttf", map: "application/json",
-  dcpak: "application/octet-stream",
+  pak: "application/octet-stream",
 };
 function resolve(path: string): string | null {
   let p = DIST + path.replace(/^\/+/, "").replace(/\.\.+/g, "");

--- a/spec/gen-rust.ts
+++ b/spec/gen-rust.ts
@@ -10,14 +10,14 @@
 import {
   ANIMATABLE,
   BTN,
-  DCPAK_ALIGN,
-  DCPAK_DTYPE,
-  DCPAK_ENTRY_SIZE,
-  DCPAK_FNV1A_OFFSET_BASIS,
-  DCPAK_FNV1A_PRIME,
-  DCPAK_HEADER_SIZE,
-  DCPAK_MAGIC,
-  DCPAK_VERSION,
+  PAK_ALIGN,
+  PAK_DTYPE,
+  PAK_ENTRY_SIZE,
+  PAK_FNV1A_OFFSET_BASIS,
+  PAK_FNV1A_PRIME,
+  PAK_HEADER_SIZE,
+  PAK_MAGIC,
+  PAK_VERSION,
   DRAW_OP,
   ENUMS,
   FIXED_DT,
@@ -273,18 +273,18 @@ export function generateRust(): string {
   put("}");
   put("");
 
-  // --- dcpak ----------------------------------------------------------------------
-  put("/// .dcpak container constants (byte-compatible with dreamcart's format;");
-  put("/// copied from framework/bake/dcpak.ts + docs/dcpak-format.md).");
-  put("pub mod dcpak {");
-  put(`    pub const MAGIC: u32 = ${hex(DCPAK_MAGIC)}; // 'DCPK' LE`);
-  put(`    pub const VERSION: u16 = ${DCPAK_VERSION};`);
-  put(`    pub const HEADER_SIZE: usize = ${DCPAK_HEADER_SIZE};`);
-  put(`    pub const ENTRY_SIZE: usize = ${DCPAK_ENTRY_SIZE};`);
-  put(`    pub const ALIGN: usize = ${DCPAK_ALIGN};`);
-  put(`    pub const FNV1A_OFFSET_BASIS: u32 = ${hex(DCPAK_FNV1A_OFFSET_BASIS)};`);
-  put(`    pub const FNV1A_PRIME: u32 = ${hex(DCPAK_FNV1A_PRIME)};`);
-  for (const [name, v] of Object.entries(DCPAK_DTYPE)) {
+  // --- pak ----------------------------------------------------------------------
+  put("/// .pak container constants (byte-compatible with dreamcart's format;");
+  put("/// copied from framework/bake/pak.ts + docs/pak-format.md).");
+  put("pub mod pak {");
+  put(`    pub const MAGIC: u32 = ${hex(PAK_MAGIC)}; // 'DCPK' LE`);
+  put(`    pub const VERSION: u16 = ${PAK_VERSION};`);
+  put(`    pub const HEADER_SIZE: usize = ${PAK_HEADER_SIZE};`);
+  put(`    pub const ENTRY_SIZE: usize = ${PAK_ENTRY_SIZE};`);
+  put(`    pub const ALIGN: usize = ${PAK_ALIGN};`);
+  put(`    pub const FNV1A_OFFSET_BASIS: u32 = ${hex(PAK_FNV1A_OFFSET_BASIS)};`);
+  put(`    pub const FNV1A_PRIME: u32 = ${hex(PAK_FNV1A_PRIME)};`);
+  for (const [name, v] of Object.entries(PAK_DTYPE)) {
     put(`    pub const DT_${name.toUpperCase()}: u8 = ${v};`);
   }
   put("}");

--- a/spec/spec.ts
+++ b/spec/spec.ts
@@ -89,7 +89,7 @@ export const SIZE_FULL = -1;
 //   cancelAnim(animId)
 //   setFocus(idOr0)                        [applies focus: variant natively]
 //   loadStyles(buf) / loadFontAtlas(buf)   [web/test hosts only; PSP feeds core
-//                                           natively from the dcpak]
+//                                           natively from the pak]
 //   measureText(str, fontSlot) -> width:f32
 
 export const OP = {
@@ -622,28 +622,28 @@ export const DRAW_OP = {
 } as const;
 
 // ---------------------------------------------------------------------------
-// DCPAK container constants
+// PAK container constants
 // ---------------------------------------------------------------------------
-// PocketJS packs (styles.bin, font atlases, images) reuse the dreamcart .dcpak
+// PocketJS packs (styles.bin, font atlases, images) reuse the dreamcart .pak
 // container byte-for-byte so existing tooling can open them. Values copied
-// from dreamcart framework/bake/dcpak.ts + docs/dcpak-format.md (v1).
+// from dreamcart framework/bake/pak.ts + docs/pak-format.md (v1).
 // Header: magic u32, version u16, flags u16, entryCount u32, dirOffset u32,
 // namesOffset u32, blobsOffset u32 (16-aligned), fileSize u32, reserved u32.
 // Entry: keyHash(fnv1a) u32, blobOff u32, byteLen u32, nameOff u32,
 // nameLen u16, dtype u8, reserved u8, reserved u32. Entries sorted by key;
 // blobs 16-byte aligned.
 
-export const DCPAK_MAGIC = 0x4b504344; // 'DCPK' LE
-export const DCPAK_VERSION = 1;
-export const DCPAK_HEADER_SIZE = 32;
-export const DCPAK_ENTRY_SIZE = 24;
-export const DCPAK_ALIGN = 16;
+export const PAK_MAGIC = 0x4b504344; // 'DCPK' LE
+export const PAK_VERSION = 1;
+export const PAK_HEADER_SIZE = 32;
+export const PAK_ENTRY_SIZE = 24;
+export const PAK_ALIGN = 16;
 /** FNV-1a 32-bit params for entry keyHash (h ^= byte; h *= prime). */
-export const DCPAK_FNV1A_OFFSET_BASIS = 0x811c9dc5;
-export const DCPAK_FNV1A_PRIME = 0x01000193;
+export const PAK_FNV1A_OFFSET_BASIS = 0x811c9dc5;
+export const PAK_FNV1A_PRIME = 0x01000193;
 
-/** dcpak dtype codes (advisory element type of a blob). */
-export const DCPAK_DTYPE = {
+/** pak dtype codes (advisory element type of a blob). */
+export const PAK_DTYPE = {
   u8: 0, i8: 1, u16: 2, i16: 3, u32: 4, i32: 5, f32: 6, f64: 7,
 } as const;
 

--- a/src/host.ts
+++ b/src/host.ts
@@ -54,7 +54,7 @@ export interface HostOps {
   cancelAnim(animId: number): void;
   /** 0 clears focus. Applies the `focus:` style variant natively. */
   setFocus(idOr0: number): void;
-  /** web/test hosts only — on PSP the native bin feeds core from the dcpak. */
+  /** web/test hosts only — on PSP the native bin feeds core from the pak. */
   loadStyles?(buf: Uint8Array): void;
   /** web/test hosts only — one call per baked font atlas blob. */
   loadFontAtlas?(buf: Uint8Array): void;
@@ -80,7 +80,7 @@ let current: Host | null = null;
  * non-strict — `__textures` is set only by native ffi.rs, never by web/wasm/
  * test hosts, so those keep the strict injected contract. This also routes
  * render() into its PSP branch (bind native texture handles, skip the
- * loadStyles/loadFontAtlas re-feed the native dcpak walker already did).
+ * loadStyles/loadFontAtlas re-feed the native pak walker already did).
  */
 export function detectHost(injected?: HostOps): Host {
   const native = (globalThis as { ui?: HostOps & { __textures?: unknown } }).ui;

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,7 +32,7 @@ import { setOverlayRoot } from "./overlay.ts";
 import { registerStyles, resolveStyle } from "./styles.ts";
 import { handleFrame, setInputRoot } from "./input.ts";
 import { resetFrameHooks, runFrameHooks } from "./frame.ts";
-import { entries as dcpakEntries, get as dcpakGet, hasPack, loadPack } from "./dcpak.ts";
+import { entries as pakEntries, get as pakGet, hasPack, loadPack } from "./pak.ts";
 import { STYLE_IDS as DEFAULT_STYLE_IDS } from "./styles.generated.ts";
 import { ENUMS, SCREEN_H, SCREEN_W } from "../spec/spec.ts";
 
@@ -41,14 +41,14 @@ export interface RenderOptions {
   ops?: HostOps;
   /** STYLE_IDS table (styles.generated.ts) — class literal → styleId. */
   styles?: Record<string, number>;
-  /** App pack; defaults to globalThis.__dcpak when present. */
-  dcpak?: ArrayBuffer;
+  /** App pack; defaults to globalThis.__pak when present. */
+  pak?: ArrayBuffer;
 }
 
 export type MountOptions = RenderOptions;
 
-/** dcpak entry keys the runtime understands when it loads a pack JS-side.
- * Must match compiler/dcpak.ts (KEY_STYLES / keyFont). */
+/** pak entry keys the runtime understands when it loads a pack JS-side.
+ * Must match compiler/pak.ts (KEY_STYLES / keyFont). */
 const STYLES_KEY = "ui:styles";
 const FONT_PREFIX = "ui:font.";
 const IMG_PREFIX = "ui:img.";
@@ -57,12 +57,12 @@ function globalOps(): HostOps | undefined {
   return (globalThis as { ui?: HostOps }).ui;
 }
 
-function uploadDcpakImages(ops: HostOps): void {
-  // PSP native dcpak.rs already uploaded pack images and exposed the handle
+function uploadPakImages(ops: HostOps): void {
+  // PSP native pak.rs already uploaded pack images and exposed the handle
   // table through ui.__textures; web/wasm/test hosts need the JS-side upload.
   if ((ops as HostOps & { __textures?: unknown }).__textures) return;
-  for (const key of dcpakEntries(IMG_PREFIX)) {
-    const blob = dcpakGet(key);
+  for (const key of pakEntries(IMG_PREFIX)) {
+    const blob = pakGet(key);
     const dv = new DataView(blob.buffer, blob.byteOffset, blob.byteLength);
     const w = dv.getUint16(0, true);
     const h = dv.getUint16(2, true);
@@ -83,7 +83,7 @@ function createLayer(style: Record<string, number>): NodeMirror {
  * disposer that unmounts and destroys the app subtree.
  *
  * On PSP the native bin has already fed styles/atlases to the core from the
- * dcpak (zero QuickJS transit); on injected hosts (web/test) render() pushes
+ * pak (zero QuickJS transit); on injected hosts (web/test) render() pushes
  * them through ops.loadStyles/loadFontAtlas here.
  */
 export function render(code: () => unknown, opts: RenderOptions = {}): () => void {
@@ -94,7 +94,7 @@ export function render(code: () => unknown, opts: RenderOptions = {}): () => voi
   if (opts.styles) registerStyles(opts.styles);
 
   if (host.kind === "psp") {
-    // PSP native host: native/src/dcpak.rs already fed styles/atlases to the
+    // PSP native host: native/src/pak.rs already fed styles/atlases to the
     // core and uploaded the pack's images at boot, leaving a name -> texture-
     // handle table on the ui namespace (ffi.rs). Bind it so <image src="name">
     // resolves through the renderer's texture registry.
@@ -105,13 +105,13 @@ export function render(code: () => unknown, opts: RenderOptions = {}): () => voi
   }
 
   if (host.kind === "injected") {
-    if (opts.dcpak) loadPack(opts.dcpak);
+    if (opts.pak) loadPack(opts.pak);
     if (hasPack()) {
-      for (const key of dcpakEntries()) {
+      for (const key of pakEntries()) {
         if (key === STYLES_KEY) {
-          host.ops.loadStyles?.(dcpakGet(key));
+          host.ops.loadStyles?.(pakGet(key));
         } else if (key.startsWith(FONT_PREFIX)) {
-          host.ops.loadFontAtlas?.(dcpakGet(key));
+          host.ops.loadFontAtlas?.(pakGet(key));
         }
         // images: hosts upload + registerTexture() themselves (w/h/psm live
         // in host-specific metadata, not in the runtime).
@@ -162,7 +162,7 @@ export function render(code: () => unknown, opts: RenderOptions = {}): () => voi
 /**
  * App-level entry point for demo/application bundles. It mirrors a web-style
  * mount call: pick the current host, feed the current generated style table,
- * upload dcpak images for injected hosts, and mount the component. Per-frame
+ * upload pak images for injected hosts, and mount the component. Per-frame
  * app behavior belongs in component lifecycle callbacks such as onFrame/onButtonPress.
  */
 export function mount(code: () => unknown, opts: MountOptions = {}): () => void {
@@ -170,12 +170,12 @@ export function mount(code: () => unknown, opts: MountOptions = {}): () => void 
   if (!ops) {
     throw new Error("PocketJS: mount() requires globalThis.ui or opts.ops");
   }
-  if (opts.dcpak) loadPack(opts.dcpak);
-  uploadDcpakImages(ops);
+  if (opts.pak) loadPack(opts.pak);
+  uploadPakImages(ops);
   const dispose = render(code, {
     ops,
     styles: opts.styles ?? DEFAULT_STYLE_IDS,
-    dcpak: opts.dcpak,
+    pak: opts.pak,
   });
   return dispose;
 }
@@ -187,4 +187,4 @@ export { detectHost, installHost, getOps } from "./host.ts";
 export type { NodeMirror } from "./renderer.ts";
 export { retain, release, runSweep, registerTexture, missCounters } from "./renderer.ts";
 export { registerStyles, resolveStyle } from "./styles.ts";
-export { entries as dcpakEntries, get as dcpakGet, loadPack, resetPack } from "./dcpak.ts";
+export { entries as pakEntries, get as pakGet, loadPack, resetPack } from "./pak.ts";

--- a/src/pak.ts
+++ b/src/pak.ts
@@ -1,25 +1,25 @@
-// QuickJS-safe .dcpak reader (dreamcart container v1 — constants pinned in
+// QuickJS-safe .pak reader (dreamcart container v1 — constants pinned in
 // spec/spec.ts). Used by web/test hosts to feed styles.bin / font atlases /
 // images to the core through ops.loadStyles/loadFontAtlas/uploadTexture; the
-// PSP host never runs this (native/src/dcpak.rs walks the pack from
+// PSP host never runs this (native/src/pak.rs walks the pack from
 // include_bytes! before JS eval).
 //
-// QuickJS constraints honored (precedent: framework/src/dcpak.ts):
+// QuickJS constraints honored (precedent: framework/src/pak.ts):
 //   - NO TextDecoder — keys are ASCII, decoded via String.fromCharCode.
 //   - DataView + unaligned little-endian reads only.
 //   - get() returns a FRESH copy (slice), so `.buffer` is exactly the blob.
 
 import {
-  DCPAK_ENTRY_SIZE,
-  DCPAK_HEADER_SIZE,
-  DCPAK_MAGIC,
-  DCPAK_VERSION,
+  PAK_ENTRY_SIZE,
+  PAK_HEADER_SIZE,
+  PAK_MAGIC,
+  PAK_VERSION,
 } from "../spec/spec.ts";
 
 interface Entry {
   off: number; // blob offset from pack start
   len: number; // blob byte length
-  dtype: number; // advisory DCPAK_DTYPE
+  dtype: number; // advisory PAK_DTYPE
 }
 
 let map: Map<string, Entry> | null = null;
@@ -34,12 +34,12 @@ function readKey(u8: Uint8Array, off: number, len: number): string {
 
 function parse(ab: ArrayBuffer): void {
   const dv = new DataView(ab);
-  if (ab.byteLength < DCPAK_HEADER_SIZE || dv.getUint32(0, true) !== DCPAK_MAGIC) {
-    throw new Error("dcpak: bad magic");
+  if (ab.byteLength < PAK_HEADER_SIZE || dv.getUint32(0, true) !== PAK_MAGIC) {
+    throw new Error("pak: bad magic");
   }
   const version = dv.getUint16(4, true);
-  if (version !== DCPAK_VERSION) {
-    throw new Error("dcpak: unsupported version " + version);
+  if (version !== PAK_VERSION) {
+    throw new Error("pak: unsupported version " + version);
   }
   const entryCount = dv.getUint32(8, true);
   const dirOff = dv.getUint32(12, true);
@@ -47,7 +47,7 @@ function parse(ab: ArrayBuffer): void {
   const u8 = new Uint8Array(ab);
   const m = new Map<string, Entry>();
   for (let i = 0; i < entryCount; i++) {
-    const e = dirOff + i * DCPAK_ENTRY_SIZE;
+    const e = dirOff + i * PAK_ENTRY_SIZE;
     const blobOff = dv.getUint32(e + 4, true);
     const byteLen = dv.getUint32(e + 8, true);
     const nameOff = dv.getUint32(e + 12, true);
@@ -76,12 +76,12 @@ export function resetPack(): void {
 
 function ensureLoaded(): void {
   if (map) return;
-  const ab = (globalThis as { __dcpak?: ArrayBuffer }).__dcpak;
+  const ab = (globalThis as { __pak?: ArrayBuffer }).__pak;
   if (!ab) return; // no pack — throws only on actual access
   parse(ab);
 }
 
-/** True when a pack is present (globalThis.__dcpak or loadPack). */
+/** True when a pack is present (globalThis.__pak or loadPack). */
 export function hasPack(): boolean {
   ensureLoaded();
   return map !== null;
@@ -107,19 +107,19 @@ export function get(key: string): Uint8Array {
   const e = map ? map.get(key) : undefined;
   if (!e) {
     throw new Error(
-      "dcpak: missing key " +
+      "pak: missing key " +
         key +
-        " (no __dcpak provided, or the pack is incomplete)",
+        " (no __pak provided, or the pack is incomplete)",
     );
   }
   // .slice() copies into a fresh, offset-0, length-exact ArrayBuffer.
   return bytes!.slice(e.off, e.off + e.len);
 }
 
-/** Advisory element dtype (spec DCPAK_DTYPE) of a blob; throws if absent. */
+/** Advisory element dtype (spec PAK_DTYPE) of a blob; throws if absent. */
 export function dtypeOf(key: string): number {
   ensureLoaded();
   const e = map ? map.get(key) : undefined;
-  if (!e) throw new Error("dcpak: missing key " + key);
+  if (!e) throw new Error("pak: missing key " + key);
   return e.dtype;
 }

--- a/test/contract.ts
+++ b/test/contract.ts
@@ -6,7 +6,7 @@
 //  (b) Round-trips the styles.bin encoder/decoder over a table exercising
 //      every feature (variants, transition, all three value kinds).
 //  (c) While PocketJS lives inside the dreamcart repo: greps the dreamcart
-//      sources our constants were copied from (BTN masks, dcpak magic) so an
+//      sources our constants were copied from (BTN masks, pak magic) so an
 //      upstream change is caught. Skipped silently after extraction.
 
 import { generateRust } from "../spec/gen-rust.ts";
@@ -14,7 +14,7 @@ import {
   abgr,
   animBit,
   BTN,
-  DCPAK_MAGIC,
+  PAK_MAGIC,
   decodeStyleTable,
   encodeStyleTable,
   ENUMS,
@@ -116,11 +116,11 @@ if (engineJs !== null) {
     check(re.test(engineJs), `BTN.${name} matches web/engine.js`);
   }
 }
-const dcpakTs = await Bun.file(
-  new URL("../../framework/bake/dcpak.ts", import.meta.url).pathname,
+const pakTs = await Bun.file(
+  new URL("../../framework/bake/pak.ts", import.meta.url).pathname,
 ).text().catch(() => null);
-if (dcpakTs !== null) {
-  check(dcpakTs.includes("0x4b504344") && DCPAK_MAGIC === 0x4b504344, "DCPAK magic matches framework/bake/dcpak.ts");
+if (pakTs !== null) {
+  check(pakTs.includes("0x4b504344") && PAK_MAGIC === 0x4b504344, "PAK magic matches framework/bake/pak.ts");
 }
 
 if (failed) {

--- a/test/golden.ts
+++ b/test/golden.ts
@@ -2,7 +2,7 @@
 //
 // Loads host-web/pocketjs.wasm under Bun, installs the SAME HostOps binding the
 // browser host uses (host-web/wasm-ops.js), evals a dist/<demo>.js bundle with
-// globalThis.ui + globalThis.__dcpak pre-installed (the host contract), drives
+// globalThis.ui + globalThis.__pak pre-installed (the host contract), drives
 // N fixed-dt frames with a scripted input function, captures the RGBA
 // framebuffer at chosen frames and byte-compares the encoded PNG against the
 // committed test/goldens/<demo>.<frame>.png.
@@ -280,8 +280,8 @@ async function runDemo(spec: Spec): Promise<Map<number, Uint8Array>> {
   const wasm = await createWasmUi(wasmBytes);
   const g = globalThis as Record<string, unknown>;
   g.ui = wasm.ops; // the host contract: HostOps BEFORE eval
-  g.__dcpak = existsSync(DIST + spec.name + ".dcpak")
-    ? await Bun.file(DIST + spec.name + ".dcpak").arrayBuffer()
+  g.__pak = existsSync(DIST + spec.name + ".pak")
+    ? await Bun.file(DIST + spec.name + ".pak").arrayBuffer()
     : undefined;
   g.frame = undefined;
   try {
@@ -301,7 +301,7 @@ async function runDemo(spec: Spec): Promise<Map<number, Uint8Array>> {
     return captures;
   } finally {
     delete g.ui;
-    delete g.__dcpak;
+    delete g.__pak;
     g.frame = undefined;
   }
 }

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -56,9 +56,9 @@ import { mount as publicMount, render as publicRender } from "../src/index.ts";
 import { pushButtonHandlerBlock, onButtonPress, onFrame } from "../src/lifecycle.ts";
 import { rootMirror } from "../src/renderer.ts";
 import { ActionBar, ActionHandler, FocusGrid, Modal, Portal, Text, View } from "../src/components.ts";
-import { resetPack } from "../src/dcpak.ts";
-import { encodeImageEntry, pack } from "../compiler/dcpak.ts";
-import { BTN, DCPAK_DTYPE, NODE_TYPE, PSM, ROOT_ID, PROP, STYLE_ID_NONE } from "../spec/spec.ts";
+import { resetPack } from "../src/pak.ts";
+import { encodeImageEntry, pack } from "../compiler/pak.ts";
+import { BTN, PAK_DTYPE, NODE_TYPE, PSM, ROOT_ID, PROP, STYLE_ID_NONE } from "../spec/spec.ts";
 
 // ---------------------------------------------------------------------------
 // Mock host
@@ -156,9 +156,9 @@ beforeEach(() => {
   resetInput();
   setStyleResolver(resolveStyle);
   root = freshRoot();
-  const g = globalThis as { ui?: HostOps; __dcpak?: ArrayBuffer; frame?: (buttons: number) => void };
+  const g = globalThis as { ui?: HostOps; __pak?: ArrayBuffer; frame?: (buttons: number) => void };
   delete g.ui;
-  delete g.__dcpak;
+  delete g.__pak;
   delete g.frame;
 });
 
@@ -985,15 +985,15 @@ describe("public render() (index.ts)", () => {
     dispose();
   });
 
-  test("mount() hides host, dcpak image, and frame boilerplate", () => {
-    const g = globalThis as { ui?: HostOps; __dcpak?: ArrayBuffer; frame?: (buttons: number) => void };
+  test("mount() hides host, pak image, and frame boilerplate", () => {
+    const g = globalThis as { ui?: HostOps; __pak?: ArrayBuffer; frame?: (buttons: number) => void };
     g.ui = host.ops;
     const image = encodeImageEntry(
       { width: 1, height: 1, rgba: new Uint8Array([10, 20, 30, 255]) },
       PSM.PSM_8888,
     );
-    const pak = pack([{ key: "ui:img.logo.png", dtype: DCPAK_DTYPE.u8, data: image }]);
-    g.__dcpak = pak.buffer.slice(pak.byteOffset, pak.byteOffset + pak.byteLength) as ArrayBuffer;
+    const pak = pack([{ key: "ui:img.logo.png", dtype: PAK_DTYPE.u8, data: image }]);
+    g.__pak = pak.buffer.slice(pak.byteOffset, pak.byteOffset + pak.byteLength) as ArrayBuffer;
 
     const before: number[] = [];
     const dispose = publicMount(


### PR DESCRIPTION
## Summary
- Rename PocketJS asset pack format from dcpak to pak across runtime, compiler, native host, docs, and tests.
- Update build outputs, web hosts, site preview, and homepage demo bundle paths to use `.pak`.
- Fix the landing page copy that implied PocketJS only "looks like" Solid.
- Update Babel TypeScript transform options to avoid removed Babel 8 `isTSX`/`allExtensions` flags while keeping JSX parsing explicit.

## Validation
- `bun run test`
- `bunx tsc --noEmit`
- `bun site/build.ts`
