### PR TITLE
feat: refresh bare metal landing and docs design

### DIFF
--- a/site/assets/favicon.svg
+++ b/site/assets/favicon.svg
@@ -1,20 +1,20 @@
 <svg viewBox="0 0 32 32" aria-hidden="true" xmlns="http://www.w3.org/2000/svg">
   <defs>
     <linearGradient id="pj-edge" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#f1f5f9"/>
-      <stop offset="0.35" stop-color="#94a3b8"/>
-      <stop offset="0.55" stop-color="#475569"/>
-      <stop offset="0.75" stop-color="#94a3b8"/>
-      <stop offset="1" stop-color="#e2e8f0"/>
+      <stop offset="0" stop-color="#eef6ff"/>
+      <stop offset="0.38" stop-color="#b7c8e2"/>
+      <stop offset="0.58" stop-color="#7487a0"/>
+      <stop offset="0.78" stop-color="#aec0d6"/>
+      <stop offset="1" stop-color="#dbe8f6"/>
     </linearGradient>
     <linearGradient id="pj-lens" x1="7" y1="13" x2="13" y2="19" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#e2e8f0"/>
-      <stop offset="0.5" stop-color="#94a3b8"/>
-      <stop offset="1" stop-color="#475569"/>
+      <stop offset="0" stop-color="#e4edf8"/>
+      <stop offset="0.55" stop-color="#a7b8cf"/>
+      <stop offset="1" stop-color="#53677f"/>
     </linearGradient>
     <linearGradient id="pj-bar" x1="16" y1="12" x2="24" y2="20" gradientUnits="userSpaceOnUse">
-      <stop offset="0" stop-color="#cbd5e1"/>
-      <stop offset="1" stop-color="#64748b"/>
+      <stop offset="0" stop-color="#d7e3f1"/>
+      <stop offset="1" stop-color="#71849d"/>
     </linearGradient>
   </defs>
 

--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -1,34 +1,61 @@
 /* ==========================================================================
    PocketJS — "Bare Metal Modern Web" landing page
-   Direction: Cinematic / Bold (Apple x SpaceX). All classes are .lp-* scoped.
+   Direction: Docs navy with brushed metal accents. All classes are .lp-* scoped.
    The live demo (.screen-emu / .emu-*) is owned by /assets/screen.css and is
    never targeted here — only wrapped in framing containers.
    ========================================================================== */
 
-html, body { margin: 0; background: #04060b; }
+@font-face {
+  font-family: "Inter";
+  src: url("/pg/fonts/Inter-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Inter";
+  src: url("/pg/fonts/Inter-Bold.ttf") format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
+html, body { margin: 0; background: #05070d; }
 
 .lp, .lp *, .lp *::before, .lp *::after { box-sizing: border-box; }
 
 .lp {
-  --bg: #04060b;
+  --bg: #05070d;
+  --bg-2: #090c14;
+  --panel: #0f1626;
   --ink: #f3f7fd;
-  --ink-2: #aeb9cd;
-  --muted: #6a798f;
-  --line: rgba(140, 172, 224, 0.12);
-  --line-2: rgba(140, 172, 224, 0.22);
-  --blue: #3b82f6;
-  --cyan: #22d3ee;
-  --sky: #7dd3fc;
-  --font: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --ink-2: #b9c3d4;
+  --muted: #7b8aa1;
+  --line: rgba(30, 41, 59, 0.66);
+  --line-2: rgba(43, 58, 85, 0.78);
+  --steel-0: #f4f8ff;
+  --steel-1: #d8e1ec;
+  --steel-2: #a7b3c5;
+  --steel-3: #66748a;
+  --steel-4: #293446;
+  --mint: #9de5c7;
+  --sky: #60a5fa;
+  --font: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
-  --grad: linear-gradient(96deg, #8ecbff 0%, #3b82f6 38%, #22d3ee 74%, #67e8f9 100%);
+  --metal: linear-gradient(112deg, #f3f7fd 0%, #c7d1df 18%, #8796aa 34%, #e7edf6 48%, #66748a 64%, #b4c0d0 82%, #eef3fa 100%);
+  --metal-lite: linear-gradient(112deg, #eef3fa 0%, #d2dbe7 26%, #b3becc 45%, #e8edf4 67%, #c2ccd9 100%);
+  --metal-brush: repeating-linear-gradient(104deg, rgba(255, 255, 255, 0.088) 0 1px, rgba(255, 255, 255, 0) 1px 5px, rgba(43, 58, 85, 0.07) 5px 6px, rgba(255, 255, 255, 0) 6px 11px);
+  --grad: linear-gradient(120deg, #f3f7fd 0%, #d6e0ec 36%, #8d9bb0 67%, #c5d4e6 100%);
 
   position: relative;
   min-height: 100vh;
   overflow-x: hidden;
   background:
-    radial-gradient(120% 60% at 50% -8%, rgba(38, 108, 190, 0.22), transparent 60%),
-    radial-gradient(90% 50% at 80% 8%, rgba(34, 211, 238, 0.1), transparent 55%),
+    radial-gradient(42% 72% at 0% 6%, rgba(96, 165, 250, 0.1), transparent 66%),
+    radial-gradient(36% 70% at 100% 12%, rgba(34, 211, 238, 0.055), transparent 68%),
+    radial-gradient(42% 42% at 50% 100%, rgba(30, 41, 59, 0.24), transparent 72%),
+    linear-gradient(180deg, #070a11 0%, #05070d 48%, #070a11 100%),
     var(--bg);
   color: var(--ink);
   font-family: var(--font);
@@ -36,6 +63,24 @@ html, body { margin: 0; background: #04060b; }
   line-height: 1.5;
   -webkit-font-smoothing: antialiased;
   text-rendering: optimizeLegibility;
+}
+
+.lp::before {
+  content: "";
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  pointer-events: none;
+  opacity: 0.09;
+  background:
+    linear-gradient(110deg, transparent 0 36%, rgba(148, 163, 184, 0.022) 40%, transparent 46% 100%),
+    repeating-linear-gradient(90deg, rgba(148, 163, 184, 0.01) 0 1px, transparent 1px 9px);
+  mix-blend-mode: screen;
+}
+
+.lp > * {
+  position: relative;
+  z-index: 1;
 }
 
 .lp h1, .lp h2, .lp h3, .lp h4, .lp p, .lp ul, .lp figure, .lp pre { margin: 0; }
@@ -54,10 +99,14 @@ html, body { margin: 0; background: #04060b; }
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
+  text-shadow: 0 18px 42px rgba(3, 9, 20, 0.38);
 }
 
 /* ---- Buttons -------------------------------------------------------------- */
 .lp-btn {
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -67,31 +116,88 @@ html, body { margin: 0; background: #04060b; }
   line-height: 1;
   padding: 0.9rem 1.5rem;
   border-radius: 12px;
-  border: 1px solid transparent;
+  border: 1px solid rgba(43, 58, 85, 0.9);
   text-decoration: none;
   cursor: pointer;
   white-space: nowrap;
   transition: transform 0.18s ease, box-shadow 0.28s ease, background 0.28s ease, border-color 0.28s ease;
 }
-.lp-btn svg { width: 16px; height: 16px; }
-.lp-btn--primary {
-  color: #04060b;
-  background: var(--grad);
-  box-shadow: 0 12px 34px -12px rgba(34, 211, 238, 0.65), inset 0 1px 0 rgba(255, 255, 255, 0.4);
+.lp-btn::before {
+  content: "";
+  display: none;
+  position: absolute;
+  inset: 1px;
+  z-index: -1;
+  border-radius: inherit;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.42), rgba(255, 255, 255, 0) 34%),
+    linear-gradient(105deg, rgba(255, 255, 255, 0) 0 28%, rgba(226, 232, 240, 0.32) 38%, rgba(255, 255, 255, 0) 52%),
+    var(--metal-brush);
+  opacity: 0.18;
+  pointer-events: none;
 }
+.lp-btn svg { width: 16px; height: 16px; }
+.lp-btn--primary,
+.lp-btn--primary:visited {
+  color: #000;
+  font-weight: 700;
+  text-shadow: none;
+  border-color: rgba(226, 232, 240, 0.44);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 40%),
+    var(--metal-lite);
+  box-shadow:
+    0 14px 30px -20px rgba(3, 9, 20, 0.86),
+    0 0 24px -22px rgba(96, 165, 250, 0.28),
+    inset 0 1px 0 rgba(255, 255, 255, 0.66),
+    inset 0 -10px 18px rgba(20, 37, 64, 0.14),
+    inset 0 0 0 1px rgba(15, 23, 42, 0.1);
+}
+.lp-btn--primary::before { display: block; }
 .lp-btn--primary:hover {
   transform: translateY(-2px);
-  box-shadow: 0 18px 46px -12px rgba(34, 211, 238, 0.82), inset 0 1px 0 rgba(255, 255, 255, 0.5);
+  border-color: rgba(226, 232, 240, 0.58);
+  box-shadow:
+    0 18px 38px -20px rgba(3, 9, 20, 0.88),
+    0 0 26px -20px rgba(96, 165, 250, 0.38),
+    inset 0 1px 0 rgba(255, 255, 255, 0.76),
+    inset 0 -10px 18px rgba(20, 37, 64, 0.12),
+    inset 0 0 0 1px rgba(15, 23, 42, 0.08);
 }
 .lp-btn--ghost {
   color: var(--ink);
-  background: rgba(255, 255, 255, 0.035);
-  border-color: var(--line-2);
+  background: rgba(20, 29, 49, 0.55);
+  border-color: rgba(43, 58, 85, 0.92);
+  box-shadow:
+    0 12px 28px -24px rgba(3, 9, 20, 0.86),
+    inset 0 1px 0 rgba(255, 255, 255, 0.055);
 }
+.lp-btn--ghost:visited { color: var(--ink); }
 .lp-btn--ghost:hover {
   transform: translateY(-2px);
-  border-color: rgba(140, 185, 245, 0.5);
-  background: rgba(255, 255, 255, 0.07);
+  border-color: rgba(96, 165, 250, 0.44);
+  background: rgba(20, 29, 49, 0.78);
+}
+.lp-hero__cta .lp-btn--ghost,
+.lp-hero__cta .lp-btn--ghost:visited {
+  color: var(--ink);
+  font-weight: 600;
+  background: transparent;
+  border-color: rgba(43, 58, 85, 1);
+  box-shadow:
+    0 14px 30px -22px rgba(3, 9, 20, 0.78),
+    inset 0 1px 0 rgba(255, 255, 255, 0.045);
+}
+.lp-hero__cta .lp-btn--ghost:hover {
+  color: #fff;
+  border-color: rgba(96, 165, 250, 0.52);
+  background: rgba(20, 29, 49, 0.72);
+}
+a.lp-btn--primary,
+a.lp-btn--primary:link,
+a.lp-btn--primary:visited,
+a.lp-btn--primary:hover {
+  color: #000 !important;
 }
 .lp-btn:focus-visible { outline: 2px solid var(--sky); outline-offset: 3px; }
 
@@ -101,7 +207,9 @@ html, body { margin: 0; background: #04060b; }
   top: 0;
   z-index: 50;
   border-bottom: 1px solid var(--line);
-  background: rgba(5, 8, 15, 0.72);
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.46), rgba(9, 12, 20, 0.82)),
+    rgba(9, 12, 20, 0.78);
   backdrop-filter: blur(14px) saturate(1.25);
   -webkit-backdrop-filter: blur(14px) saturate(1.25);
 }
@@ -132,7 +240,7 @@ html, body { margin: 0; background: #04060b; }
   border-radius: 8px;
   transition: color 0.2s ease, background 0.2s ease;
 }
-.lp-nav__link:hover { color: var(--ink); background: rgba(255, 255, 255, 0.06); }
+.lp-nav__link:hover { color: var(--ink); background: rgba(20, 29, 49, 0.9); }
 .lp-nav__gh { display: inline-flex; align-items: center; gap: 0.45rem; }
 .lp-nav__gh svg { width: 18px; height: 18px; }
 @media (max-width: 480px) {
@@ -150,21 +258,22 @@ html, body { margin: 0; background: #04060b; }
   position: absolute;
   inset: -2px;
   background:
-    linear-gradient(to right, rgba(130, 168, 228, 0.075) 1px, transparent 1px) 0 0 / 62px 62px,
-    linear-gradient(to bottom, rgba(130, 168, 228, 0.075) 1px, transparent 1px) 0 0 / 62px 62px;
-  -webkit-mask-image: radial-gradient(120% 88% at 50% 6%, #000 0%, transparent 66%);
-  mask-image: radial-gradient(120% 88% at 50% 6%, #000 0%, transparent 66%);
+    linear-gradient(to right, rgba(43, 58, 85, 0.24) 1px, transparent 1px) 0 0 / 62px 62px,
+    linear-gradient(to bottom, rgba(43, 58, 85, 0.18) 1px, transparent 1px) 0 0 / 62px 62px;
+  -webkit-mask-image: radial-gradient(120% 88% at 50% 6%, rgba(0, 0, 0, 0.75) 0%, transparent 62%);
+  mask-image: radial-gradient(120% 88% at 50% 6%, rgba(0, 0, 0, 0.75) 0%, transparent 62%);
   pointer-events: none;
 }
 .lp-hero__aurora {
   position: absolute;
-  left: 50%;
+  left: 0;
   top: -22%;
-  transform: translateX(-50%);
-  width: min(1240px, 150%);
+  width: 100%;
   height: 780px;
-  background: radial-gradient(closest-side, rgba(56, 189, 248, 0.22), rgba(59, 130, 246, 0.13) 44%, transparent 72%);
-  filter: blur(18px);
+  background:
+    radial-gradient(closest-side at 0% 22%, rgba(96, 165, 250, 0.105), rgba(20, 29, 49, 0.055) 38%, transparent 70%),
+    radial-gradient(closest-side at 100% 24%, rgba(34, 211, 238, 0.06), rgba(20, 29, 49, 0.04) 38%, transparent 72%);
+  filter: blur(16px);
   pointer-events: none;
 }
 .lp-hero__in {
@@ -186,20 +295,23 @@ html, body { margin: 0; background: #04060b; }
   padding: 0.38rem 0.9rem 0.38rem 0.45rem;
   border-radius: 999px;
   border: 1px solid var(--line-2);
-  background: rgba(255, 255, 255, 0.035);
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.84), rgba(11, 15, 26, 0.74)),
+    rgba(15, 22, 38, 0.76);
   backdrop-filter: blur(6px);
   transition: border-color 0.25s ease, color 0.25s ease;
 }
-.lp-eyebrow:hover { border-color: rgba(140, 185, 245, 0.55); color: var(--ink); }
+.lp-eyebrow:hover { border-color: rgba(96, 165, 250, 0.5); color: var(--ink); }
 .lp-eyebrow__tag {
   font-family: var(--mono);
   font-size: 11px;
   font-weight: 700;
   letter-spacing: 0.03em;
-  color: #05070d;
+  color: #04060b;
   padding: 0.22rem 0.55rem;
   border-radius: 999px;
-  background: var(--grad);
+  background: var(--metal-lite);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.56), inset 0 -6px 10px rgba(20, 37, 64, 0.13);
 }
 .lp-eyebrow__arw { opacity: 0.55; }
 .lp-h1 {
@@ -212,7 +324,7 @@ html, body { margin: 0; background: #04060b; }
 }
 .lp-h1 .lp-grad {
   display: block;
-  filter: drop-shadow(0 6px 34px rgba(56, 189, 248, 0.28));
+  filter: drop-shadow(0 8px 30px rgba(96, 165, 250, 0.14));
 }
 .lp-sub {
   margin: 1.6rem auto 0;
@@ -241,7 +353,10 @@ html, body { margin: 0; background: #04060b; }
   position: absolute;
   inset: -16% -12% -26%;
   z-index: 0;
-  background: radial-gradient(58% 62% at 50% 46%, rgba(34, 211, 238, 0.42), rgba(59, 130, 246, 0.24) 44%, transparent 72%);
+  background:
+    radial-gradient(60% 62% at 50% 48%, rgba(30, 41, 59, 0.34), rgba(9, 12, 20, 0.2) 46%, transparent 72%),
+    radial-gradient(42% 50% at 6% 52%, rgba(96, 165, 250, 0.08), transparent 70%),
+    radial-gradient(42% 50% at 94% 52%, rgba(34, 211, 238, 0.055), transparent 70%);
   filter: blur(48px);
   pointer-events: none;
 }
@@ -250,48 +365,24 @@ html, body { margin: 0; background: #04060b; }
   z-index: 1;
   padding: clamp(9px, 1.6vw, 15px);
   border-radius: 24px;
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.06), rgba(255, 255, 255, 0.012));
+  background:
+    linear-gradient(160deg, rgba(20, 29, 49, 0.92), #0b0f1a),
+    var(--panel);
   border: 1px solid var(--line-2);
-  box-shadow: 0 46px 96px -44px rgba(0, 0, 0, 0.92), inset 0 1px 0 rgba(255, 255, 255, 0.07);
+  box-shadow:
+    0 48px 96px -44px rgba(0, 0, 0, 0.94),
+    0 0 0 1px rgba(255, 255, 255, 0.05),
+    inset 0 1px 0 rgba(255, 255, 255, 0.1),
+    0 0 0 1px rgba(56, 189, 248, 0.05),
+    inset 0 -22px 30px rgba(3, 9, 20, 0.2);
 }
-.lp-stage__meta {
-  position: relative;
-  z-index: 1;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 1rem;
-  margin-top: 0.95rem;
-  padding: 0 0.4rem;
-  font-family: var(--mono);
-  font-size: 12px;
-  color: var(--muted);
-}
-.lp-live { display: inline-flex; align-items: center; gap: 0.5rem; }
-.lp-live__dot {
-  width: 7px;
-  height: 7px;
-  border-radius: 50%;
-  background: #34d399;
-  box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.55);
-  animation: lp-pulse 2.4s ease-out infinite;
-}
-.lp-fps { color: #34d399; font-variant-numeric: tabular-nums; }
-@keyframes lp-pulse {
-  0% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0.55); }
-  70% { box-shadow: 0 0 0 8px rgba(52, 211, 153, 0); }
-  100% { box-shadow: 0 0 0 0 rgba(52, 211, 153, 0); }
-}
-
 /* ---- Section scaffolding -------------------------------------------------- */
 .lp-section { padding: clamp(4.5rem, 10vw, 8rem) 0; }
 .lp-kicker {
-  font-family: var(--mono);
-  font-size: 12px;
+  display: inline-block;
+  font-size: 0.94rem;
   font-weight: 600;
-  letter-spacing: 0.2em;
-  text-transform: uppercase;
-  color: #4cbbe8;
+  color: #a9b7cb;
 }
 .lp-secthead { max-width: 680px; margin: 0 auto; text-align: center; }
 .lp-secthead .lp-kicker { display: block; margin-bottom: 0.9rem; }
@@ -309,20 +400,18 @@ html, body { margin: 0; background: #04060b; }
   color: var(--ink-2);
 }
 
-/* ---- Tools strip ---------------------------------------------------------- */
-.lp-tools {
-  padding: clamp(2.75rem, 6vw, 4rem) 0;
+/* ---- Hardware section ----------------------------------------------------- */
+.lp-hardware {
   border-top: 1px solid var(--line);
-  border-bottom: 1px solid var(--line);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.018), transparent);
+  background:
+    radial-gradient(38% 50% at 0% 8%, rgba(96, 165, 250, 0.06), transparent 70%),
+    radial-gradient(36% 48% at 100% 14%, rgba(34, 211, 238, 0.035), transparent 72%),
+    linear-gradient(180deg, rgba(20, 29, 49, 0.2), transparent);
 }
 .lp-tools__label {
   text-align: center;
-  font-family: var(--mono);
-  font-size: 12px;
+  font-size: 0.95rem;
   font-weight: 600;
-  letter-spacing: 0.16em;
-  text-transform: uppercase;
   color: var(--muted);
 }
 .lp-tools__row {
@@ -330,13 +419,13 @@ html, body { margin: 0; background: #04060b; }
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
-  gap: clamp(1.5rem, 5vw, 3.75rem);
-  margin-top: 1.7rem;
+  gap: clamp(1rem, 3vw, 2.1rem);
+  margin-top: clamp(2rem, 4vw, 2.8rem);
 }
 .lp-tool {
   display: inline-flex;
   align-items: center;
-  gap: 0.7rem;
+  justify-content: center;
   font-weight: 600;
   font-size: clamp(1rem, 2vw, 1.18rem);
   color: var(--ink);
@@ -344,37 +433,36 @@ html, body { margin: 0; background: #04060b; }
   transition: opacity 0.2s ease;
 }
 .lp-tool:hover { opacity: 1; }
-.lp-tool svg { flex: none; }
-
-/* ---- Stats band ----------------------------------------------------------- */
-.lp-stats {
+.lp-tool svg {
+  flex: none;
+  width: clamp(42px, 5vw, 58px);
+  height: auto;
+  max-height: 54px;
+}
+.lp-proof-grid {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 1px;
-  background: var(--line);
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-top: clamp(2.2rem, 5vw, 3rem);
+}
+.lp-proof {
   border: 1px solid var(--line);
-  border-radius: 20px;
-  overflow: hidden;
+  border-radius: 16px;
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.58), rgba(7, 10, 17, 0.9)),
+    var(--bg-2);
+  padding: 1.4rem;
 }
-@media (min-width: 760px) { .lp-stats { grid-template-columns: repeat(4, 1fr); } }
-.lp-stat {
-  background: #06090f;
-  padding: clamp(1.7rem, 4vw, 2.7rem) 1.4rem;
-  text-align: center;
+.lp-proof h3 {
+  color: var(--ink);
+  font-size: 1.05rem;
+  font-weight: 700;
+  margin-bottom: 0.55rem;
 }
-.lp-stat__n {
-  font-weight: 800;
-  letter-spacing: -0.03em;
-  line-height: 1;
-  font-size: clamp(2.6rem, 6.2vw, 3.7rem);
-}
-.lp-stat__u { font-size: 0.9em; }
-.lp-stat__l {
-  margin-top: 0.6rem;
-  font-family: var(--mono);
-  font-size: 0.82rem;
-  letter-spacing: 0.02em;
-  color: var(--muted);
+.lp-proof p {
+  color: var(--ink-2);
+  font-size: 0.94rem;
+  line-height: 1.6;
 }
 
 /* ---- Feature grid --------------------------------------------------------- */
@@ -389,7 +477,9 @@ html, body { margin: 0; background: #04060b; }
   padding: 1.7rem;
   border-radius: 18px;
   border: 1px solid var(--line);
-  background: linear-gradient(180deg, rgba(255, 255, 255, 0.038), rgba(255, 255, 255, 0.012));
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.68), rgba(11, 15, 26, 0.9)),
+    var(--bg-2);
   overflow: hidden;
   transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
 }
@@ -399,7 +489,7 @@ html, body { margin: 0; background: #04060b; }
   inset: 0;
   border-radius: inherit;
   padding: 1px;
-  background: linear-gradient(140deg, rgba(56, 189, 248, 0.55), rgba(59, 130, 246, 0.15) 42%, transparent 60%);
+  background: linear-gradient(140deg, rgba(148, 163, 184, 0.44), rgba(96, 165, 250, 0.16) 42%, transparent 60%);
   -webkit-mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
   -webkit-mask-composite: xor;
   mask: linear-gradient(#000 0 0) content-box, linear-gradient(#000 0 0);
@@ -411,7 +501,7 @@ html, body { margin: 0; background: #04060b; }
 .lp-card:hover {
   transform: translateY(-4px);
   border-color: var(--line-2);
-  box-shadow: 0 28px 54px -32px rgba(0, 0, 0, 0.9);
+  box-shadow: 0 28px 54px -32px rgba(3, 9, 20, 0.92), inset 0 1px 0 rgba(255, 255, 255, 0.055);
 }
 .lp-card:hover::before { opacity: 1; }
 .lp-card__ic {
@@ -420,9 +510,10 @@ html, body { margin: 0; background: #04060b; }
   width: 46px;
   height: 46px;
   border-radius: 13px;
-  color: var(--sky);
-  background: rgba(56, 189, 248, 0.1);
-  border: 1px solid rgba(56, 189, 248, 0.22);
+  color: #dbeafe;
+  background: rgba(20, 29, 49, 0.78);
+  border: 1px solid rgba(43, 58, 85, 0.95);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
   margin-bottom: 1.15rem;
 }
 .lp-card h3 {
@@ -436,7 +527,7 @@ html, body { margin: 0; background: #04060b; }
 .lp-card code {
   font-family: var(--mono);
   font-size: 0.85em;
-  color: var(--sky);
+  color: #cbd5e1;
 }
 
 /* ---- Split (code) section ------------------------------------------------- */
@@ -453,8 +544,8 @@ html, body { margin: 0; background: #04060b; }
   font-family: var(--mono);
   font-size: 0.85em;
   color: var(--sky);
-  background: rgba(56, 189, 248, 0.09);
-  border: 1px solid rgba(56, 189, 248, 0.16);
+  background: rgba(20, 29, 49, 0.78);
+  border: 1px solid rgba(43, 58, 85, 0.92);
   padding: 0.08em 0.4em;
   border-radius: 6px;
   white-space: nowrap;
@@ -474,16 +565,18 @@ html, body { margin: 0; background: #04060b; }
   line-height: 1.5;
   color: var(--ink-2);
 }
-.lp-checklist svg { flex: none; margin-top: 0.15rem; color: var(--sky); }
+.lp-checklist svg { flex: none; margin-top: 0.15rem; color: #cbd5e1; }
 .lp-split__copy .lp-btn { margin-top: 1.9rem; }
 
 /* ---- Code card ------------------------------------------------------------ */
 .lp-codecard {
   border-radius: 16px;
   border: 1px solid var(--line-2);
-  background: #070a12;
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.62), rgba(9, 12, 20, 0.94)),
+    #090c14;
   overflow: hidden;
-  box-shadow: 0 46px 90px -46px rgba(0, 0, 0, 0.92);
+  box-shadow: 0 46px 90px -46px rgba(3, 9, 20, 0.94);
 }
 .lp-codecard__bar {
   display: flex;
@@ -491,9 +584,9 @@ html, body { margin: 0; background: #04060b; }
   gap: 0.5rem;
   padding: 0.78rem 1.05rem;
   border-bottom: 1px solid var(--line);
-  background: rgba(255, 255, 255, 0.022);
+  background: rgba(20, 29, 49, 0.72);
 }
-.lp-dot { width: 11px; height: 11px; border-radius: 50%; background: rgba(140, 172, 224, 0.28); }
+.lp-dot { width: 11px; height: 11px; border-radius: 50%; background: rgba(148, 163, 184, 0.28); box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18); }
 .lp-codecard__name {
   margin-left: 0.55rem;
   font-family: var(--mono);
@@ -506,16 +599,16 @@ html, body { margin: 0; background: #04060b; }
   font-family: var(--mono);
   font-size: 13.5px;
   line-height: 1.75;
-  color: #c7d4e8;
+  color: #cbd5e1;
   -webkit-text-size-adjust: 100%;
 }
 .lp-code code { font: inherit; white-space: pre; }
-.lp-k { color: #c8a6ff; }
-.lp-t { color: #6ec6ff; }
-.lp-f { color: #57d6c6; }
-.lp-a { color: #f2b184; }
-.lp-s { color: #8ee79f; }
-.lp-n { color: #ffb27a; }
+.lp-k { color: #e8d5ff; }
+.lp-t { color: #dbeafe; }
+.lp-f { color: #b6f4dc; }
+.lp-a { color: #f1d2b8; }
+.lp-s { color: #cdf8d8; }
+.lp-n { color: #f7cfaa; }
 .lp-code-mut { color: #566780; }
 
 /* ---- Closing CTA ---------------------------------------------------------- */
@@ -531,7 +624,7 @@ html, body { margin: 0; background: #04060b; }
   transform: translate(-50%, -50%);
   width: min(900px, 120%);
   height: 520px;
-  background: radial-gradient(closest-side, rgba(34, 211, 238, 0.2), rgba(59, 130, 246, 0.12) 45%, transparent 72%);
+  background: radial-gradient(closest-side, rgba(96, 165, 250, 0.09), rgba(20, 29, 49, 0.12) 48%, transparent 72%);
   filter: blur(30px);
   pointer-events: none;
 }
@@ -555,7 +648,7 @@ html, body { margin: 0; background: #04060b; }
 /* ---- Footer --------------------------------------------------------------- */
 .lp-footer {
   border-top: 1px solid var(--line);
-  background: linear-gradient(180deg, transparent, rgba(255, 255, 255, 0.014));
+  background: linear-gradient(180deg, transparent, rgba(20, 29, 49, 0.34));
 }
 .lp-footer__grid {
   display: grid;
@@ -583,7 +676,7 @@ html, body { margin: 0; background: #04060b; }
 }
 .lp-footer ul { list-style: none; padding: 0; display: flex; flex-direction: column; gap: 0.6rem; }
 .lp-footer li a { color: var(--muted); text-decoration: none; font-size: 0.9rem; transition: color 0.2s ease; }
-.lp-footer li a:hover { color: var(--sky); }
+.lp-footer li a:hover { color: #e2e8f0; }
 .lp-footer__bar {
   display: flex;
   flex-wrap: wrap;

--- a/site/assets/screen.css
+++ b/site/assets/screen.css
@@ -14,9 +14,9 @@
   overflow: hidden;
   background: #05070d;
   box-shadow:
-    0 0 0 1px rgba(120, 160, 230, 0.16),
+    0 0 0 1px rgba(43, 58, 85, 0.95),
     0 28px 56px -22px rgba(0, 0, 0, 0.7),
-    0 0 70px -26px rgba(56, 189, 248, 0.32);
+    0 0 42px -28px rgba(56, 189, 248, 0.24);
 }
 .screen-emu canvas {
   display: block;
@@ -55,17 +55,17 @@
   display: grid;
   place-items: center;
   color: rgba(255, 255, 255, 0.92);
-  background: rgba(51, 66, 97, 0.32);
+  background: rgba(20, 29, 49, 0.56);
   border: 1px solid rgba(255, 255, 255, 0.4);
-  box-shadow: inset 0 0 6px rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
   transition: background 0.1s ease, transform 0.05s ease, border-color 0.1s ease;
 }
 .emu-key svg { width: 46%; height: 46%; }
-.emu-key:hover { background: rgba(51, 66, 97, 0.44); }
+.emu-key:hover { background: rgba(30, 41, 59, 0.68); }
 .emu-key.is-down,
 .emu-key:active {
-  background: rgba(96, 165, 250, 0.6);
-  border-color: rgba(191, 219, 254, 0.9);
+  background: rgba(96, 165, 250, 0.3);
+  border-color: rgba(147, 197, 253, 0.68);
   transform: scale(0.9);
 }
 
@@ -91,17 +91,21 @@
 .emu-dpad .right { right: 2%;  top: 35%;  height: 30%; width: 34%; }
 .emu-dpad .emu-key.is-down,
 .emu-dpad .emu-key:active {
-  background: rgba(96, 165, 250, 0.42);
+  background: rgba(96, 165, 250, 0.24);
   border-radius: 6px;
   transform: none;
 }
 
 /* face buttons diamond */
 .emu-faces .emu-key { width: 36%; aspect-ratio: 1; border-radius: 50%; }
-.emu-faces .tri   { top: 0;     left: 32%; color: #9ff2c6; }
-.emu-faces .sq    { top: 32%; left: 0;     color: #f8bfe0; }
-.emu-faces .ci    { top: 32%; right: 0;    color: #ffbcc2; }
-.emu-faces .cross { bottom: 0;  left: 32%; color: #b3ccff; }
+.emu-faces .tri,
+.emu-faces .sq,
+.emu-faces .ci,
+.emu-faces .cross { color: rgba(255, 255, 255, 0.92); }
+.emu-faces .tri   { top: 0;     left: 32%; }
+.emu-faces .sq    { top: 32%; left: 0;     }
+.emu-faces .ci    { top: 32%; right: 0;    }
+.emu-faces .cross { bottom: 0;  left: 32%; }
 
 /* SELECT / START */
 .emu-sys {
@@ -122,12 +126,12 @@
   padding: 1cqw 2.4cqw;
   border-radius: 999px;
   color: rgba(255, 255, 255, 0.82);
-  background: rgba(51, 66, 97, 0.34);
+  background: rgba(20, 29, 49, 0.56);
   border: 1px solid rgba(255, 255, 255, 0.34);
   transition: background 0.1s ease;
 }
 .emu-sys-btn.is-down,
 .emu-sys-btn:active {
-  background: rgba(96, 165, 250, 0.6);
+  background: rgba(96, 165, 250, 0.3);
   color: #fff;
 }

--- a/site/assets/tailwind.css
+++ b/site/assets/tailwind.css
@@ -4,18 +4,34 @@
 /* Scan every place a class can appear (TS template strings, HTML, JS glue). */
 @source "../**/*.{ts,html,js}";
 
+@font-face {
+  font-family: "Inter";
+  src: url("/pg/fonts/Inter-Regular.ttf") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Inter";
+  src: url("/pg/fonts/Inter-Bold.ttf") format("truetype");
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}
+
 /* ---- brand theme ---------------------------------------------------------- */
 @theme {
   --font-sans:
-    ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Inter, Helvetica, Arial, sans-serif;
+    Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --font-mono:
     ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
 
   /* near-black navy base + layered surfaces */
-  --color-ink: #090c14;
-  --color-ink-2: #0b0f1a;
-  --color-surface: #0f1626;
-  --color-surface-2: #141d31;
+  --color-ink: #05070d;
+  --color-ink-2: #070a11;
+  --color-surface: #0b0f1a;
+  --color-surface-2: #101827;
   --color-line: #1e293b;
   --color-line-2: #2b3a55;
 
@@ -32,7 +48,10 @@
     -webkit-text-size-adjust: 100%;
   }
   body {
-    background: var(--color-ink);
+    background:
+      radial-gradient(42% 72% at 0% 6%, color-mix(in oklab, var(--color-brand-3) 10%, transparent), transparent 66%),
+      radial-gradient(36% 70% at 100% 12%, color-mix(in oklab, var(--color-brand-2) 6%, transparent), transparent 68%),
+      linear-gradient(180deg, #070a11 0%, var(--color-ink) 48%, #070a11 100%);
     color: var(--color-slate-300);
     font-family: var(--font-sans);
     -webkit-font-smoothing: antialiased;
@@ -46,7 +65,7 @@
     color: inherit;
     text-decoration: none;
   }
-  /* subtle top-of-page aurora */
+  /* Edge-only page glow, shared with the landing page direction. */
   body::before {
     content: "";
     position: fixed;
@@ -55,14 +74,14 @@
     pointer-events: none;
     z-index: -1;
     background:
-      radial-gradient(60% 90% at 22% -10%, color-mix(in oklab, var(--color-brand-3) 20%, transparent), transparent 70%),
-      radial-gradient(50% 80% at 90% -20%, color-mix(in oklab, var(--color-brand-2) 16%, transparent), transparent 70%);
+      radial-gradient(42% 72% at 0% 6%, color-mix(in oklab, var(--color-brand-3) 9%, transparent), transparent 66%),
+      radial-gradient(36% 70% at 100% 12%, color-mix(in oklab, var(--color-brand-2) 5%, transparent), transparent 68%);
   }
 }
 
 /* ---- reusable brand bits -------------------------------------------------- */
 @utility text-gradient {
-  background: linear-gradient(120deg, var(--color-brand-3), var(--color-brand-2));
+  background: linear-gradient(120deg, #f3f7fd 0%, #d6e0ec 36%, #8d9bb0 67%, #c5d4e6 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
@@ -91,9 +110,11 @@
     transform: translateY(-1px);
   }
   .btn-primary {
-    border-color: transparent;
-    color: #04121b;
-    background: linear-gradient(120deg, var(--color-brand-3), var(--color-brand-2));
+    border-color: rgba(226, 232, 240, 0.44);
+    color: #05070d;
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 40%),
+      linear-gradient(112deg, #eef3fa 0%, #d2dbe7 26%, #b3becc 45%, #e8edf4 67%, #c2ccd9 100%);
   }
   .btn-primary:hover {
     filter: brightness(1.06);
@@ -156,7 +177,7 @@
     box-shadow:
       0 1px 0 rgba(255, 255, 255, 0.05) inset,
       0 30px 60px -30px rgba(0, 0, 0, 0.7),
-      0 0 0 1px rgba(56, 189, 248, 0.06);
+      0 0 0 1px rgba(56, 189, 248, 0.05);
   }
   .pocket-screen {
     position: relative;
@@ -164,7 +185,7 @@
     overflow: hidden;
     background: #000;
     border: 1px solid #05070d;
-    box-shadow: 0 0 0 6px #05070d, 0 0 24px -4px rgba(56, 189, 248, 0.25) inset;
+    box-shadow: 0 0 0 6px #05070d, 0 0 18px -8px rgba(56, 189, 248, 0.22) inset;
     aspect-ratio: 480 / 272;
   }
   .pocket-screen canvas,
@@ -240,7 +261,7 @@
   }
   .pg-tb-left { display: flex; align-items: center; gap: 0.6rem; flex-wrap: wrap; }
   .pg-tb-right { display: flex; align-items: center; gap: 0.9rem; }
-  .pg-tb-label { font-size: 0.75rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-slate-500); }
+  .pg-tb-label { font-size: 0.78rem; font-weight: 600; color: var(--color-slate-500); }
   #pg-demo {
     background: var(--color-surface-2);
     color: var(--color-slate-100);
@@ -270,7 +291,8 @@
     align-items: center;
     gap: 1rem;
     background:
-      radial-gradient(80% 50% at 50% 0%, color-mix(in oklab, var(--color-brand-3) 8%, transparent), transparent 70%),
+      radial-gradient(42% 60% at 0% 8%, color-mix(in oklab, var(--color-brand-3) 7%, transparent), transparent 70%),
+      radial-gradient(36% 58% at 100% 12%, color-mix(in oklab, var(--color-brand-2) 4%, transparent), transparent 72%),
       var(--color-ink);
   }
   .pg-device { width: 100%; max-width: 460px; }
@@ -304,7 +326,7 @@
   .pad:hover { border-color: var(--color-brand); }
   .pad.held, .pad:active { background: var(--color-brand); color: #04121b; transform: scale(0.94); }
   .pg-sys { display: flex; gap: 0.75rem; }
-  .pad.sys { width: auto; padding: 0 0.7rem; height: 24px; font-size: 0.62rem; letter-spacing: 0.05em; }
+  .pad.sys { width: auto; padding: 0 0.7rem; height: 24px; font-size: 0.66rem; }
   .pg-error {
     width: 100%; max-width: 620px; margin: 0; padding: 0.75rem 0.9rem;
     background: color-mix(in oklab, #7f1d1d 30%, var(--color-ink-2));
@@ -324,7 +346,7 @@
   }
   @media (min-width: 1000px) { .doc-nav { display: block; } }
   .doc-sec { margin-bottom: 1.4rem; }
-  .doc-sec-t { font-size: 0.72rem; text-transform: uppercase; letter-spacing: 0.08em; color: var(--color-slate-500); margin-bottom: 0.5rem; }
+  .doc-sec-t { font-size: 0.78rem; font-weight: 600; color: var(--color-slate-500); margin-bottom: 0.5rem; }
   .doc-nav a { display: block; padding: 0.3rem 0.6rem; border-radius: 0.4rem; font-size: 0.88rem; color: var(--color-slate-400); }
   .doc-nav a:hover { color: var(--color-slate-100); background: var(--color-surface); }
   .doc-nav a.on { color: var(--color-brand-2); background: color-mix(in oklab, var(--color-brand) 12%, transparent); font-weight: 600; }
@@ -334,5 +356,5 @@
   .doc-pager a { display: flex; flex-direction: column; padding: 0.75rem 1rem; border: 1px solid var(--color-line); border-radius: 0.6rem; font-size: 0.9rem; color: var(--color-slate-200); max-width: 48%; }
   .doc-pager a:hover { border-color: var(--color-brand); }
   .doc-pager a.next { text-align: right; margin-left: auto; }
-  .doc-pager span { font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.06em; color: var(--color-slate-500); }
+  .doc-pager span { font-size: 0.72rem; font-weight: 600; color: var(--color-slate-500); }
 }

--- a/site/build.ts
+++ b/site/build.ts
@@ -13,6 +13,7 @@
 //   /playground/          the live editor page
 //   /docs/*, /index.html  rendered from site/content (added below)
 
+import { spawnSync } from "node:child_process";
 import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync, cpSync, rmSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { marked } from "marked";
@@ -35,6 +36,33 @@ const copy = (from: string, toRel: string) => {
   mkdirSync(dirname(p), { recursive: true });
   cpSync(from, p, { recursive: true });
 };
+
+function ensureShowcaseBundle(name: string): void {
+  const js = ROOT + "dist/" + name + ".js";
+  const pak = ROOT + "dist/" + name + ".pak";
+  const legacyPak = ROOT + "dist/" + name + ".dcpak";
+  if (existsSync(js) && (existsSync(pak) || existsSync(legacyPak))) return;
+
+  console.log(`  dist/${name}.js + dist/${name}.pak missing; building showcase`);
+  const res = spawnSync("bun", ["scripts/build.ts", name], { cwd: ROOT, stdio: "inherit" });
+  if (res.status !== 0) throw new Error(`showcase build failed: ${name}`);
+}
+
+function copyShowcaseBundle(name: string): void {
+  ensureShowcaseBundle(name);
+
+  const js = ROOT + "dist/" + name + ".js";
+  const pak = ROOT + "dist/" + name + ".pak";
+  const legacyPak = ROOT + "dist/" + name + ".dcpak";
+  const pakSource = existsSync(pak) ? pak : legacyPak;
+
+  if (!existsSync(js) || !existsSync(pakSource)) {
+    throw new Error(`missing showcase bundle: dist/${name}.js + dist/${name}.pak`);
+  }
+
+  copy(js, "pg/demo-bundles/" + name + ".js");
+  copy(pakSource, "pg/demo-bundles/" + name + ".pak");
+}
 
 // --- node-builtin shims: let @babel/core + preset-solid bundle for the browser
 const SHIM_MAP: Record<string, string> = { assert: "assert.js", "node:assert": "assert.js", path: "path.js", "node:path": "path.js" };
@@ -125,13 +153,11 @@ async function main() {
   write("pg/demos.json", JSON.stringify(demos));
   console.log(`  pg/demos.json  (${demos.length} demos: ${demos.map((d) => d.name).join(", ")})`);
 
-  // 4. prebuilt showcase bundles for the homepage hero (no compiler needed)
+  // 4. prebuilt showcase bundles for the homepage hero. Reuse dist/ when
+  //    present, and build missing bundles so the site never emits 404 demos.
   const showcase = ["settings-main", "launcher-main", "music-main"];
   for (const s of showcase) {
-    const js = ROOT + "dist/" + s + ".js";
-    const pak = ROOT + "dist/" + s + ".pak";
-    if (existsSync(js)) copy(js, "pg/demo-bundles/" + s + ".js");
-    if (existsSync(pak)) copy(pak, "pg/demo-bundles/" + s + ".pak");
+    copyShowcaseBundle(s);
   }
 
   // 5. static assets + Tailwind CSS (compiled AFTER pages exist so the content

--- a/site/content/docs/overview.md
+++ b/site/content/docs/overview.md
@@ -1,11 +1,10 @@
 # Overview
 
-PocketJS is a JSX UI stack for the Sony PSP (and beyond). You write components
-with **Solid** and style them with a **Tailwind subset**; a build step compiles
-your styles and bakes your fonts, and the whole thing runs on top of a single
-`no_std` Rust core that does flexbox layout, styling, animation, text, and
-rendering. The same `app.tsx` runs on real PSP hardware, in the PPSSPP
-emulator, in the browser, and headless under Bun.
+PocketJS lets you build **Solid** and **Tailwind** interfaces for the Sony PSP
+and similarly constrained hardware. It compiles class strings and font glyphs at
+build time, then renders real flexbox, sub-pixel text and native animation
+through a compact `no_std` Rust core. The same `app.tsx` runs on real PSP
+hardware, in the PPSSPP emulator, in the browser, and headless under Bun.
 
 If you know React or Solid, you already know most of PocketJS. The primitives
 are `View`, `Text`, and `Image`; state is `createSignal` / `createEffect`;

--- a/site/home.html
+++ b/site/home.html
@@ -3,11 +3,15 @@
     <div class="lp-container lp-nav__in">
       <a class="lp-brand" href="/" aria-label="PocketJS home">
         <svg viewBox="0 0 32 32" aria-hidden="true">
-          <rect x="1.5" y="5.5" width="29" height="21" rx="5" fill="none" stroke="url(#lp-pgn)" stroke-width="2"/>
-          <circle cx="9" cy="16" r="3.2" fill="url(#lp-pgn)"/>
-          <rect x="18.5" y="12.6" width="7.5" height="1.9" rx=".95" fill="url(#lp-pgn)"/>
-          <rect x="18.5" y="17.6" width="7.5" height="1.9" rx=".95" fill="url(#lp-pgn)"/>
-          <defs><linearGradient id="lp-pgn" x1="0" y1="0" x2="32" y2="32"><stop offset="0" stop-color="#60a5fa"/><stop offset="1" stop-color="#22d3ee"/></linearGradient></defs>
+          <defs>
+            <linearGradient id="lp-pgn-edge" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#eef6ff"/><stop offset="0.38" stop-color="#b7c8e2"/><stop offset="0.58" stop-color="#7487a0"/><stop offset="0.78" stop-color="#aec0d6"/><stop offset="1" stop-color="#dbe8f6"/></linearGradient>
+            <linearGradient id="lp-pgn-lens" x1="7" y1="13" x2="13" y2="19" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#e4edf8"/><stop offset="0.55" stop-color="#a7b8cf"/><stop offset="1" stop-color="#53677f"/></linearGradient>
+            <linearGradient id="lp-pgn-bar" x1="16" y1="12" x2="24" y2="20" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#d7e3f1"/><stop offset="1" stop-color="#71849d"/></linearGradient>
+          </defs>
+          <rect x="2" y="6" width="28" height="20" rx="6" fill="none" stroke="url(#lp-pgn-edge)" stroke-width="2.6" stroke-linejoin="round"/>
+          <circle cx="10" cy="16" r="3.1" fill="url(#lp-pgn-lens)"/>
+          <rect x="16" y="12.6" width="10" height="2.2" rx="1.1" fill="url(#lp-pgn-bar)"/>
+          <rect x="16" y="17.2" width="6.5" height="2.2" rx="1.1" fill="url(#lp-pgn-bar)"/>
         </svg>
         <span>PocketJS</span>
       </a>
@@ -29,15 +33,14 @@
       <div class="lp-hero__aurora" aria-hidden="true"></div>
       <div class="lp-container lp-hero__in">
         <a class="lp-eyebrow" href="/docs/architecture/">
-          <span class="lp-eyebrow__tag">NEW</span>
+          <span class="lp-eyebrow__tag">Now</span>
           The modern web, from 32&nbsp;MB up
           <span class="lp-eyebrow__arw" aria-hidden="true">&rarr;</span>
         </a>
         <h1 class="lp-h1">Bare Metal<span class="lp-grad">Modern Web</span></h1>
         <p class="lp-sub">
-          PocketJS renders a real <span class="lp-hl">Solid</span> app &mdash; JSX, Tailwind, signals and
-          TypeScript &mdash; natively on the metal. Real flexbox, sub-pixel text and hardware-accelerated
-          animation, at a fluid <span class="lp-hl">60&nbsp;FPS in 32&nbsp;MB of RAM</span>.
+          PocketJS makes browser-style UI practical off the browser:
+          familiar JSX, Tailwind utilities and native rendering on PSP-class hardware.
         </p>
         <div class="lp-hero__cta">
           <a class="lp-btn lp-btn--primary" href="/docs/getting-started/">Get started</a>
@@ -54,7 +57,7 @@
               <canvas id="hero-canvas" width="480" height="272" tabindex="0"></canvas>
               <div id="hero-loading" class="emu-loading">booting core…</div>
               <div class="emu-dpad">
-                <svg class="emu-cross" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M36 3 H64 V36 H97 V64 H64 V97 H36 V64 H3 V36 H36 Z" fill="rgba(51,66,97,0.55)" stroke="rgba(255,255,255,0.34)" stroke-width="2.5" stroke-linejoin="round"/></svg>
+                <svg class="emu-cross" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M36 3 H64 V36 H97 V64 H64 V97 H36 V64 H3 V36 H36 Z" fill="rgba(20,29,49,0.68)" stroke="rgba(255,255,255,0.28)" stroke-width="2.5" stroke-linejoin="round"/></svg>
                 <button class="emu-key up" data-btn="0x0010" aria-label="Up"><svg viewBox="0 0 24 24"><path d="M12 8 l6 8 h-12 z" fill="currentColor"/></svg></button>
                 <button class="emu-key down" data-btn="0x0040" aria-label="Down"><svg viewBox="0 0 24 24"><path d="M12 16 l6 -8 h-12 z" fill="currentColor"/></svg></button>
                 <button class="emu-key left" data-btn="0x0080" aria-label="Left"><svg viewBox="0 0 24 24"><path d="M8 12 l8 -6 v12 z" fill="currentColor"/></svg></button>
@@ -72,89 +75,57 @@
               </div>
             </div>
           </div>
-          <div class="lp-stage__meta">
-            <span class="lp-live"><span class="lp-live__dot" aria-hidden="true"></span>live &middot; tap the on-screen controls to drive it</span>
-            <span id="hero-fps" class="lp-fps"></span>
-          </div>
         </div>
       </div>
     </section>
 
-    <!-- TOOLS STRIP -->
-    <section class="lp-tools">
-      <div class="lp-container">
-        <p class="lp-tools__label">The stack you already know &mdash; running on the metal</p>
-        <div class="lp-tools__row">
-          <span class="lp-tool">
-            <svg width="30" height="28" viewBox="0 0 48 38" aria-hidden="true"><defs><linearGradient id="lp-sld1" x1="0" y1="0" x2="48" y2="38" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#79b8e3"/><stop offset="1" stop-color="#2f5d8f"/></linearGradient><linearGradient id="lp-sld2" x1="0" y1="14" x2="40" y2="38" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#4b81bd"/><stop offset="1" stop-color="#2b527f"/></linearGradient></defs><path fill="url(#lp-sld1)" d="M25 2C14 2 7 7 5 16c8-6 15-4 21 1 4 3 10 4 16 1-2-10-9-16-17-16z"/><path fill="url(#lp-sld2)" d="M8 20c-9 4-6 12 3 14 8 2 15-1 19-7-8 5-16 3-22-7z"/></svg>
-            <span>Solid</span>
-          </span>
-          <span class="lp-tool">
-            <svg width="30" height="27" viewBox="-11.5 -10.23 23 20.46" aria-hidden="true"><circle r="2.05" fill="#61dafb"/><g fill="none" stroke="#61dafb" stroke-width="1"><ellipse rx="11" ry="4.2"/><ellipse rx="11" ry="4.2" transform="rotate(60)"/><ellipse rx="11" ry="4.2" transform="rotate(120)"/></g></svg>
-            <span>JSX</span>
-          </span>
-          <span class="lp-tool">
-            <svg width="34" height="21" viewBox="0 0 54 33" aria-hidden="true"><path fill="#38bdf8" fill-rule="evenodd" clip-rule="evenodd" d="M27 0c-7.2 0-11.7 3.6-13.5 10.8 2.7-3.6 5.85-4.95 9.45-4.05 2.054.513 3.522 2.004 5.147 3.653C30.744 13.09 33.808 16.2 40.5 16.2c7.2 0 11.7-3.6 13.5-10.8-2.7 3.6-5.85 4.95-9.45 4.05-2.054-.513-3.522-2.004-5.147-3.653C36.756 3.11 33.692 0 27 0zM13.5 16.2C6.3 16.2 1.8 19.8 0 27c2.7-3.6 5.85-4.95 9.45-4.05 2.054.514 3.522 2.004 5.147 3.653C17.244 29.29 20.308 32.4 27 32.4c7.2 0 11.7-3.6 13.5-10.8-2.7 3.6-5.85 4.95-9.45 4.05-2.054-.513-3.522-2.004-5.147-3.653C23.256 19.31 20.192 16.2 13.5 16.2z"/></svg>
-            <span>Tailwind</span>
-          </span>
-          <span class="lp-tool">
-            <svg width="27" height="27" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="5" fill="#3178c6"/><text x="16.5" y="22.5" font-family="ui-sans-serif,system-ui,Arial,sans-serif" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">TS</text></svg>
-            <span>TypeScript</span>
-          </span>
-        </div>
-      </div>
-    </section>
-
-    <!-- STATS BAND -->
-    <section class="lp-section" style="padding-bottom: clamp(2.5rem, 6vw, 4rem);">
-      <div class="lp-container lp-reveal">
-        <div class="lp-stats">
-          <div class="lp-stat"><div class="lp-stat__n lp-grad">60<span class="lp-stat__u"> FPS</span></div><div class="lp-stat__l">frame-locked, sustained</div></div>
-          <div class="lp-stat"><div class="lp-stat__n lp-grad">32<span class="lp-stat__u"> MB</span></div><div class="lp-stat__l">the whole system's RAM</div></div>
-          <div class="lp-stat"><div class="lp-stat__n lp-grad">0<span class="lp-stat__u"> kB</span></div><div class="lp-stat__l">runtime CSS shipped</div></div>
-          <div class="lp-stat"><div class="lp-stat__n lp-grad">1<span class="lp-stat__u"> core</span></div><div class="lp-stat__l">PSP, browser &amp; Bun</div></div>
-        </div>
-      </div>
-    </section>
-
-    <!-- FEATURES -->
-    <section class="lp-section" style="padding-top: clamp(3rem, 6vw, 4.5rem);">
+    <!-- 32 MB HARDWARE -->
+    <section class="lp-section lp-hardware">
       <div class="lp-container">
         <div class="lp-secthead lp-reveal">
-          <span class="lp-kicker">Engineered down to the byte</span>
-          <h2 class="lp-h2">A whole UI engine, sized for a handheld</h2>
-          <p class="lp-lead">No VDOM. No runtime CSS. No font files shipped. Everything the app can't need is compiled away before it ever reaches the device.</p>
+          <span class="lp-kicker">Familiar tools, constrained hardware</span>
+          <h2 class="lp-h2">Tailwind, flexbox and Solid signals in 32&nbsp;MB.</h2>
+          <p class="lp-lead">PocketJS keeps the authoring model modern while moving the expensive work to build time and to a tiny Rust core. The result is a real interface stack that can run smoothly on a Sony PSP.</p>
         </div>
-        <div class="lp-grid">
-          <div class="lp-card lp-reveal">
-            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/></svg></span>
-            <h3>No VDOM</h3>
-            <p>Solid's fine-grained reactivity runs only the effect closures of changed signals. Updates cross a single FFI boundary per frame &mdash; never a diff.</p>
+        <div class="lp-tools__row lp-reveal" aria-label="PocketJS frontend stack">
+          <span class="lp-tool" aria-label="Solid">
+            <svg width="32" height="30" viewBox="0 0 76 70.7" aria-hidden="true">
+              <defs>
+                <linearGradient id="lp-solid-a" x1="11.67" y1="73.36" x2="70.61" y2="44.72" gradientTransform="matrix(1,0,0,-1,0,73.4)" gradientUnits="userSpaceOnUse"><stop offset="0.1" stop-color="#76b3e1"/><stop offset="0.3" stop-color="#dcf2fd"/><stop offset="1" stop-color="#76b3e1"/></linearGradient>
+                <linearGradient id="lp-solid-b" x1="44" y1="59.33" x2="33.68" y2="24.96" gradientTransform="matrix(1,0,0,-1,0,73.4)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#76b3e1"/><stop offset="0.5" stop-color="#4377bb"/><stop offset="1" stop-color="#1f3b77"/></linearGradient>
+                <linearGradient id="lp-solid-c" x1="7.34" y1="44.34" x2="66.94" y2="3.82" gradientTransform="matrix(1,0,0,-1,0,73.4)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#315aa9"/><stop offset="0.5" stop-color="#518ac8"/><stop offset="1" stop-color="#315aa9"/></linearGradient>
+                <linearGradient id="lp-solid-d" x1="34.25" y1="39.49" x2="10.2" y2="-48.7" gradientTransform="matrix(1,0,0,-1,0,73.4)" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#4377bb"/><stop offset="0.5" stop-color="#1a336b"/><stop offset="1" stop-color="#1a336b"/></linearGradient>
+              </defs>
+              <path fill="#76b3e1" d="M75.81,15.35S50.86-3.49,31.5.91l-1.7.47A12.35,12.35,0,0,0,23.22,6a11.18,11.18,0,0,0-.71,1.18L15.36,19.33l12.35,2.41A22,22,0,0,0,45.32,25.2l22,4.3Z"/>
+              <path fill="url(#lp-solid-a)" opacity=".3" d="M75.81,15.35S50.86-3.49,31.5.91l-1.7.47A12.35,12.35,0,0,0,23.22,6a11.18,11.18,0,0,0-.71,1.18L15.36,19.33l12.35,2.41A22,22,0,0,0,45.32,25.2l22,4.3Z"/>
+              <path fill="#518ac8" d="M23,15.11l-1.71.48c-7.9,2.55-10.6,9.94-6.06,16.42a21.12,21.12,0,0,0,22.54,7.1L67.29,29.5S42.39,10.71,23,15.11Z"/>
+              <path fill="url(#lp-solid-b)" opacity=".3" d="M23,15.11l-1.71.48c-7.9,2.55-10.6,9.94-6.06,16.42a21.12,21.12,0,0,0,22.54,7.1L67.29,29.5S42.39,10.71,23,15.11Z"/>
+              <path fill="url(#lp-solid-c)" d="M61.89,36.42a21.11,21.11,0,0,0-22.58-7.15L9.82,38.83.54,55.35l52.83,9,9.47-16.85C64.73,44.27,64.54,40.2,61.89,36.42Z"/>
+              <path fill="url(#lp-solid-d)" d="M52.61,52.94a21.14,21.14,0,0,0-22.53-7.15L.54,55.35s25,18.84,44.31,14.44l1.7-.47C54.46,66.81,57.16,59.42,52.61,52.94Z"/>
+            </svg>
+          </span>
+          <span class="lp-tool" aria-label="JSX">
+            <svg width="30" height="27" viewBox="-11.5 -10.23 23 20.46" aria-hidden="true"><circle r="2.05" fill="#61dafb"/><g fill="none" stroke="#61dafb" stroke-width="1"><ellipse rx="11" ry="4.2"/><ellipse rx="11" ry="4.2" transform="rotate(60)"/><ellipse rx="11" ry="4.2" transform="rotate(120)"/></g></svg>
+          </span>
+          <span class="lp-tool" aria-label="Tailwind CSS">
+            <svg width="34" height="21" viewBox="0 0 54 33" aria-hidden="true"><path fill="#38bdf8" fill-rule="evenodd" clip-rule="evenodd" d="M27 0c-7.2 0-11.7 3.6-13.5 10.8 2.7-3.6 5.85-4.95 9.45-4.05 2.054.513 3.522 2.004 5.147 3.653C30.744 13.09 33.808 16.2 40.5 16.2c7.2 0 11.7-3.6 13.5-10.8-2.7 3.6-5.85 4.95-9.45 4.05-2.054-.513-3.522-2.004-5.147-3.653C36.756 3.11 33.692 0 27 0zM13.5 16.2C6.3 16.2 1.8 19.8 0 27c2.7-3.6 5.85-4.95 9.45-4.05 2.054.514 3.522 2.004 5.147 3.653C17.244 29.29 20.308 32.4 27 32.4c7.2 0 11.7-3.6 13.5-10.8-2.7 3.6-5.85 4.95-9.45 4.05-2.054-.513-3.522-2.004-5.147-3.653C23.256 19.31 20.192 16.2 13.5 16.2z"/></svg>
+          </span>
+          <span class="lp-tool" aria-label="TypeScript">
+            <svg width="27" height="27" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="5" fill="#3178c6"/><text x="16.5" y="22.5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">TS</text></svg>
+          </span>
+        </div>
+        <div class="lp-proof-grid">
+          <div class="lp-proof lp-reveal">
+            <h3>Flexbox is native</h3>
+            <p>Layout runs in the Rust core through taffy, so a familiar <span class="lp-mono">flex-col gap-4</span> interface lays out deterministically on PSP, browser and Bun.</p>
           </div>
-          <div class="lp-card lp-reveal">
-            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m12 2 9 5-9 5-9-5 9-5z"/><path d="m3 12 9 5 9-5"/><path d="m3 17 9 5 9-5"/></svg></span>
-            <h3>Zero runtime CSS</h3>
-            <p>A class string compiles to a style record only if every token is a supported utility. The Tailwind subset resolves at build time &mdash; nothing ships to parse.</p>
+          <div class="lp-proof lp-reveal">
+            <h3>Tailwind compiles away</h3>
+            <p>Class literals become compact style records at build time. There is no CSS parser, stylesheet cascade or utility runtime on the device.</p>
           </div>
-          <div class="lp-card lp-reveal">
-            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7V4h16v3M9 20h6M12 4v16"/></svg></span>
-            <h3>Baked fonts</h3>
-            <p>Inter is rasterized at build time into coverage atlases for exactly the glyphs you use. No font files, no shaper at runtime &mdash; just pixels.</p>
-          </div>
-          <div class="lp-card lp-reveal">
-            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12c2 0 2-4 4-4s2 8 4 8 2-8 4-8 2 4 4 4 2-2 2-2"/></svg></span>
-            <h3>Native animation</h3>
-            <p>Tweens and springs tick in Rust at a fixed 1/60&nbsp;s. Each frame is a pure function of its index &mdash; the reason byte-exact goldens are possible.</p>
-          </div>
-          <div class="lp-card lp-reveal">
-            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg></span>
-            <h3>Real flexbox</h3>
-            <p>taffy 0.11 &mdash; <code>no_std</code>, f32-only &mdash; does the layout; text measures natively. The same engine positions every pixel on every host.</p>
-          </div>
-          <div class="lp-card lp-reveal">
-            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 2v2M15 2v2M9 20v2M15 20v2M2 9h2M2 15h2M20 9h2M20 15h2"/></svg></span>
-            <h3>One tiny Rust core</h3>
-            <p>Layout, styling, animation, text and the draw list live in one portable <code>no_std</code> core &mdash; a few hundred kilobytes, compiled to the PSP and to WebAssembly alike.</p>
+          <div class="lp-proof lp-reveal">
+            <h3>Text is still sharp</h3>
+            <p>Inter glyphs are baked into coverage atlases and rendered with sub-pixel positioning, so tiny PSP screens still get readable UI text.</p>
           </div>
         </div>
       </div>
@@ -165,21 +136,17 @@
       <div class="lp-container">
         <div class="lp-split">
           <div class="lp-split__copy lp-reveal">
-            <span class="lp-kicker">Real Solid, native pixels</span>
-            <h2 class="lp-h2">Write a component. Ship it to the metal.</h2>
-            <p>You already know the surface: <span class="lp-mono">View</span>, <span class="lp-mono">Text</span>, signals and class strings. <span class="lp-mono">focusable</span> and <span class="lp-mono">onPress</span> map straight to the d-pad and face buttons.</p>
+            <span class="lp-kicker">Business logic stays intact</span>
+            <h2 class="lp-h2">Full Solid on a tiny machine.</h2>
+            <p>Write standard Solid components, run them on QuickJS, and let PocketJS handle the native pixels.</p>
             <ul class="lp-checklist">
               <li>
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m20 6-11 11-5-5"/></svg>
-                <span>Dynamic styles are ternaries of full class literals or <span class="lp-mono">animate()</span> calls &mdash; never runtime CSS.</span>
+                <span><span class="lp-mono">focusable</span> and <span class="lp-mono">onPress</span> map to PSP controls.</span>
               </li>
               <li>
                 <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m20 6-11 11-5-5"/></svg>
-                <span>The <span class="lp-mono">focus:</span> and <span class="lp-mono">active:</span> variants switch natively, with zero JS on focus change.</span>
-              </li>
-              <li>
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m20 6-11 11-5-5"/></svg>
-                <span>One codebase compiles to a <span class="lp-mono">.pak</span> for a real PSP and runs unchanged right here in your browser.</span>
+                <span><span class="lp-mono">focus:</span> variants and packed assets become native data in the <span class="lp-mono">.pak</span>.</span>
               </li>
             </ul>
             <a class="lp-btn lp-btn--primary" href="/playground/">
@@ -200,8 +167,8 @@
   <span class="lp-k">return</span> (
     <span class="lp-code-mut">&lt;</span><span class="lp-t">View</span> <span class="lp-a">class</span>=<span class="lp-s">"flex-col items-center gap-4 p-6 bg-slate-950"</span><span class="lp-code-mut">&gt;</span>
       <span class="lp-code-mut">&lt;</span><span class="lp-t">Text</span> <span class="lp-a">class</span>=<span class="lp-s">"text-2xl text-slate-50 font-bold"</span><span class="lp-code-mut">&gt;</span>Count: {<span class="lp-f">n</span>()}<span class="lp-code-mut">&lt;/</span><span class="lp-t">Text</span><span class="lp-code-mut">&gt;</span>
-      <span class="lp-code-mut">&lt;</span><span class="lp-t">View</span> <span class="lp-a">class</span>=<span class="lp-s">"px-4 py-2 rounded-xl bg-blue-600 focus:bg-blue-500"</span> <span class="lp-a">focusable</span> <span class="lp-a">onPress</span>={() =&gt; <span class="lp-f">setN</span>(<span class="lp-f">n</span>() + <span class="lp-n">1</span>)}<span class="lp-code-mut">&gt;</span>
-        <span class="lp-code-mut">&lt;</span><span class="lp-t">Text</span> <span class="lp-a">class</span>=<span class="lp-s">"text-base text-white font-bold"</span><span class="lp-code-mut">&gt;</span>Press Circle<span class="lp-code-mut">&lt;/</span><span class="lp-t">Text</span><span class="lp-code-mut">&gt;</span>
+      <span class="lp-code-mut">&lt;</span><span class="lp-t">View</span> <span class="lp-a">class</span>=<span class="lp-s">"px-4 py-2 rounded-xl bg-slate-700 focus:bg-slate-500"</span> <span class="lp-a">focusable</span> <span class="lp-a">onPress</span>={() =&gt; <span class="lp-f">setN</span>(<span class="lp-f">n</span>() + <span class="lp-n">1</span>)}<span class="lp-code-mut">&gt;</span>
+        <span class="lp-code-mut">&lt;</span><span class="lp-t">Text</span> <span class="lp-a">class</span>=<span class="lp-s">"text-base text-slate-50 font-bold"</span><span class="lp-code-mut">&gt;</span>Press Circle<span class="lp-code-mut">&lt;/</span><span class="lp-t">Text</span><span class="lp-code-mut">&gt;</span>
       <span class="lp-code-mut">&lt;/</span><span class="lp-t">View</span><span class="lp-code-mut">&gt;</span>
     <span class="lp-code-mut">&lt;/</span><span class="lp-t">View</span><span class="lp-code-mut">&gt;</span>
   );
@@ -211,13 +178,56 @@
       </div>
     </section>
 
+    <!-- FEATURES -->
+    <section class="lp-section lp-features">
+      <div class="lp-container">
+        <div class="lp-secthead lp-reveal">
+          <span class="lp-kicker">The hard parts move below JSX</span>
+          <h2 class="lp-h2">Layout, styling, text and animation in a tiny native core.</h2>
+          <p class="lp-lead">You keep JSX and signals; PocketJS turns the expensive browser work into native data and draw calls.</p>
+        </div>
+        <div class="lp-grid">
+          <div class="lp-card lp-reveal">
+            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M13 2 3 14h9l-1 8 10-12h-9l1-8z"/></svg></span>
+            <h3>Fine-grained reactivity</h3>
+            <p>Solid updates the closures touched by changed signals. Mutations go straight to the core tree &mdash; no VDOM diff pass in between.</p>
+          </div>
+          <div class="lp-card lp-reveal">
+            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="m12 2 9 5-9 5-9-5 9-5z"/><path d="m3 12 9 5 9-5"/><path d="m3 17 9 5 9-5"/></svg></span>
+            <h3>Compiled styling</h3>
+            <p>Every supported class literal resolves to a numeric style record. Unsupported runtime class composition fails at build time instead of drifting on hardware.</p>
+          </div>
+          <div class="lp-card lp-reveal">
+            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M4 7V4h16v3M9 20h6M12 4v16"/></svg></span>
+            <h3>Baked font atlases</h3>
+            <p>The build scans your source, bakes the glyphs you use and ships coverage atlases. Runtime text drawing is compositing, not font rasterization.</p>
+          </div>
+          <div class="lp-card lp-reveal">
+            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M2 12c2 0 2-4 4-4s2 8 4 8 2-8 4-8 2 4 4 4 2-2 2-2"/></svg></span>
+            <h3>Native animation</h3>
+            <p>Tweens and springs tick in Rust at a fixed 1/60&nbsp;s. JS declares the motion; the core advances each frame.</p>
+          </div>
+          <div class="lp-card lp-reveal">
+            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg></span>
+            <h3>Deterministic flexbox</h3>
+            <p>taffy 0.11 does layout inside the Rust core. The same source positions pixels on PSP hardware, browser canvas and golden tests.</p>
+          </div>
+          <div class="lp-card lp-reveal">
+            <span class="lp-card__ic"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="6" width="12" height="12" rx="2"/><path d="M9 2v2M15 2v2M9 20v2M15 20v2M2 9h2M2 15h2M20 9h2M20 15h2"/></svg></span>
+            <h3>One portable core</h3>
+            <p>Layout, style resolution, animation, text and draw lists live in a <code>no_std</code> Rust core compiled for PSP and WebAssembly.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
     <!-- CLOSING CTA -->
     <section class="lp-section lp-cta">
       <div class="lp-cta__glow" aria-hidden="true"></div>
       <div class="lp-container lp-cta__in lp-reveal">
-        <span class="lp-kicker">Ship it</span>
-        <h2 class="lp-h2" style="margin-top: 0.9rem;">Every screen deserves the modern web.</h2>
-        <p>It starts on a 2005 handheld with 32&nbsp;MB of RAM and a fluid 60&nbsp;FPS. It won't stop there.</p>
+        <span class="lp-kicker">Start from the hardware up</span>
+        <h2 class="lp-h2" style="margin-top: 0.9rem;">Build modern UI where the browser cannot go.</h2>
+        <p>Bring modern frontend ergonomics to hardware that was never built for the web.</p>
         <div class="lp-cta__btns">
           <a class="lp-btn lp-btn--primary" href="/docs/getting-started/">Get started</a>
           <a class="lp-btn lp-btn--ghost" href="/docs/overview/">Read the docs</a>
@@ -233,15 +243,19 @@
         <div class="lp-footer__brand">
           <a class="lp-brand" href="/" aria-label="PocketJS home">
             <svg viewBox="0 0 32 32" aria-hidden="true">
-              <rect x="1.5" y="5.5" width="29" height="21" rx="5" fill="none" stroke="url(#lp-pgf)" stroke-width="2"/>
-              <circle cx="9" cy="16" r="3.2" fill="url(#lp-pgf)"/>
-              <rect x="18.5" y="12.6" width="7.5" height="1.9" rx=".95" fill="url(#lp-pgf)"/>
-              <rect x="18.5" y="17.6" width="7.5" height="1.9" rx=".95" fill="url(#lp-pgf)"/>
-              <defs><linearGradient id="lp-pgf" x1="0" y1="0" x2="32" y2="32"><stop offset="0" stop-color="#60a5fa"/><stop offset="1" stop-color="#22d3ee"/></linearGradient></defs>
+              <defs>
+                <linearGradient id="lp-pgf-edge" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#eef6ff"/><stop offset="0.38" stop-color="#b7c8e2"/><stop offset="0.58" stop-color="#7487a0"/><stop offset="0.78" stop-color="#aec0d6"/><stop offset="1" stop-color="#dbe8f6"/></linearGradient>
+                <linearGradient id="lp-pgf-lens" x1="7" y1="13" x2="13" y2="19" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#e4edf8"/><stop offset="0.55" stop-color="#a7b8cf"/><stop offset="1" stop-color="#53677f"/></linearGradient>
+                <linearGradient id="lp-pgf-bar" x1="16" y1="12" x2="24" y2="20" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#d7e3f1"/><stop offset="1" stop-color="#71849d"/></linearGradient>
+              </defs>
+              <rect x="2" y="6" width="28" height="20" rx="6" fill="none" stroke="url(#lp-pgf-edge)" stroke-width="2.6" stroke-linejoin="round"/>
+              <circle cx="10" cy="16" r="3.1" fill="url(#lp-pgf-lens)"/>
+              <rect x="16" y="12.6" width="10" height="2.2" rx="1.1" fill="url(#lp-pgf-bar)"/>
+              <rect x="16" y="17.2" width="6.5" height="2.2" rx="1.1" fill="url(#lp-pgf-bar)"/>
             </svg>
             <span>PocketJS</span>
           </a>
-          <p>Bare Metal Modern Web &mdash; the full Solid frontend, rendered natively at 60&nbsp;FPS in 32&nbsp;MB of RAM.</p>
+          <p>Solid and Tailwind UI for a 32&nbsp;MB Sony PSP, rendered through a tiny native core.</p>
         </div>
         <div>
           <h4>Docs</h4>
@@ -271,7 +285,7 @@
         </div>
       </div>
       <div class="lp-footer__bar">
-        <span>Bare Metal Modern Web</span>
+        <span>Solid UI, native pixels</span>
         <span>&copy; 2026 PocketJS &middot; MIT</span>
       </div>
     </div>

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -15,13 +15,15 @@ export interface PageOpts {
 }
 
 export const LOGO = `<svg viewBox="0 0 32 32" width="26" height="26" aria-hidden="true">
-  <rect x="1.5" y="5.5" width="29" height="21" rx="5" fill="none" stroke="url(#pg)" stroke-width="2"/>
-  <circle cx="9" cy="16" r="3.2" fill="url(#pg)"/>
-  <rect x="18.5" y="12.6" width="7.5" height="1.9" rx=".95" fill="url(#pg)"/>
-  <rect x="18.5" y="17.6" width="7.5" height="1.9" rx=".95" fill="url(#pg)"/>
-  <defs><linearGradient id="pg" x1="0" y1="0" x2="32" y2="32">
-    <stop offset="0" stop-color="#60a5fa"/><stop offset="1" stop-color="#22d3ee"/>
-  </linearGradient></defs>
+  <defs>
+    <linearGradient id="pj-shell-edge" x1="4" y1="4" x2="28" y2="28" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#eef6ff"/><stop offset="0.38" stop-color="#b7c8e2"/><stop offset="0.58" stop-color="#7487a0"/><stop offset="0.78" stop-color="#aec0d6"/><stop offset="1" stop-color="#dbe8f6"/></linearGradient>
+    <linearGradient id="pj-shell-lens" x1="7" y1="13" x2="13" y2="19" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#e4edf8"/><stop offset="0.55" stop-color="#a7b8cf"/><stop offset="1" stop-color="#53677f"/></linearGradient>
+    <linearGradient id="pj-shell-bar" x1="16" y1="12" x2="24" y2="20" gradientUnits="userSpaceOnUse"><stop offset="0" stop-color="#d7e3f1"/><stop offset="1" stop-color="#71849d"/></linearGradient>
+  </defs>
+  <rect x="2" y="6" width="28" height="20" rx="6" fill="none" stroke="url(#pj-shell-edge)" stroke-width="2.6" stroke-linejoin="round"/>
+  <circle cx="10" cy="16" r="3.1" fill="url(#pj-shell-lens)"/>
+  <rect x="16" y="12.6" width="10" height="2.2" rx="1.1" fill="url(#pj-shell-bar)"/>
+  <rect x="16" y="17.2" width="6.5" height="2.2" rx="1.1" fill="url(#pj-shell-bar)"/>
 </svg>`;
 
 function header(active: string): string {
@@ -48,7 +50,7 @@ const footer = `<footer class="mt-24 border-t border-line/70 bg-ink-2/60">
     <div class="grid gap-10 sm:grid-cols-2 lg:grid-cols-4">
       <div>
         <div class="flex items-center gap-2 font-semibold text-slate-100">${LOGO}<span>PocketJS</span></div>
-        <p class="mt-3 max-w-xs text-sm text-slate-400">Bare Metal Modern Web — the full Solid frontend, rendered natively at 60 FPS in 32 MB of RAM.</p>
+        <p class="mt-3 max-w-xs text-sm text-slate-400">Solid and Tailwind UI for a 32 MB Sony PSP, rendered through a tiny native core.</p>
       </div>
       <div class="text-sm">
         <h4 class="mb-3 font-semibold text-slate-200">Docs</h4>
@@ -78,7 +80,7 @@ const footer = `<footer class="mt-24 border-t border-line/70 bg-ink-2/60">
       </div>
     </div>
     <div class="mt-10 flex flex-col gap-2 border-t border-line/60 pt-6 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-between">
-      <span>Bare Metal Modern Web</span>
+      <span>Solid UI, native pixels</span>
       <span>© ${YEAR} PocketJS · MIT</span>
     </div>
   </div>
@@ -87,7 +89,7 @@ const footer = `<footer class="mt-24 border-t border-line/70 bg-ink-2/60">
 export function renderPage(o: PageOpts): string {
   const fullTitle = o.title ? `${o.title} · PocketJS` : "PocketJS — Bare Metal Modern Web";
   const desc =
-    "PocketJS runs the full Solid frontend — JSX, Tailwind, signals, TypeScript, flexbox and native animation — natively on the metal, at 60 FPS in 32 MB of RAM. Bare Metal Modern Web, starting on the Sony PSP.";
+    "PocketJS builds Solid and Tailwind interfaces for a 32 MB Sony PSP, with native flexbox, sub-pixel text, animation and deterministic rendering.";
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -98,7 +100,7 @@ export function renderPage(o: PageOpts): string {
 <meta property="og:title" content="${fullTitle}">
 <meta property="og:description" content="${desc}">
 <meta property="og:type" content="website">
-<meta name="theme-color" content="#090c14">
+<meta name="theme-color" content="#05070d">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
 <link rel="stylesheet" href="/assets/site.css">
 ${o.head ?? ""}


### PR DESCRIPTION
## Summary

- Refresh the landing page around the darker bare-metal visual direction, lighter metal accents, revised copy, and larger tool icons without visible text labels.
- Sync the docs design tokens, shared PocketJS logo, favicon, and overview copy with the landing-page direction.
- Make the homepage showcase bundle build path resilient so missing `.pak` demo assets are generated or resolved from legacy `.dcpak` output instead of shipping 404s.

## Validation

- `bun site/build.ts`
- `bun run test`
- `bunx tsc --noEmit`
- `xmllint --noout site/assets/favicon.svg`
- `git diff --check`
- Local homepage/docs probes with `bun site/verify.ts`
- `curl -I http://127.0.0.1:8141/pg/demo-bundles/settings-main.pak` returned `200 OK`
