### PR TITLE
feat: native <Video> component (Media-Engine decode over PSPLink)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -153,8 +153,9 @@ PocketJS/
     engine.js          loads wasm, HostOps, rAF loop (fixed-step), keyboard map
     serve.ts           static Bun.serve dev server (no livereload; rebuild + reload manually)
   demos/
-    hero/, cards/, stats/, library/, settings/, notifications/, music/
-                       each demo has app.tsx + main.tsx (mount entry)
+    hero/, cards/, stats/, library/, settings/, notifications/, music/, video/
+                       each demo has app.tsx + main.tsx (mount entry);
+                       video/ = the native <Video> end-to-end demo (see "Video")
   test/
     contract.ts        spec drift guard (regen + byte-compare) + engine constants
     golden.ts          headless Bun: wasm rasterizer, scripted input, byte-exact PNGs
@@ -199,7 +200,7 @@ children[], …}`) so reconciler *reads* never cross the FFI. Handles are `i32`
 
 | op | signature | notes |
 |---|---|---|
-| createNode | `(type:i32) → id` | 0=view 1=text 2=image |
+| createNode | `(type:i32) → id` | 0=view 1=text 2=image 3=video |
 | destroyNode | `(id)` | subtree; frees anim tracks; clears focus if inside **[R]** |
 | insertBefore | `(parent, child, anchorOr0)` | **DOM move semantics: if child is attached anywhere, unlink first** (core tree + taffy + JS mirror) **[R]**; append when anchor=0; silently no-ops past `MAX_TREE_DEPTH` (spec, 64) so recursive tree walks stay stack-bounded on PSP |
 | removeChild | `(parent, child)` | keeps node alive (Solid re-inserts); renderer sweep destroys it at frame end if still detached |
@@ -214,6 +215,10 @@ children[], …}`) so reconciler *reads* never cross the FFI. Handles are `i32`
 | setFocus | `(idOr0)` | applies `focus:` variant natively |
 | loadStyles / loadFontAtlas | `(buf …)` | **web/test hosts only** — on PSP, native/src/pak.rs feeds core directly from include_bytes! **[R]** |
 | measureText | `(str, fontSlot) → width` | JS convenience; layout measures natively |
+| videoOpen | `(path, w, h, loopFlag) → handle` | **optional op** (see "Video"); open a host-fs decoder; handle < 0 = failure |
+| videoControl | `(handle, cmd, arg)` | cmd = spec `VIDEO_CMD` (play/pause/stop/seek/close) |
+| videoBind | `(nodeId, handle)` | attach a decoder to a video node (handle < 0 clears → `Ui::set_video`) |
+| videoState | `(handle) → status` | packed `VIDEO_STATE \| (ptsMs << 8)` for `onEnded` |
 
 **Text model [R].** A `<text>` element lays out its text-node children as one
 concatenated inline run (single measure, not N flex items). Text nodes inherit
@@ -224,8 +229,8 @@ until `replaceText` makes them non-empty.
 
 Application code should not write those lower-case host tags directly. The
 public SDK surface is imported from `PocketJS` and uses React Native-style
-`View`, `Text`, and `Image` primitives; the lower-case tags remain an internal
-renderer target for `src/primitives.ts` and low-level tests.
+`View`, `Text`, `Image` and `Video` primitives; the lower-case tags remain an
+internal renderer target for `src/primitives.ts` and low-level tests.
 
 **Frame order (PSP).** `sceCtrlRead → sceGuStart → JS frame(buttons) → drain
 jobs (while JS_ExecutePendingJob(rt,&mut ctx)>0 — declare the symbol in a local
@@ -312,6 +317,83 @@ One FFI crossing per steady-state frame; DrawList ≤ ~40 sceGuDrawArray calls,
 animations relayout that frame (prefer transforms); Solid effects only on
 interaction. Boot: unminified but tree-shaken bundle; all binary assets in the
 pak (base64-in-JS is the known QuickJS boot killer).
+
+## Video (native Media-Engine decode)
+
+`<Video>` composites a streamed video as a native node in the flexbox tree —
+not a fullscreen takeover. Pixels come from the host's hardware decoder each
+frame; decode runs **off** the render thread so the 60 Hz UI never stalls on
+host I/O or decode. (Research + path comparison: the video-decode dossier.)
+
+**Path (PSP): `scePsmfPlayer` on the Media Engine.** The ME (the PSP's second
+core + fixed-function AVC/CSC hardware) does demux + H.264 + colorspace-convert;
+`scePsmfPlayer` wraps all of it — it opens a `.pmf` by filename (incl.
+`host0:/…` over PSPLink), runs its own read/demux/decode threads, and
+`GetVideoData` writes a linear ABGR8888 frame into a caller-supplied buffer at a
+caller-chosen stride. We add ONE dedicated poll thread (`native/src/video.rs`);
+the vblank worker only does an atomic load + pointer read. Runner-up if
+`scePsmfPlayer` streaming proves rough or the source is live: low-level
+`sceMpeg` with our own `sceIoRead` ring (same `.pmf` input — no re-encode).
+`sceVideocodec` was rejected (its AVCC framing + CSC pairing is unbound/wrong in
+this rust-psp fork); MJPEG (`sceJpeg`) rejected (intra-only bitrate > PSPLink).
+
+**Node model (codec-agnostic core).** `NODE_TYPE.video = 3`; `tree.rs` `Node.vid`
+is an **opaque host decoder handle** (never a core texture id). `draw.rs` emits
+`DRAW_OP.videoQuad` at the node's laid-out rect (same 9-word shape as TEX_QUAD,
+axis-aligned only — rotated video is culled). The core never learns pixel dims;
+the backend resolves the handle to a live frame buffer.
+
+**GE bind (`ge.rs`, zero-copy).** The `VIDEO_QUAD` arm binds the decoder's
+current **front** buffer via `sceGuTexImage` as a declared 512×512 (pow2),
+`tbw = 512`, sampling only the 480×272 active sub-rect (UV texels =
+normalized × active dims). **Nearest + Clamp** (no bilinear/edge bleed; clamp
+stops a bottom/right tap wrapping modulo 512 into unrelated RAM). **Modulate +
+`Rgb`** so the frame's (possibly 0x00) alpha is ignored and alpha comes from the
+vertex → opaque, while node opacity still works.
+
+**Threading + buffers.** `video.rs` triple-buffers frames (512×288×4 each, guard
+rows past 272) in the arena. The poll thread decodes into a BACK buffer,
+`sceKernelDcacheWritebackInvalidateRange`s it (ME wrote via DMA behind the CPU
+cache), then release-stores a `ready` index; the worker acquire-loads it as
+FRONT — so the GE never samples a buffer mid-decode. `videoControl(Close)` (from
+the JS component's `onCleanup`) joins the thread + frees buffers *before* the
+node is destroyed. Boot loads the AV modules (`sceUtilityLoadAvModule` AvCodec →
+MpegBase → Atrac3Plus) + `sceMpegInit` (mandatory on hardware; PPSSPP HLEs them
+for free). The arena margin is raised 2 MB → 6 MB for the player create-buffer +
+ME EDRAM.
+
+**JS + web.** `Video` (`src/components.ts`) is a managed component: opens/binds
+on mount, drives play/pause reactively, closes on cleanup, polls `videoState`
+for `onEnded`. The video ops are **optional** on `HostOps` — the wasm/web host
+omits ME decode and instead drives a hidden HTML5 `<video>`, blitting frames
+into a raster surface (`raster.rs` `VIDEO_QUAD` arm); a headless golden host has
+no `document`, so `raster.rs` draws its deterministic checker placeholder (video
+goldens stay byte-stable). One draw path, three hosts.
+
+**Wire format.** 480×272 (both /16 = the ME AVC max, no padding), H.264 Main +
+CABAC, Level 3.0, 30 fps, no B-frames (one AU = one frame, PTS=DTS), closed 1 s
+GOP (clean loop/seek joins), ~1–1.5 Mbps CBR (well within PSPLink). Produce with
+`bun scripts/video-encode.ts <input>` (ffmpeg → `.h264` + a web-preview `.mp4`),
+then mux the `.h264` to a PSMF `.pmf` (ffmpeg has **no** game-`.pmf` muxer — use
+a PSMF muxer or the byte layout below) and drop it in the `usbhostfs_pc` host
+dir so it resolves as `host0:/clip.pmf`.
+
+```
+.pmf: [0x000] PSMF header 0x800B: magic "PSMF", version, mpegOffset=0x800,
+              streamSize, stream table @0x82 (video 0xE0, codec 0x0E AVC),
+              EP-map (nEntries, {ptsHi, offset, id}…)
+      [0x800] MPEG-PS: repeating 2048-byte packs — pack_start(0x000001BA),
+              PES(0xE0){ PTS/DTS, AVC AU: SPS/PPS on IDR, then slice NALs }
+              (audio v2: private_stream_1 ATRAC3+ AUs interleaved)
+```
+
+**Hardware-gate (validate first — cannot be checked in the emulator/CI):**
+PMF acceptance of the exact x264 settings; `scePsmfPlayer` real-time smoothness
+over `host0:`/PSPLink; per-frame ME decode budget; whether the player + ME EDRAM
+draw from the primary user partition (arena margin); GE texture-cache freshness
+without `sceGuTexFlush` (address ping-pong + dcache invalidate). Demo v1 is
+**silent** (video-only PMF); audio (ATRAC3+ via `GetAudioData` →
+`sceAudioOutput2OutputBlocking`, audio-clock master) is v2.
 
 ## What v1 explicitly punts
 

--- a/core/src/draw.rs
+++ b/core/src/draw.rs
@@ -428,7 +428,15 @@ impl<'a> Walker<'a> {
 
         // -- image --------------------------------------------------------------
         if node.node_type == spec::NodeType::Image as u8 && node.tex >= 0 {
-            self.emit_tex_quad(dl, &world, l.w, l.h, node.tex as u32, op, &clip);
+            self.emit_sampled_quad(dl, &world, l.w, l.h, node.tex as u32, spec::draw_op::TEX_QUAD, op, &clip);
+        }
+
+        // -- video --------------------------------------------------------------
+        // Same axis-aligned quad as an image, but the handle is an opaque host
+        // decoder handle (node.vid) emitted as VIDEO_QUAD; the backend samples
+        // the decoder's current frame buffer. See DESIGN.md "Video".
+        if node.node_type == spec::NodeType::Video as u8 && node.vid >= 0 {
+            self.emit_sampled_quad(dl, &world, l.w, l.h, node.vid as u32, spec::draw_op::VIDEO_QUAD, op, &clip);
         }
 
         // -- children (overflow-hidden scissor around them; z-index stable
@@ -1046,9 +1054,12 @@ impl<'a> Walker<'a> {
         }
     }
 
-    /// Emit an image TEX_QUAD (axis-aligned only; rotated images are
-    /// conservatively culled — no textured-triangle op in the DrawList v1).
-    fn emit_tex_quad(&self, dl: &mut DrawList, world: &Affine, w: f32, h: f32, tex: u32, op: f32, clip: &Clip) {
+    /// Emit a sampled quad (axis-aligned only; rotated quads are conservatively
+    /// culled — no textured-triangle op in the DrawList v1). `draw_op` selects
+    /// TEX_QUAD (core texture handle) vs VIDEO_QUAD (opaque host decoder handle);
+    /// the geometry, clip and UV re-interpolation are identical.
+    #[allow(clippy::too_many_arguments)]
+    fn emit_sampled_quad(&self, dl: &mut DrawList, world: &Affine, w: f32, h: f32, handle: u32, draw_op: u32, op: f32, clip: &Clip) {
         if !world.is_axis_aligned() {
             return;
         }
@@ -1071,8 +1082,8 @@ impl<'a> Walker<'a> {
         let u1 = (c.x1 - sx0) / (sx1 - sx0);
         let v0 = (c.y0 - sy0) / (sy1 - sy0);
         let v1 = (c.y1 - sy0) / (sy1 - sy0);
-        dl.words.push(spec::draw_op::TEX_QUAD);
-        dl.words.push(tex);
+        dl.words.push(draw_op);
+        dl.words.push(handle);
         dl.words.push(xy_word(c.x0, c.y0));
         dl.words.push(wh_word(c.x1 - c.x0, c.y1 - c.y0));
         dl.words.push(u0.to_bits());

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -102,7 +102,7 @@ impl Ui {
     /// Create a detached node of `node_type` (spec::NodeType value).
     /// Returns its generation-tagged id, or 0 on failure.
     pub fn create_node(&mut self, node_type: u8) -> i32 {
-        if node_type > spec::NodeType::Image as u8 {
+        if node_type > spec::NodeType::Video as u8 {
             return 0;
         }
         self.tree.alloc(node_type)
@@ -251,6 +251,19 @@ impl Ui {
         let node = &mut self.tree.slots[slot as usize];
         if node.node_type == spec::NodeType::Image as u8 {
             node.tex = if tex < 0 { -1 } else { tex };
+        }
+    }
+
+    /// Bind an opaque host decoder handle to a video node (mirrors set_image).
+    /// The core never dereferences `handle` — it is emitted in VIDEO_QUAD for
+    /// the backend to resolve to a live frame buffer. handle < 0 clears.
+    /// Unknown positive handles are accepted verbatim (validity is the host's
+    /// concern, same as any FFI handle).
+    pub fn set_video(&mut self, id: i32, handle: i32) {
+        let Some(slot) = self.tree.resolve(id) else { return };
+        let node = &mut self.tree.slots[slot as usize];
+        if node.node_type == spec::NodeType::Video as u8 {
+            node.vid = if handle < 0 { -1 } else { handle };
         }
     }
 

--- a/core/src/spec.rs
+++ b/core/src/spec.rs
@@ -44,6 +44,7 @@ pub enum NodeType {
     View = 0,
     Text = 1,
     Image = 2,
+    Video = 3,
 }
 
 /// UI op codes (the wasm/FFI ABI identity of each `ui.*` op; 0 reserved).
@@ -65,6 +66,27 @@ pub mod op {
     pub const LOAD_STYLES: u8 = 14;
     pub const LOAD_FONT_ATLAS: u8 = 15;
     pub const MEASURE_TEXT: u8 = 16;
+    pub const VIDEO_OPEN: u8 = 17;
+    pub const VIDEO_CONTROL: u8 = 18;
+    pub const VIDEO_BIND: u8 = 19;
+    pub const VIDEO_STATE: u8 = 20;
+}
+
+/// `videoControl` command codes (host decoder contract; core is agnostic).
+pub mod video_cmd {
+    pub const PLAY: u32 = 0;
+    pub const PAUSE: u32 = 1;
+    pub const STOP: u32 = 2;
+    pub const SEEK: u32 = 3;
+    pub const CLOSE: u32 = 4;
+}
+/// `videoState` low-byte playback state (high bits carry ptsMs).
+pub mod video_state {
+    pub const IDLE: u32 = 0;
+    pub const PLAYING: u32 = 1;
+    pub const PAUSED: u32 = 2;
+    pub const ENDED: u32 = 3;
+    pub const ERROR: u32 = 4;
 }
 
 /// Property ids (u8, stable, append-only). Groups:
@@ -298,7 +320,7 @@ pub mod font_atlas {
 
 /// DrawList op codes (core -> backend Vec<u32> words; layout in spec.ts).
 /// Word counts incl. header: RECT 4, GRAD_RECT 6, GLYPH_RUN 3+2n,
-/// TEX_QUAD 9, SCISSOR 3, SCISSOR_POP 1, TRI 7.
+/// TEX_QUAD 9, SCISSOR 3, SCISSOR_POP 1, TRI 7, VIDEO_QUAD 9.
 pub mod draw_op {
     pub const RECT: u32 = 1;
     pub const GRAD_RECT: u32 = 2;
@@ -307,6 +329,7 @@ pub mod draw_op {
     pub const SCISSOR: u32 = 5;
     pub const SCISSOR_POP: u32 = 6;
     pub const TRI: u32 = 7;
+    pub const VIDEO_QUAD: u32 = 8;
 }
 
 /// .pak container constants (byte-compatible with dreamcart's format;

--- a/core/src/tree.rs
+++ b/core/src/tree.rs
@@ -66,6 +66,10 @@ pub struct Node {
     pub text: String,
     /// Uploaded texture handle (image nodes only; -1 = none).
     pub tex: i32,
+    /// Opaque host decoder handle (video nodes only; -1 = none). The core
+    /// never dereferences it — it is emitted verbatim in VIDEO_QUAD for the
+    /// backend to resolve to a live frame buffer. See DESIGN.md "Video".
+    pub vid: i32,
     pub focused: bool,
     pub active: bool,
     /// taffy handle of the last layout build (None = excluded from layout).
@@ -88,6 +92,7 @@ impl Node {
             anim_values: Vec::new(),
             text: String::new(),
             tex: -1,
+            vid: -1,
             focused: false,
             active: false,
             taffy: None,

--- a/demos/video/app.tsx
+++ b/demos/video/app.tsx
@@ -1,0 +1,29 @@
+// Minimal end-to-end demo of the native <Video> component: a 480×272 H.264
+// stream decoded on the PSP Media Engine (scePsmfPlayer), streamed from the dev
+// host over PSPLink as host0:/clip.pmf, composited as a NON-fullscreen flex
+// child while the rest of the UI redraws at 60 fps.
+//
+// Build + run: see DESIGN.md "Video" (encode clip.pmf, start usbhostfs_pc,
+//   bun scripts/psp.ts video, load the EBOOT over PSPLink).
+
+import { Text, View, Video } from "@pocketjs/framework/components";
+
+export default function VideoDemo() {
+  return (
+    <View class="w-full h-full flex-col items-center justify-center gap-3 bg-slate-950">
+      <Text class="text-base text-slate-100 font-bold tracking-wide">
+        PocketJS · Native Video
+      </Text>
+
+      <View class="rounded-xl overflow-hidden shadow-md border-slate-800">
+        {/* 384×218 keeps the 480×272 (≈16:9) aspect; the Media Engine decodes
+            full-res and the GE scales it into this laid-out rect. */}
+        <Video src="host0:/clip.pmf" loop autoplay style={{ width: 384, height: 218 }} />
+      </View>
+
+      <Text class="text-xs text-slate-500 tracking-wide">
+        480×272 H.264 · Media Engine · host0:/clip.pmf
+      </Text>
+    </View>
+  );
+}

--- a/demos/video/main.tsx
+++ b/demos/video/main.tsx
@@ -1,0 +1,5 @@
+// @title PocketJS: Video
+import VideoDemo from "./app.tsx";
+import { mount } from "@pocketjs/framework";
+
+mount(() => <VideoDemo />);

--- a/host-web/engine.js
+++ b/host-web/engine.js
@@ -72,6 +72,7 @@ function safeFrame() {
 
 function blit() {
   if (!wasm || !ctx) return;
+  wasm.pumpVideos?.(); // feed HTML5 <video> frames to the raster surfaces first
   imageData.data.set(wasm.render());
   ctx.putImageData(imageData, 0, 0);
 }

--- a/host-web/wasm-ops.d.ts
+++ b/host-web/wasm-ops.d.ts
@@ -15,6 +15,8 @@ export interface WasmUi {
   tick(): void;
   /** Rasterize and return the RGBA8 480x272 framebuffer as a fresh view. */
   render(): Uint8Array;
+  /** Blit active HTML5 <video> frames into the wasm surfaces; call before render(). */
+  pumpVideos(): void;
 }
 
 export declare function createWasmUi(

--- a/host-web/wasm-ops.js
+++ b/host-web/wasm-ops.js
@@ -41,6 +41,94 @@ export async function createWasmUi(wasm) {
   }
   const withStr = (s, fn) => withBytes(encoder.encode(String(s)), fn);
 
+  // --- native <Video> (web fallback) ---------------------------------------
+  // Drive HTML5 <video> elements and feed their frames to the wasm rasterizer
+  // as RGBA8888 surfaces. In a HEADLESS host (Bun goldens: no `document`),
+  // videoOpen tracks the handle but uploads NO surface, so raster.rs draws its
+  // deterministic checker placeholder — keeping goldens byte-stable.
+  const hasDOM = typeof document !== "undefined";
+  const videos = new Map();
+  let nextVideoHandle = 0;
+
+  // "host0:/clip.pmf" -> "/clip.mp4": browsers can't play PMF, so the dev
+  // server serves a web-friendly encode next to the demo. Missing file => the
+  // <video> never yields frames => raster draws the checker placeholder.
+  const webUrlForPath = (path) =>
+    "/" + (String(path).split(/[\\/]/).pop() || "clip").replace(/\.pmf$/i, ".mp4");
+
+  function videoOpen(path, w, h, loopFlag) {
+    const handle = nextVideoHandle++;
+    if (handle >= 4) return -1; // raster.rs MAX_VIDEO_SURFACES
+    const entry = { w, h, ptr: 0, el: null, ctx: null, ended: false };
+    if (hasDOM) {
+      const el = document.createElement("video");
+      el.src = webUrlForPath(path);
+      el.loop = !!loopFlag;
+      el.muted = true; // v1 is silent; also unblocks autoplay
+      el.playsInline = true;
+      el.autoplay = true;
+      el.addEventListener("ended", () => {
+        entry.ended = true;
+      });
+      el.play?.().catch(() => {});
+      const canvas = document.createElement("canvas");
+      canvas.width = w;
+      canvas.height = h;
+      entry.el = el;
+      entry.ctx = canvas.getContext("2d", { willReadFrequently: true });
+      entry.ptr = ex.ui_alloc(w * h * 4);
+    }
+    videos.set(handle, entry);
+    return handle;
+  }
+
+  function videoControl(handle, cmd, _arg) {
+    const v = videos.get(handle);
+    if (!v) return;
+    if (cmd === 0) v.el?.play?.().catch(() => {}); // play
+    else if (cmd === 1) v.el?.pause?.(); // pause
+    else if (cmd === 2) {
+      if (v.el) {
+        v.el.pause();
+        v.el.currentTime = 0;
+      }
+    } else if (cmd === 4) {
+      // close
+      v.el?.pause?.();
+      if (v.ptr) {
+        ex.ui_video_surface(handle, 0, 0, 0);
+        ex.ui_free(v.ptr, v.w * v.h * 4);
+      }
+      videos.delete(handle);
+    }
+  }
+
+  function videoState(handle) {
+    const v = videos.get(handle);
+    if (!v) return 4; // VIDEO_STATE.error
+    if (v.ended) return 3; // ended
+    if (v.el && v.el.paused) return 2; // paused
+    return 1; // playing
+  }
+
+  // Blit each active <video>'s current frame into its wasm RGBA surface. Called
+  // once per frame by engine.js BEFORE render(). No-op in a headless host.
+  function pumpVideos() {
+    if (!hasDOM) return;
+    for (const [handle, v] of videos) {
+      if (!v.el || !v.ptr || v.el.readyState < 2) continue;
+      try {
+        v.ctx.drawImage(v.el, 0, 0, v.w, v.h);
+        const img = v.ctx.getImageData(0, 0, v.w, v.h);
+        // Rebuilt each call: memory.buffer detaches whenever linear memory grows.
+        new Uint8Array(ex.memory.buffer, v.ptr, v.w * v.h * 4).set(img.data);
+        ex.ui_video_surface(handle, v.ptr, v.w, v.h);
+      } catch {
+        /* frame not decodable yet */
+      }
+    }
+  }
+
   /** @type {import("../src/host.ts").HostOps} */
   const ops = {
     createNode: (type) => ex.ui_create_node(type),
@@ -64,11 +152,17 @@ export async function createWasmUi(wasm) {
       withBytes(buf, (p, l) => ex.ui_load_font_atlas(p, l));
     },
     measureText: (str, fontSlot) => withStr(str, (p, l) => ex.ui_measure_text(p, l, fontSlot)),
+    videoOpen,
+    videoControl,
+    videoBind: (nodeId, handle) => ex.ui_set_video(nodeId, handle),
+    videoState,
   };
 
   return {
     ops,
     exports: ex,
+    /** Blit active <video> frames into wasm surfaces; call before render(). */
+    pumpVideos,
     /** Reset the core to a fresh Ui (fresh tree/styles/atlases/textures). */
     init: () => ex.ui_init(),
     /** Advance exactly one fixed-dt (1/60 s) frame. */

--- a/native/src/arena.rs
+++ b/native/src/arena.rs
@@ -2,9 +2,11 @@
 // change [R]: ensure_init calls sceKernelAllocPartitionMemory /
 // sceKernelGetBlockHeadAddr DIRECTLY. In this crate the arena IS the
 // #[global_allocator] (src/alloc.rs), so the original's alloc::alloc::alloc
-// route would recurse infinitely. Margin shrunk 4 MB -> 2 MB: retained core
-// buffers/textures now live inside the arena, so the margin only covers
-// late kernel allocations (utility thread stacks) + safety.
+// route would recurse infinitely. Margin is 6 MB (raised from 2 MB for the
+// native <Video> component): most retained buffers/textures live inside the
+// arena, but the scePsmfPlayer create-buffer + ME EDRAM may draw from the same
+// primary user partition, so the margin covers those + late kernel allocations
+// (utility thread stacks) + safety. See DESIGN.md "Video".
 
 
 //! A single-arena sub-allocator for QuickJS + newlib `malloc` + Rust `alloc`.
@@ -58,7 +60,12 @@ unsafe fn ensure_init() {
     }
     INITED = true;
     let free = sys::sceKernelMaxFreeMemSize() as usize;
-    let margin = 2 * 1024 * 1024;
+    // 2 MB covered late kernel allocations (utility thread stacks) + safety.
+    // Raised to 6 MB for the native <Video> component (video.rs): the
+    // scePsmfPlayer create-buffer (~3 MB) + ME EDRAM (~2 MB) may draw from this
+    // same primary user partition (UNCERTAIN — validate on hardware; DESIGN.md
+    // "Video"). Video frame buffers themselves come FROM the arena.
+    let margin = 6 * 1024 * 1024;
     let size = if free > margin + 1024 * 1024 { free - margin } else { free / 2 };
     if size == 0 {
         return;

--- a/native/src/ffi.rs
+++ b/native/src/ffi.rs
@@ -311,6 +311,69 @@ unsafe extern "C" fn js_load_font_atlas(
     JS_NewBool(ctx, ok)
 }
 
+// ---------------------------------------------------------------------------
+// video ops (native/src/video.rs — the <Video> component)
+// ---------------------------------------------------------------------------
+
+/// videoOpen(path, w, h, loopFlag) -> handle (>= 0) or -1. w/h are advisory
+/// (native geometry is fixed 480x272); they exist for the web/wasm fallback.
+unsafe extern "C" fn js_video_open(
+    ctx: *mut JSContext,
+    _this: JSValue,
+    argc: i32,
+    argv: *mut JSValue,
+) -> JSValue {
+    if argc < 1 {
+        return JS_NewInt32(ctx, -1);
+    }
+    let mut len: size_t = 0;
+    // JS_ToCStringLen2 returns a NUL-terminated C string — usable straight as
+    // the host-fs path (e.g. "host0:/clip.pmf"). video::open reads it before we
+    // free it (scePsmfPlayerSetPsmf copies the path internally).
+    let s = JS_ToCStringLen2(ctx, &mut len, *argv.offset(0), 0);
+    if s.is_null() {
+        return JS_NewInt32(ctx, -1);
+    }
+    let loop_flag = arg_i32(ctx, argc, argv, 3) != 0;
+    let handle = crate::video::open(s as *const u8, loop_flag);
+    JS_FreeCString(ctx, s);
+    JS_NewInt32(ctx, handle)
+}
+
+unsafe extern "C" fn js_video_control(
+    ctx: *mut JSContext,
+    _this: JSValue,
+    argc: i32,
+    argv: *mut JSValue,
+) -> JSValue {
+    crate::video::control(
+        arg_i32(ctx, argc, argv, 0),
+        arg_i32(ctx, argc, argv, 1) as u32,
+        arg_i32(ctx, argc, argv, 2),
+    );
+    JS_UNDEFINED
+}
+
+/// videoBind(nodeId, handle): attach a decoder to a video node (handle < 0 clears).
+unsafe extern "C" fn js_video_bind(
+    ctx: *mut JSContext,
+    _this: JSValue,
+    argc: i32,
+    argv: *mut JSValue,
+) -> JSValue {
+    ui().set_video(arg_i32(ctx, argc, argv, 0), arg_i32(ctx, argc, argv, 1));
+    JS_UNDEFINED
+}
+
+unsafe extern "C" fn js_video_state(
+    ctx: *mut JSContext,
+    _this: JSValue,
+    argc: i32,
+    argv: *mut JSValue,
+) -> JSValue {
+    JS_NewInt32(ctx, crate::video::state(arg_i32(ctx, argc, argv, 0)) as i32)
+}
+
 unsafe extern "C" fn js_measure_text(
     ctx: *mut JSContext,
     _this: JSValue,
@@ -370,6 +433,10 @@ pub unsafe fn register(ctx: *mut JSContext, global: JSValue, textures: &[(String
     add_fn(ctx, ui_obj, b"loadStyles\0", js_load_styles, 1);
     add_fn(ctx, ui_obj, b"loadFontAtlas\0", js_load_font_atlas, 1);
     add_fn(ctx, ui_obj, b"measureText\0", js_measure_text, 2);
+    add_fn(ctx, ui_obj, b"videoOpen\0", js_video_open, 4);
+    add_fn(ctx, ui_obj, b"videoControl\0", js_video_control, 3);
+    add_fn(ctx, ui_obj, b"videoBind\0", js_video_bind, 2);
+    add_fn(ctx, ui_obj, b"videoState\0", js_video_state, 1);
 
     // ui.__textures: pak image name -> texture handle (see module docs).
     let tex_obj = JS_NewObject(ctx);

--- a/native/src/ge.rs
+++ b/native/src/ge.rs
@@ -32,7 +32,7 @@ use core::ffi::c_void;
 use core::ptr::null;
 
 use psp::sys::{
-    self, BlendFactor, BlendOp, ClearBuffer, GuPrimitive, GuState, MipmapLevel,
+    self, BlendFactor, BlendOp, ClearBuffer, GuPrimitive, GuState, GuTexWrapMode, MipmapLevel,
     TextureColorComponent, TextureEffect, TextureFilter, TexturePixelFormat, VertexType,
 };
 use psp::{SCREEN_HEIGHT, SCREEN_WIDTH};
@@ -425,6 +425,70 @@ pub unsafe fn render(ui: &Ui, words: &[u32]) {
                     };
                     flush(GuPrimitive::Sprites, VTYPE_TC, 2, verts as *const c_void, bytes);
                     sys::sceGuDisable(GuState::Texture2D);
+                }
+                i += 9;
+            }
+            spec::draw_op::VIDEO_QUAD if i + 9 <= n => {
+                // Same 9-word shape as TEX_QUAD, but the handle resolves to the
+                // native decoder's CURRENT front frame buffer (video.rs), bound
+                // zero-copy. No frame yet (surface == None) => draw nothing.
+                let handle = words[i + 1] as i32;
+                let (x, y) = xy(words[i + 2]);
+                let (w, h) = wh(words[i + 3]);
+                let u0 = f32::from_bits(words[i + 4]);
+                let v0 = f32::from_bits(words[i + 5]);
+                let u1 = f32::from_bits(words[i + 6]);
+                let v1 = f32::from_bits(words[i + 7]);
+                let color = words[i + 8];
+                if let Some(s) = crate::video::surface(handle) {
+                    sys::sceGuEnable(GuState::Texture2D);
+                    sys::sceGuTexMode(TexturePixelFormat::Psm8888, 0, 0, 0);
+                    // Declared pow2 (512x512), texture-buffer-width = 512 stride,
+                    // sampling only the 480x272 active sub-rect below.
+                    sys::sceGuTexImage(
+                        MipmapLevel::None,
+                        s.tex_dim as i32,
+                        s.tex_dim as i32,
+                        s.stride_px as i32,
+                        s.ptr as *const c_void,
+                    );
+                    // RGB modulate + white/opaque vertex: the frame's texture
+                    // alpha (which the decoder may leave 0x00) is ignored; alpha
+                    // comes from the vertex color (node opacity) => opaque video.
+                    sys::sceGuTexFunc(TextureEffect::Modulate, TextureColorComponent::Rgb);
+                    // Nearest + Clamp: no bilinear/edge bleed across the
+                    // 480/272 seam, and clamp stops a bottom/right tap wrapping
+                    // modulo the declared 512 into unrelated memory.
+                    sys::sceGuTexFilter(TextureFilter::Nearest, TextureFilter::Nearest);
+                    sys::sceGuTexWrap(GuTexWrapMode::Clamp, GuTexWrapMode::Clamp);
+                    // TRANSFORM_2D UVs are TEXELS: scale normalized UVs by the
+                    // ACTIVE dims (480x272), not the declared 512.
+                    let (aw, ah) = (s.active_w as f32, s.active_h as f32);
+                    let bytes = 2 * core::mem::size_of::<VertTC>();
+                    let verts = pool_alloc(bytes) as *mut VertTC;
+                    *verts.add(0) = VertTC {
+                        u: (u0 * aw) as i16,
+                        v: (v0 * ah) as i16,
+                        color,
+                        x,
+                        y,
+                        z: 0,
+                        _pad: 0,
+                    };
+                    *verts.add(1) = VertTC {
+                        u: (u1 * aw) as i16,
+                        v: (v1 * ah) as i16,
+                        color,
+                        x: (x as i32 + w) as i16,
+                        y: (y as i32 + h) as i16,
+                        z: 0,
+                        _pad: 0,
+                    };
+                    flush(GuPrimitive::Sprites, VTYPE_TC, 2, verts as *const c_void, bytes);
+                    sys::sceGuDisable(GuState::Texture2D);
+                    // Restore the default wrap so a later image TEX_QUAD (which
+                    // never sets wrap) doesn't inherit this Clamp.
+                    sys::sceGuTexWrap(GuTexWrapMode::Repeat, GuTexWrapMode::Repeat);
                 }
                 i += 9;
             }

--- a/native/src/main.rs
+++ b/native/src/main.rs
@@ -43,6 +43,7 @@ mod pak;
 mod ffi;
 mod ge;
 mod qjs_alloc;
+mod video;
 
 psp::module!("pocketjs", 1, 1);
 
@@ -204,6 +205,8 @@ unsafe fn run() {
     trace("run: home button enabled");
     init_graphics();
     trace("run: graphics initialized");
+    init_media();
+    trace("run: media modules loaded");
 
     // ---- Controller ----
     sys::sceCtrlSetSamplingCycle(0);
@@ -545,6 +548,17 @@ unsafe fn halt(msg: &str) -> ! {
     loop {
         sys::sceDisplayWaitVblankStart();
     }
+}
+
+/// Load the AV codec modules the native <Video> component (video.rs) needs and
+/// init the MPEG library. MANDATORY on real hardware — PPSSPP HLEs these for
+/// free, but the metal will fail scePsmfPlayerCreate/decode without them.
+/// Order matters: Atrac3Plus + MpegBase both require AvCodec first.
+unsafe fn init_media() {
+    sys::sceUtilityLoadAvModule(sys::AvModule::AvCodec);
+    sys::sceUtilityLoadAvModule(sys::AvModule::MpegBase);
+    sys::sceUtilityLoadAvModule(sys::AvModule::Atrac3Plus);
+    sys::sceMpegInit();
 }
 
 /// Double-buffered 480x272 PSM8888 GU init — copied from dreamcart

--- a/native/src/video.rs
+++ b/native/src/video.rs
@@ -1,0 +1,436 @@
+//! Native Video decode subsystem — the PSP side of the `<Video>` component.
+//!
+//! Design (DESIGN.md "Video"; grounded in the research dossier): a video node
+//! carries an opaque decoder handle. The core emits a VIDEO_QUAD at the node's
+//! laid-out rect; `ge.rs` binds THIS module's current front frame buffer as a
+//! GE texture (zero-copy). Decode is offloaded to the **Media Engine** via the
+//! high-level `scePsmfPlayer` (demux + H.264 + optional ATRAC3+ + A/V sync on
+//! the player's own kernel/ME threads). We add ONE dedicated poll thread so
+//! that `host0:`/PSPLink reads and the blocking `Get*Data` calls NEVER stall
+//! the 60 Hz vblank worker.
+//!
+//! Threading contract:
+//!   - The vblank worker (`main.rs`) only ever does an atomic load + a pointer
+//!     read here (`surface()`), from the VIDEO_QUAD arm in `ge.rs`.
+//!   - The poll thread is the SOLE `&mut *player` user; the worker touches only
+//!     `Atomic*` fields + post-open-immutable buffer headers, accessed through a
+//!     RAW pointer (`ctx_ptr`), never a `&mut VideoCtx` — so the two threads
+//!     never hold aliasing `&mut`s to the same ctx.
+//!   - Frames are triple-buffered; the poll thread publishes a ready index with
+//!     a release store, the worker latches it with an acquire load, so the GE
+//!     never samples a buffer mid-decode.
+//!
+//! HARDWARE-GATED (see DESIGN.md "Video" Phase-0): the exact player create-buffer
+//! size, thread priorities, ConfigPlayer pixel mode, arena/ME partition headroom
+//! and GE texture-cache freshness must be validated on real hardware + PSPLink.
+//! Fully HLE'd by PPSSPP; the metal needs the AV modules loaded (main.rs).
+
+use core::ffi::c_void;
+use core::ptr;
+use core::sync::atomic::{AtomicU32, Ordering};
+
+use alloc::boxed::Box;
+use alloc::vec;
+use alloc::vec::Vec;
+
+use pocketjs_core::spec::{video_cmd, video_state};
+use psp::sys::{
+    self, PsmfConfigMode, PsmfPlayer, PsmfPlayerData, PsmfPlayerMode, PsmfPlayerStatus,
+    PsmfVideoData, SceUid, ThreadAttributes,
+};
+
+// ---------------------------------------------------------------------------
+// Frame geometry
+// ---------------------------------------------------------------------------
+// The active picture is 480x272 (the PSP panel + the ME AVC max). The GE needs
+// a pow2-declared texture, so we bind a declared 512x512 with texture-buffer-
+// width 512 and sample only the 480x272 sub-rect (u<=480, v<=272 texels). The
+// player writes 480px rows at a 512px stride into `display_buf`; columns
+// 480..511 and the guard rows below 272 are never sampled.
+
+const ACTIVE_W: u32 = 480;
+const ACTIVE_H: u32 = 272;
+/// Texture-buffer width / declared pow2 side handed to the GE, and the pixel
+/// stride passed to the player as `frame_width`.
+const STRIDE_PX: u32 = 512;
+/// Rows actually allocated per buffer: 272 active + guard rows (rounded to 288)
+/// so a nearest-tap at the exact v=272 bottom edge can never read past the end.
+const BUF_ROWS: u32 = 288;
+const BYTES_PER_PX: u32 = 4; // Psm8888
+const FRAME_BYTES: usize = (STRIDE_PX * BUF_ROWS * BYTES_PER_PX) as usize;
+
+/// Triple buffering: 30 fps decode vs 60 fps present means the decoder cannot
+/// lap the GE within a frame, but a third buffer removes any chance of the poll
+/// thread touching the in-flight FRONT.
+const NBUF: usize = 3;
+const READY_NONE: u32 = NBUF as u32; // sentinel: no frame published yet
+
+/// Player working buffer. `scePsmfPlayerCreate` needs a large scratch/ring
+/// buffer; the documented floor is ~0x285800. Rounded up for headroom. NOTE:
+/// the arena rounds allocations up to a power-of-two class, so 3 MB actually
+/// consumes a 4 MB block (arena.rs) — sized deliberately just over the floor.
+const PLAYER_BUF_SIZE: usize = 0x0030_0000; // 3 MB (-> 4 MB arena class)
+/// Priority of the player's INTERNAL read/demux/decode threads — below the
+/// prio-32 render worker so they never preempt the 60 Hz present. (tunable)
+const PLAYER_THREAD_PRIO: i32 = 0x2C; // 44
+/// Priority of OUR poll thread — also below the render worker. (tunable)
+const POLL_THREAD_PRIO: i32 = 0x28; // 40
+const POLL_STACK: i32 = 48 * 1024;
+
+/// One concurrent video keeps the arena budget realistic: player 4 MB + 3x1 MB
+/// frame blocks (pow2 rounding) ≈ 7 MB. A second would ≈ double it and risk OOM
+/// alongside the QuickJS heap + core + textures on a 32 MB PSP-1000.
+const MAX_VIDEOS: usize = 1;
+
+// PsmfPlayerData codec ids (PPSSPP / pspsdk): AVC video, ATRAC3+ audio.
+const PSMF_VIDEO_CODEC_AVC: i32 = 0x0E;
+const PSMF_AUDIO_CODEC_ATRAC3PLUS: i32 = 0x0F;
+/// ConfigPlayer(PixelType, ...) value for ABGR8888 output (verify on HW).
+const PSMF_PIXEL_TYPE_8888: i32 = 3;
+/// ConfigPlayer(Loop, ...) attr — 0 ENABLES looping, 1 disables (pspsdk/PPSSPP).
+const PSMF_LOOP_ON: i32 = 0;
+const PSMF_LOOP_OFF: i32 = 1;
+
+// ---------------------------------------------------------------------------
+// Surface handed to ge.rs
+// ---------------------------------------------------------------------------
+
+/// The current front frame of a video, for the GE to bind as a texture.
+pub struct Surface {
+    /// Front buffer base pointer (already dcache-flushed by the decoder).
+    pub ptr: *const u8,
+    /// Sampled sub-rect (texels): 480x272.
+    pub active_w: u32,
+    pub active_h: u32,
+    /// Declared pow2 texture side + texture-buffer-width (512).
+    pub tex_dim: u32,
+    pub stride_px: u32,
+}
+
+// ---------------------------------------------------------------------------
+// Per-video context
+// ---------------------------------------------------------------------------
+
+struct VideoCtx {
+    /// The player struct is ~64 KB (its temp_buf is 0x10000) — must live in the
+    /// arena, never on a thread stack. Boxed = one arena allocation. Mutated
+    /// ONLY by the poll thread (and by open/close, which never overlap it).
+    player: Box<PsmfPlayer>,
+    /// The large player working buffer (kept alive for the ctx lifetime).
+    _work: Vec<u8>,
+    /// NBUF frame buffers (arena). Their base pointers are stable after open.
+    frames: [Vec<u8>; NBUF],
+    /// Index of the latest fully decoded buffer (release/acquire published),
+    /// or READY_NONE. The GE reads this to pick the FRONT.
+    ready: AtomicU32,
+    /// Pending command (VIDEO_CMD.*), consumed by the poll thread.
+    command: AtomicU32,
+    /// Coarse playback state | (ptsMs << 8), for `videoState`.
+    status: AtomicU32,
+    /// Our poll thread; -1 until started.
+    thread: SceUid,
+    loop_playback: bool,
+    /// This ctx's slot index (passed to the poll thread as its argument).
+    slot: u32,
+}
+
+static mut REG: [Option<VideoCtx>; MAX_VIDEOS] = [None];
+
+/// Raw pointer to the ctx at `handle`, or null. Callers deref specific fields
+/// (`(*p).ready` etc.) — this deliberately does NOT hand out a `&mut VideoCtx`,
+/// so the worker's field reads never alias the poll thread's `&mut *player`.
+#[inline]
+unsafe fn ctx_ptr(handle: i32) -> *mut VideoCtx {
+    let Ok(h) = usize::try_from(handle) else { return ptr::null_mut() };
+    if h >= MAX_VIDEOS {
+        return ptr::null_mut();
+    }
+    match REG[h].as_mut() {
+        Some(c) => c as *mut VideoCtx,
+        None => ptr::null_mut(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Public API (called from ffi.rs on the JS thread, except `surface` from ge.rs)
+// ---------------------------------------------------------------------------
+
+/// Open a decoder for a host-fs stream. `path` is a NUL-terminated byte string
+/// (e.g. `host0:/clip.pmf\0`). Returns a handle (>= 0) or -1 on failure.
+pub unsafe fn open(path: *const u8, loop_playback: bool) -> i32 {
+    // Find a free slot.
+    let mut slot = usize::MAX;
+    for (i, s) in REG.iter().enumerate() {
+        if s.is_none() {
+            slot = i;
+            break;
+        }
+    }
+    if slot == usize::MAX {
+        return -1;
+    }
+
+    // Allocate the working + frame buffers from the arena.
+    let work: Vec<u8> = vec![0u8; PLAYER_BUF_SIZE];
+    let frames: [Vec<u8>; NBUF] = [
+        vec![0u8; FRAME_BYTES],
+        vec![0u8; FRAME_BYTES],
+        vec![0u8; FRAME_BYTES],
+    ];
+    // Flush the zero-init dirty cache lines ONCE now, before the ME ever DMAs
+    // into these buffers — so the poll loop's post-decode invalidate never
+    // writes stale zeros over freshly decoded pixels.
+    for f in &frames {
+        sys::sceKernelDcacheWritebackInvalidateRange(f.as_ptr() as *const c_void, FRAME_BYTES as u32);
+    }
+    let player: Box<PsmfPlayer> = Box::new(core::mem::zeroed::<PsmfPlayer>());
+
+    let mut c = VideoCtx {
+        player,
+        _work: work,
+        frames,
+        ready: AtomicU32::new(READY_NONE),
+        command: AtomicU32::new(video_cmd::PLAY),
+        status: AtomicU32::new(video_state::IDLE),
+        thread: SceUid(-1),
+        loop_playback,
+        slot: slot as u32,
+    };
+
+    // scePsmfPlayerCreate: pass [bufferAddr, bufferSize, threadPriority] as the
+    // create-data triple.
+    let create_data: [u32; 3] = [
+        c._work.as_mut_ptr() as u32,
+        PLAYER_BUF_SIZE as u32,
+        PLAYER_THREAD_PRIO as u32,
+    ];
+    if sys::scePsmfPlayerCreate(&mut *c.player, create_data.as_ptr()) < 0 {
+        c.status.store(video_state::ERROR, Ordering::Relaxed);
+        return -1;
+    }
+    if sys::scePsmfPlayerSetPsmf(&mut *c.player, path) < 0 {
+        sys::scePsmfPlayerDelete(&mut *c.player);
+        return -1;
+    }
+    // ABGR8888 frames (the only format ge.rs binds beside 4444); loop mode.
+    sys::scePsmfPlayerConfigPlayer(&mut *c.player, PsmfConfigMode::PixelType, PSMF_PIXEL_TYPE_8888);
+    sys::scePsmfPlayerConfigPlayer(
+        &mut *c.player,
+        PsmfConfigMode::Loop,
+        if loop_playback { PSMF_LOOP_ON } else { PSMF_LOOP_OFF },
+    );
+
+    // Start playback. v1 is SILENT with a VIDEO-ONLY PMF: audio_stream_num = -1
+    // selects no audio stream (declaring one that doesn't exist can fail Start,
+    // and an undrained audio ring stalls video). v2: real ATRAC3+ stream drained
+    // via GetAudioData -> sceAudioOutput2, audio-clock master. (verify on HW)
+    let data = PsmfPlayerData {
+        video_codec: PSMF_VIDEO_CODEC_AVC,
+        video_stream_num: 0,
+        audio_codec: PSMF_AUDIO_CODEC_ATRAC3PLUS,
+        audio_stream_num: -1,
+        play_mode: 0,
+        play_speed: 0,
+    };
+    if sys::scePsmfPlayerStart(&mut *c.player, &data, 0) < 0 {
+        sys::scePsmfPlayerReleasePsmf(&mut *c.player);
+        sys::scePsmfPlayerDelete(&mut *c.player);
+        return -1;
+    }
+    c.status.store(video_state::PLAYING, Ordering::Relaxed);
+
+    // Install the ctx BEFORE creating the thread (the thread reads REG[slot]).
+    // Create does NOT start the thread, so there is no read before we finish
+    // wiring `thread` below.
+    REG[slot] = Some(c);
+
+    // Spawn the poll thread; hand it the slot index as its start argument.
+    let tid = sys::sceKernelCreateThread(
+        b"pocketjs_video\0".as_ptr(),
+        poll_main,
+        POLL_THREAD_PRIO,
+        POLL_STACK,
+        ThreadAttributes::USER,
+        ptr::null_mut(),
+    );
+    if tid.0 < 0 {
+        // Could not spawn: tear the player down (scoped borrow) and free the
+        // slot. The borrow must end BEFORE the `REG[slot] = None` write.
+        if let Some(inst) = REG[slot].as_mut() {
+            sys::scePsmfPlayerStop(&mut *inst.player);
+            sys::scePsmfPlayerReleasePsmf(&mut *inst.player);
+            sys::scePsmfPlayerDelete(&mut *inst.player);
+        }
+        REG[slot] = None;
+        return -1;
+    }
+    REG[slot].as_mut().unwrap().thread = tid;
+    let mut arg = slot as u32;
+    sys::sceKernelStartThread(tid, 4, &mut arg as *mut u32 as *mut c_void);
+    slot as i32
+}
+
+/// Queue a control command for the poll thread. Close is handled inline
+/// (joins the thread + frees the ctx) so buffers are reclaimed deterministically.
+pub unsafe fn control(handle: i32, cmd: u32, _arg: i32) {
+    if cmd == video_cmd::CLOSE {
+        close(handle);
+        return;
+    }
+    let p = ctx_ptr(handle);
+    if !p.is_null() {
+        (*p).command.store(cmd, Ordering::Relaxed);
+    }
+}
+
+/// Packed playback status for `videoState`: state | (ptsMs << 8).
+pub unsafe fn state(handle: i32) -> u32 {
+    let p = ctx_ptr(handle);
+    if p.is_null() {
+        return video_state::ERROR;
+    }
+    (*p).status.load(Ordering::Relaxed)
+}
+
+/// The current front frame for the GE to bind. `None` until the first frame is
+/// decoded (the VIDEO_QUAD arm then draws nothing / a placeholder).
+///
+/// Called from the vblank worker (ge.rs) — a pure atomic load + pointer read;
+/// touches only `ready` (atomic) and the FRONT buffer's stable base pointer,
+/// never `&mut` and never `scePsmfPlayer*`.
+pub unsafe fn surface(handle: i32) -> Option<Surface> {
+    let p = ctx_ptr(handle);
+    if p.is_null() {
+        return None;
+    }
+    let idx = (*p).ready.load(Ordering::Acquire);
+    if idx >= NBUF as u32 {
+        return None;
+    }
+    Some(Surface {
+        ptr: (*p).frames[idx as usize].as_ptr(),
+        active_w: ACTIVE_W,
+        active_h: ACTIVE_H,
+        tex_dim: STRIDE_PX,
+        stride_px: STRIDE_PX,
+    })
+}
+
+/// Tear a decoder down: signal the poll thread to exit, join it, delete the
+/// player, drop the ctx (frees all arena buffers).
+pub unsafe fn close(handle: i32) {
+    let p = ctx_ptr(handle);
+    if p.is_null() {
+        return;
+    }
+    let slot = (*p).slot as usize;
+    let tid = (*p).thread;
+    (*p).command.store(video_cmd::CLOSE, Ordering::Relaxed);
+    if tid.0 >= 0 {
+        // The poll thread checks `command` each iteration and exits on Close.
+        // After WaitThreadEnd it no longer runs, so the teardown below is the
+        // sole accessor of this ctx.
+        sys::sceKernelWaitThreadEnd(tid, ptr::null_mut());
+        sys::sceKernelDeleteThread(tid);
+    }
+    sys::scePsmfPlayerStop(&mut *(*p).player);
+    sys::scePsmfPlayerReleasePsmf(&mut *(*p).player);
+    sys::scePsmfPlayerDelete(&mut *(*p).player);
+    REG[slot] = None; // drops _work + frames (arena free)
+}
+
+/// Close every open video (teardown on unmount / exit).
+pub unsafe fn stop_all() {
+    for i in 0..MAX_VIDEOS {
+        if REG[i].is_some() {
+            close(i as i32);
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Poll thread
+// ---------------------------------------------------------------------------
+
+/// One poll thread per open video. Advances the player, pulls the freshly
+/// decoded frame into a BACK buffer, dcache-invalidates it (the ME wrote it via
+/// DMA behind the CPU cache; the buffer was pre-flushed at open so this never
+/// clobbers pixels), then publishes it as the new FRONT.
+unsafe extern "C" fn poll_main(_argc: usize, argv: *mut c_void) -> i32 {
+    let slot = if argv.is_null() { 0 } else { *(argv as *const u32) as usize };
+    let p = if slot < MAX_VIDEOS { ctx_ptr(slot as i32) } else { ptr::null_mut() };
+    if p.is_null() {
+        return 0;
+    }
+    // Rotating write cursor: never write the buffer currently published as FRONT.
+    let mut write: u32 = 0;
+    let mut paused = false;
+
+    loop {
+        let cmd = (*p).command.load(Ordering::Relaxed);
+        if cmd == video_cmd::CLOSE {
+            break;
+        }
+        if cmd == video_cmd::PAUSE {
+            if !paused {
+                // Actually pause the player's clock (not just stop pulling) so
+                // resume doesn't jump forward in time / overflow the rings.
+                sys::scePsmfPlayerChangePlayMode(&mut *(*p).player, PsmfPlayerMode::Pause, 0);
+                paused = true;
+                let pts = (*p).status.load(Ordering::Relaxed) & !0xff;
+                (*p).status.store(video_state::PAUSED | pts, Ordering::Relaxed);
+            }
+            sys::sceKernelDelayThread(16_000); // ~1 frame; yield and re-check
+            continue;
+        }
+        if paused {
+            sys::scePsmfPlayerChangePlayMode(&mut *(*p).player, PsmfPlayerMode::Play, 0);
+            paused = false;
+        }
+
+        // Finished (non-looping): the player's Loop config re-arms internally
+        // when looping, so we only observe Finished when loop is off.
+        let st = sys::scePsmfPlayerGetCurrentStatus(&mut *(*p).player);
+        if matches!(st, PsmfPlayerStatus::PlayingFinished) && !(*p).loop_playback {
+            let pts = (*p).status.load(Ordering::Relaxed) & !0xff;
+            (*p).status.store(video_state::ENDED | pts, Ordering::Relaxed);
+            sys::sceKernelDelayThread(16_000);
+            continue;
+        }
+
+        sys::scePsmfPlayerUpdate(&mut *(*p).player);
+
+        // Choose a BACK buffer != the published FRONT.
+        let front = (*p).ready.load(Ordering::Relaxed);
+        if write == front {
+            write = (write + 1) % NBUF as u32;
+        }
+        let back = write as usize;
+
+        let mut vd = PsmfVideoData {
+            frame_width: STRIDE_PX as i32,
+            display_buf: (*p).frames[back].as_mut_ptr() as u32,
+            display_pts: 0,
+        };
+        let r = sys::scePsmfPlayerGetVideoData(&mut *(*p).player, &mut vd);
+        if r >= 0 {
+            // Invalidate so the GE (which samples RAM) sees the ME's DMA output,
+            // not stale cache. Writeback-invalidate is alignment-safe and, since
+            // the CPU never writes these buffers post-open, carries no dirty
+            // lines to clobber the frame with.
+            sys::sceKernelDcacheWritebackInvalidateRange(
+                (*p).frames[back].as_ptr() as *const c_void,
+                FRAME_BYTES as u32,
+            );
+            // Publish the new FRONT (release: pairs with surface()'s acquire).
+            (*p).ready.store(back as u32, Ordering::Release);
+            write = (back as u32 + 1) % NBUF as u32;
+            let pts_ms = vd.display_pts / 90; // 90 kHz PTS -> ms
+            (*p).status.store(video_state::PLAYING | (pts_ms << 8), Ordering::Relaxed);
+        } else {
+            // NO_MORE_DATA / warm-up: back off briefly and retry.
+            sys::sceKernelDelayThread(8_000);
+        }
+    }
+    0
+}

--- a/scripts/video-encode.ts
+++ b/scripts/video-encode.ts
@@ -1,0 +1,74 @@
+// scripts/video-encode.ts <input> [out-basename]
+//
+// Produce the "most PSP-suited" video for the native <Video> component from any
+// source clip, using ffmpeg. Emits TWO artifacts:
+//
+//   dist/video/<name>.h264   H.264 Annex-B elementary stream — the input to the
+//                            PSMF muxer (step 2 below); the PSP Media Engine's
+//                            AVC decoder consumes this framing.
+//   host-web/<name>.mp4      web-preview encode the browser dev host plays for
+//                            the <Video> web fallback (served at /<name>.mp4).
+//
+// Encode profile (research-grounded — see DESIGN.md "Video"): 480×272 (both
+// multiples of 16 = the ME AVC max, no padding), H.264 Main + CABAC, Level 3.0,
+// 30 fps, NO B-frames (one AU == one displayable frame, PTS=DTS), closed 1 s
+// GOP (clean loop/seek joins), ~1.5 Mbps CBR (comfortably within PSPLink).
+//
+// STEP 2 (mux to host0:/<name>.pmf) is NOT done here — ffmpeg has no PSMF/game
+// `.pmf` muxer (its `-f psp` makes an XMB MP4, not a game PMF). Use a PSMF muxer
+// (UMDGen / MakePMF-class tooling) or the byte layout in DESIGN.md "Video". The
+// resulting <name>.pmf goes in the usbhostfs_pc host dir so it resolves as
+// host0:/<name>.pmf over PSPLink.
+//
+// Requires ffmpeg with libx264 on PATH.
+
+import { $ } from "bun";
+import { existsSync, mkdirSync } from "node:fs";
+
+const [input, outArg] = Bun.argv.slice(2);
+if (!input) {
+  console.error("usage: bun scripts/video-encode.ts <input.mov> [out-basename]");
+  process.exit(1);
+}
+if (!existsSync(input)) {
+  console.error(`video-encode: input not found: ${input}`);
+  process.exit(1);
+}
+if (!Bun.which("ffmpeg")) {
+  console.error("video-encode: ffmpeg not found on PATH (brew install ffmpeg)");
+  process.exit(1);
+}
+
+const root = new URL("..", import.meta.url).pathname; // PocketJS/
+const name = (outArg ?? "clip").replace(/\.[^.]+$/, "");
+const outDir = `${root}dist/video`;
+mkdirSync(outDir, { recursive: true });
+
+// scale to fit inside 480×272 preserving aspect, then pad to exactly 480×272.
+const VF =
+  "scale=480:272:force_original_aspect_ratio=decrease," +
+  "pad=480:272:(ow-iw)/2:(oh-ih)/2,fps=30,format=yuv420p";
+// PSP Media Engine profile: Main + CABAC, L3.0, no B-frames, closed 1 s GOP.
+const X264 =
+  "cabac=1:ref=1:bframes=0:keyint=30:min-keyint=30:scenecut=0:aud=1:nal-hrd=cbr";
+
+const h264 = `${outDir}/${name}.h264`;
+const mp4 = `${root}host-web/${name}.mp4`;
+
+console.log(`video-encode: ${input} -> ${name}.h264 (+ web ${name}.mp4)`);
+
+// 1) H.264 Annex-B elementary stream for the PSMF muxer / Media Engine.
+await $`ffmpeg -y -i ${input} -vf ${VF} \
+  -c:v libx264 -profile:v main -level:v 3.0 -x264-params ${X264} \
+  -b:v 1500k -maxrate 1500k -bufsize 1500k -an -f h264 ${h264}`;
+
+// 2) Web-preview mp4 for the browser dev host (<Video> web fallback).
+await $`ffmpeg -y -i ${input} -vf ${VF} \
+  -c:v libx264 -profile:v main -level:v 3.0 -pix_fmt yuv420p \
+  -b:v 1500k -movflags +faststart -an ${mp4}`;
+
+console.log(`  elementary stream: ${h264}`);
+console.log(`  web preview:       ${mp4}  (served at /${name}.mp4)`);
+console.log("");
+console.log("Next: mux the .h264 to a PSMF `.pmf` (see DESIGN.md \"Video\") and place");
+console.log(`it in the usbhostfs_pc host dir so it resolves as host0:/${name}.pmf.`);

--- a/spec/gen-rust.ts
+++ b/spec/gen-rust.ts
@@ -53,6 +53,8 @@ import {
   TEX_MAX_DIM,
   TRANSITION_MASK_ALL,
   VALUE_KIND,
+  VIDEO_CMD,
+  VIDEO_STATE,
   type PropName,
 } from "./spec.ts";
 
@@ -151,6 +153,21 @@ export function generateRust(): string {
   put("pub mod op {");
   for (const [name, v] of Object.entries(OP)) {
     put(`    pub const ${screaming(name)}: u8 = ${v};`);
+  }
+  put("}");
+  put("");
+
+  // --- video control codes ----------------------------------------------------
+  put("/// `videoControl` command codes (host decoder contract; core is agnostic).");
+  put("pub mod video_cmd {");
+  for (const [name, v] of Object.entries(VIDEO_CMD)) {
+    put(`    pub const ${screaming(name)}: u32 = ${v};`);
+  }
+  put("}");
+  put("/// `videoState` low-byte playback state (high bits carry ptsMs).");
+  put("pub mod video_state {");
+  for (const [name, v] of Object.entries(VIDEO_STATE)) {
+    put(`    pub const ${screaming(name)}: u32 = ${v};`);
   }
   put("}");
   put("");
@@ -265,7 +282,7 @@ export function generateRust(): string {
   // --- drawlist ------------------------------------------------------------------
   put("/// DrawList op codes (core -> backend Vec<u32> words; layout in spec.ts).");
   put("/// Word counts incl. header: RECT 4, GRAD_RECT 6, GLYPH_RUN 3+2n,");
-  put("/// TEX_QUAD 9, SCISSOR 3, SCISSOR_POP 1, TRI 7.");
+  put("/// TEX_QUAD 9, SCISSOR 3, SCISSOR_POP 1, TRI 7, VIDEO_QUAD 9.");
   put("pub mod draw_op {");
   for (const [name, v] of Object.entries(DRAW_OP)) {
     put(`    pub const ${screaming(name)}: u32 = ${v};`);

--- a/spec/spec.ts
+++ b/spec/spec.ts
@@ -35,6 +35,12 @@ export const NODE_TYPE = {
   view: 0,
   text: 1,
   image: 2,
+  // A native video surface: an image-like box whose pixels are supplied every
+  // frame by the host's decoder (PSP Media Engine), not the core texture table.
+  // The core stays codec-agnostic — a video node carries an opaque decoder
+  // handle (node.vid) and emits a VIDEO_QUAD at its laid-out rect; the backend
+  // binds the decoder's current frame buffer. See DESIGN.md "Video".
+  video: 3,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -91,6 +97,14 @@ export const SIZE_FULL = -1;
 //   loadStyles(buf) / loadFontAtlas(buf)   [web/test hosts only; PSP feeds core
 //                                           natively from the pak]
 //   measureText(str, fontSlot) -> width:f32
+//   videoOpen(path, w, h, loopFlag) -> handle   [open a native decoder for a
+//                                           host-fs stream; handle < 0 = failure]
+//   videoControl(handle, cmd:VIDEO_CMD, arg)    [play/pause/stop/seek/close]
+//   videoBind(nodeId, handle)              [attach a decoder to a video node —
+//                                           handle < 0 clears]
+//   videoState(handle) -> packed status    [VIDEO_STATE bits | (ptsMs << 8)]
+//   These four are OPTIONAL on HostOps: wasm/test hosts that cannot decode omit
+//   them and render a placeholder for VIDEO_QUAD instead.
 
 export const OP = {
   createNode: 1,
@@ -109,6 +123,35 @@ export const OP = {
   loadStyles: 14,
   loadFontAtlas: 15,
   measureText: 16,
+  videoOpen: 17,
+  videoControl: 18,
+  videoBind: 19,
+  videoState: 20,
+} as const;
+
+// ---------------------------------------------------------------------------
+// Video decoder control (native Video component — DESIGN.md "Video")
+// ---------------------------------------------------------------------------
+// `videoControl(handle, cmd, arg)` command codes. The core never interprets
+// these — they cross straight to the host decoder (native/src/video.rs on PSP).
+// Append-only.
+
+export const VIDEO_CMD = {
+  play: 0,
+  pause: 1,
+  stop: 2, // stop + rewind to the start (stays open)
+  seek: 3, // arg = target position in ms
+  close: 4, // tear the decoder down (frees buffers + the decode thread)
+} as const;
+
+// `videoState(handle)` low byte: coarse playback state. High bits carry the
+// current presentation timestamp in ms (state | (ptsMs << 8)).
+export const VIDEO_STATE = {
+  idle: 0,
+  playing: 1,
+  paused: 2,
+  ended: 3,
+  error: 4,
 } as const;
 
 // ---------------------------------------------------------------------------
@@ -597,6 +640,12 @@ export const FONT_FLAG_BOLD = 1 << 0;
 //                                      word: bits 0-15 gid, bits 16-31 reserved(0) }
 //   TEX_QUAD    (9 words):  op, texHandle, xy, wh, u0, v0, u1, v1 (f32 bits,
 //                           normalized 0..1), color (modulate; 0xFFFFFFFF = none)
+//   VIDEO_QUAD  (9 words):  op, vidHandle, xy, wh, u0, v0, u1, v1 (f32 bits,
+//                           normalized 0..1), color — identical shape to TEX_QUAD
+//                           but the handle is an OPAQUE host decoder handle, not
+//                           a core texture id. The backend samples the decoder's
+//                           current frame buffer (PSP: the front video surface).
+//                           A backend that cannot decode draws a placeholder.
 //   SCISSOR     (3 words):  op, xy, wh — push clip rect. The core emits rects
 //                           already intersected with every enclosing scissor,
 //                           so backends just SET the rect (a depth counter,
@@ -619,6 +668,7 @@ export const DRAW_OP = {
   scissor: 5,
   scissorPop: 6,
   tri: 7,
+  videoQuad: 8,
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/src/components.ts
+++ b/src/components.ts
@@ -2,8 +2,9 @@
 
 import type { JSX as SolidJSX } from "solid-js";
 import { createEffect, onCleanup, onMount, splitProps } from "solid-js";
-import { ENUMS, SCREEN_H, SCREEN_W } from "../spec/spec.ts";
-import { pushButtonHandlerBlock, onButtonPress, type ButtonPressOptions } from "./frame.ts";
+import { ENUMS, SCREEN_H, SCREEN_W, VIDEO_CMD, VIDEO_STATE } from "../spec/spec.ts";
+import { getOps } from "./host.ts";
+import { onFrame, pushButtonHandlerBlock, onButtonPress, type ButtonPressOptions } from "./frame.ts";
 import { pushFocusGrid, pushFocusScope, type FocusGridOptions, type FocusScopeOptions } from "./input.ts";
 import { getOverlayRoot } from "./overlay.ts";
 import { View, type ViewProps } from "./primitives.ts";
@@ -218,6 +219,100 @@ function ModalFrame(props: ModalProps): SolidJSX.Element {
 
 export function Modal(props: ModalProps): SolidJSX.Element {
   return Portal({ children: () => ModalFrame(props) });
+}
+
+// ---------------------------------------------------------------------------
+// Video — a native, Media-Engine-decoded video surface (DESIGN.md "Video")
+// ---------------------------------------------------------------------------
+// Composites like an <Image>, but its pixels come from the host's decoder
+// (PSP: scePsmfPlayer on the Media Engine) each frame, streamed from the host
+// filesystem. The decode runs off the render thread, so the 60 fps UI never
+// stalls on host I/O or decode.
+
+type StyleObject = Record<string, number | string>;
+
+export interface VideoProps {
+  /** Host-fs stream path, e.g. `host0:/clip.pmf`. */
+  src: string;
+  class?: string;
+  style?: StyleObject;
+  /** Loop at end of stream (default false). */
+  loop?: boolean;
+  /** Begin playing on mount (default true). */
+  autoplay?: boolean;
+  /** Reactive pause control (boolean or accessor; default false = playing). */
+  paused?: boolean | (() => boolean);
+  /** Fires once when a non-looping stream reaches its end. */
+  onEnded?: () => void;
+  ref?: RefProp;
+}
+
+/** Native decode geometry — the PSP Media Engine's max / the panel size. */
+const VIDEO_NATIVE_W = 480;
+const VIDEO_NATIVE_H = 272;
+
+export function Video(props: VideoProps): SolidJSX.Element {
+  const el = createElement("video");
+  callRef(props.ref, el);
+
+  // class + style behave exactly as on any node (class may be a ternary of
+  // full literals; style is prev-diffed).
+  createEffect(() => setProp(el, "class", props.class, undefined));
+  let prevStyle: StyleObject | undefined;
+  createEffect(() => {
+    setProp(el, "style", props.style, prevStyle);
+    prevStyle = props.style;
+  });
+
+  let handle = -1;
+  // The decoder begins playing the moment it opens (scePsmfPlayerStart), so we
+  // track the last-known transport state and only send a command on an ACTUAL
+  // change — autoplay therefore needs no command at all.
+  let playing = true;
+  let firstRun = true;
+  const isPaused = () =>
+    typeof props.paused === "function" ? props.paused() : props.paused ?? false;
+
+  onMount(() => {
+    const ops = getOps();
+    // Hosts without decode support (wasm/test) omit videoOpen — the box still
+    // lays out and the backend draws a placeholder for VIDEO_QUAD.
+    if (!ops.videoOpen || !ops.videoBind) return;
+    handle = ops.videoOpen(props.src, VIDEO_NATIVE_W, VIDEO_NATIVE_H, props.loop ? 1 : 0);
+    if (handle < 0) return;
+    ops.videoBind(el.id, handle);
+  });
+
+  // Single owner of play/pause (runs after onMount, so `handle` is set). On the
+  // first run `autoplay === false` starts it paused; thereafter `paused` drives.
+  createEffect(() => {
+    const wantPlaying = !(isPaused() || (firstRun && props.autoplay === false));
+    if (handle < 0) return;
+    firstRun = false;
+    if (wantPlaying === playing) return; // no transport change → no command
+    playing = wantPlaying;
+    getOps().videoControl?.(handle, wantPlaying ? VIDEO_CMD.play : VIDEO_CMD.pause, 0);
+  });
+
+  // onEnded: poll native playback state once per frame (only if wanted).
+  if (props.onEnded) {
+    let fired = false;
+    onFrame(() => {
+      if (handle < 0 || fired) return;
+      const state = getOps().videoState?.(handle) ?? 0;
+      if ((state & 0xff) === VIDEO_STATE.ended) {
+        fired = true;
+        props.onEnded!();
+      }
+    });
+  }
+
+  // Tear the decoder down (poll thread + frame buffers) before the node dies.
+  onCleanup(() => {
+    if (handle >= 0) getOps().videoControl?.(handle, VIDEO_CMD.close, 0);
+  });
+
+  return el as unknown as SolidJSX.Element;
 }
 
 export interface ActionBarProps extends ViewProps {}

--- a/src/host.ts
+++ b/src/host.ts
@@ -60,6 +60,17 @@ export interface HostOps {
   loadFontAtlas?(buf: Uint8Array): void;
   /** JS-side convenience; layout measures natively. → width in px. */
   measureText(str: string, fontSlot: number): number;
+
+  // -- native <Video> (optional: wasm/test hosts may omit these) -------------
+  /** Open a decoder for a host-fs stream. `loopFlag` 1 = loop. Returns a
+   *  handle (≥ 0) or -1 on failure. w/h are advisory (native is 480×272). */
+  videoOpen?(path: string, w: number, h: number, loopFlag: number): number;
+  /** Control a decoder: cmd = spec VIDEO_CMD (play/pause/stop/seek/close). */
+  videoControl?(handle: number, cmd: number, arg: number): void;
+  /** Attach a decoder to a video node (handle < 0 clears). */
+  videoBind?(nodeId: number, handle: number): void;
+  /** Packed playback status: spec VIDEO_STATE | (ptsMs << 8). */
+  videoState?(handle: number): number;
 }
 
 export interface Host {

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -140,7 +140,7 @@ function createElementImpl(tag: string): NodeMirror {
   const type = (NODE_TYPE as Record<string, number>)[tag];
   if (type === undefined) {
     throw new Error(
-      `PocketJS: unknown element <${tag}> — only view/text/image exist`,
+      `PocketJS: unknown element <${tag}> — only view/text/image/video exist`,
     );
   }
   return { id: getOps().createNode(type), type, parent: null, children: [] };

--- a/test/renderer.test.ts
+++ b/test/renderer.test.ts
@@ -55,10 +55,10 @@ import {
 import { mount as publicMount, render as publicRender } from "../src/index.ts";
 import { pushButtonHandlerBlock, onButtonPress, onFrame } from "../src/lifecycle.ts";
 import { rootMirror } from "../src/renderer.ts";
-import { ActionBar, ActionHandler, FocusGrid, Modal, Portal, Text, View } from "../src/components.ts";
+import { ActionBar, ActionHandler, FocusGrid, Modal, Portal, Text, Video, View } from "../src/components.ts";
 import { resetPack } from "../src/pak.ts";
 import { encodeImageEntry, pack } from "../compiler/pak.ts";
-import { BTN, PAK_DTYPE, NODE_TYPE, PSM, ROOT_ID, PROP, STYLE_ID_NONE } from "../spec/spec.ts";
+import { BTN, PAK_DTYPE, NODE_TYPE, PSM, ROOT_ID, PROP, STYLE_ID_NONE, VIDEO_CMD } from "../spec/spec.ts";
 
 // ---------------------------------------------------------------------------
 // Mock host
@@ -118,6 +118,17 @@ function makeMockHost(strict = true): MockHost {
     loadStyles: rec("loadStyles"),
     loadFontAtlas: rec("loadFontAtlas"),
     measureText: () => 0,
+    videoOpen(path: string, w: number, h: number, loopFlag: number): number {
+      const handle = 500 + calls.length;
+      calls.push(["videoOpen", path, w, h, loopFlag, handle]);
+      return handle;
+    },
+    videoControl: rec("videoControl"),
+    videoBind: rec("videoBind"),
+    videoState() {
+      calls.push(["videoState"]);
+      return 0;
+    },
   };
   return {
     ops,
@@ -189,6 +200,67 @@ describe("basic mount", () => {
 
   test("unknown tag throws", () => {
     expect(() => createElement("div")).toThrow(/unknown element/);
+  });
+});
+
+describe("<Video> native component", () => {
+  test("mount opens + binds a decoder; unmount closes it", () => {
+    const dispose = render(
+      () => comp(Video, { src: "host0:/clip.pmf", loop: true, autoplay: true }),
+      root,
+    );
+
+    // A video node (NODE_TYPE.video = 3) is created...
+    const created = host.of("createNode").map((c) => c[1]);
+    expect(created).toContain(NODE_TYPE.video);
+    const videoId = (host.of("createNode").find((c) => c[1] === NODE_TYPE.video) as Call)[2] as number;
+
+    // ...the decoder is opened for the host path with loop=1...
+    const open = host.of("videoOpen");
+    expect(open.length).toBe(1);
+    expect(open[0].slice(1, 5)).toEqual(["host0:/clip.pmf", 480, 272, 1]);
+    const handle = open[0][5] as number;
+
+    // ...and bound to that exact node.
+    expect(host.of("videoBind")).toEqual([["videoBind", videoId, handle]]);
+    // Autoplay (default) => no pause command issued.
+    expect(host.of("videoControl")).toEqual([]);
+
+    dispose();
+    // Cleanup tears the decoder down BEFORE the node is destroyed.
+    expect(host.of("videoControl")).toEqual([["videoControl", handle, VIDEO_CMD.close, 0]]);
+  });
+
+  test("paused prop pauses on mount and toggles reactively", () => {
+    const [paused, setPaused] = createSignal(true);
+    const dispose = render(() => comp(Video, { src: "host0:/clip.pmf", paused }), root);
+
+    const handle = (host.of("videoOpen")[0] as Call)[5] as number;
+    // Mounted paused => a pause command.
+    expect(host.of("videoControl")).toContainEqual(["videoControl", handle, VIDEO_CMD.pause, 0]);
+
+    host.clear();
+    setPaused(false); // resume
+    expect(host.of("videoControl")).toEqual([["videoControl", handle, VIDEO_CMD.play, 0]]);
+    dispose();
+  });
+
+  test("host without video support still lays out the node (no throw)", () => {
+    // Strip the optional decode ops (wasm/test host that cannot decode).
+    const stripped = host.ops as Record<string, unknown>;
+    delete stripped.videoOpen;
+    delete stripped.videoBind;
+    delete stripped.videoControl;
+
+    let disposed = false;
+    expect(() => {
+      const dispose = render(() => comp(Video, { src: "host0:/clip.pmf" }), root);
+      dispose();
+      disposed = true;
+    }).not.toThrow();
+    expect(disposed).toBe(true);
+    // The node was still created (it composites as an empty box / placeholder).
+    expect(host.of("createNode").map((c) => c[1])).toContain(NODE_TYPE.video);
   });
 });
 

--- a/wasm/src/lib.rs
+++ b/wasm/src/lib.rs
@@ -125,6 +125,22 @@ pub extern "C" fn ui_set_image(id: i32, tex: i32) {
     ui().set_image(id, tex)
 }
 
+// ---- native <Video> (web fallback) ------------------------------------------
+// The wasm host can't Media-Engine-decode; host-web/engine.js drives an HTML5
+// <video> and feeds its frames here. `ui_set_video` binds a node to a decoder
+// handle (the JS-side <video> id); `ui_video_surface` hands raster.rs the
+// current RGBA8888 frame for that handle. See DESIGN.md "Video".
+
+#[no_mangle]
+pub extern "C" fn ui_set_video(id: i32, handle: i32) {
+    ui().set_video(id, handle)
+}
+
+#[no_mangle]
+pub extern "C" fn ui_video_surface(handle: i32, ptr: *const u8, w: u32, h: u32) {
+    raster::set_video_surface(handle, ptr, w, h)
+}
+
 #[no_mangle]
 pub extern "C" fn ui_animate(
     id: i32,

--- a/wasm/src/raster.rs
+++ b/wasm/src/raster.rs
@@ -212,6 +212,13 @@ pub fn render(ui: &Ui, words: &[u32], fb: &mut [u8]) {
                 tri(fb, clip, &words[i + 1..i + 7]);
                 i += 7;
             }
+            draw_op::VIDEO_QUAD => {
+                if i + 9 > words.len() {
+                    return;
+                }
+                video_quad(fb, clip, &words[i + 1..i + 9]);
+                i += 9;
+            }
             // The op set is closed per DrawList version; anything else means
             // corrupt data — stop instead of misinterpreting the stream.
             _ => return,
@@ -359,6 +366,97 @@ fn glyph_run(ui: &Ui, fb: &mut [u8], clip: Clip, slot: u8, color: u32, glyphs: &
                 let cov = row[cx] as u32;
                 if cov != 0 {
                     blend_px(fb, px, py, r, g, b, (a * cov + 127) / 255);
+                }
+            }
+        }
+    }
+}
+
+// ---- VIDEO_QUAD: host-fed frame surface (web fallback) --------------------------------
+// The web/wasm host cannot Media-Engine-decode; host-web/engine.js feeds each
+// active HTML5 <video> frame as a tightly-packed RGBA8888 surface via
+// ui_video_surface() (wasm/src/lib.rs). If no surface is registered (goldens /
+// no decode) we draw a neutral checker placeholder so the laid-out box is still
+// visible AND the draw stream stays in sync — the op set is closed, so this arm
+// must never fall through to `_ => return`.
+
+const MAX_VIDEO_SURFACES: usize = 4;
+
+#[derive(Clone, Copy)]
+struct VideoSurface {
+    ptr: *const u8,
+    w: u32,
+    h: u32,
+}
+
+static mut VIDEO_SURFACES: [Option<VideoSurface>; MAX_VIDEO_SURFACES] = [None; MAX_VIDEO_SURFACES];
+
+/// Register/replace a host RGBA8888 surface for `handle` (w*h*4 bytes at `ptr`,
+/// in wasm linear memory). ptr null / zero dims clears it. Single-threaded wasm,
+/// so `static mut` matches the crate style.
+pub fn set_video_surface(handle: i32, ptr: *const u8, w: u32, h: u32) {
+    let Ok(idx) = usize::try_from(handle) else { return };
+    if idx >= MAX_VIDEO_SURFACES {
+        return;
+    }
+    unsafe {
+        VIDEO_SURFACES[idx] = if ptr.is_null() || w == 0 || h == 0 {
+            None
+        } else {
+            Some(VideoSurface { ptr, w, h })
+        };
+    }
+}
+
+fn video_quad(fb: &mut [u8], clip: Clip, p: &[u32]) {
+    let handle = p[0] as i32;
+    let (x, y) = xy(p[1]);
+    let (w, h) = wh(p[2]);
+    let u0 = f32::from_bits(p[3]);
+    let v0 = f32::from_bits(p[4]);
+    let u1 = f32::from_bits(p[5]);
+    let v1 = f32::from_bits(p[6]);
+    let modulate = p[7];
+    if w <= 0 || h <= 0 {
+        return;
+    }
+    let c = clip.intersect(Clip { x0: x, y0: y, x1: x + w, y1: y + h });
+    if c.x0 >= c.x1 || c.y0 >= c.y1 {
+        return;
+    }
+    // Opaque video: alpha comes from the vertex (node opacity), not the frame.
+    let (_mr, _mg, _mb, ma) = channels(modulate);
+    let surface = usize::try_from(handle)
+        .ok()
+        .filter(|idx| *idx < MAX_VIDEO_SURFACES)
+        .and_then(|idx| unsafe { VIDEO_SURFACES[idx] });
+
+    match surface {
+        Some(s) => {
+            let bytes = (s.w * s.h * 4) as usize;
+            let pixels = unsafe { core::slice::from_raw_parts(s.ptr, bytes) };
+            let (swf, shf) = (s.w as f32, s.h as f32);
+            let (sw_max, sh_max) = (s.w as i32 - 1, s.h as i32 - 1);
+            let inv_w = 1.0f32 / w as f32;
+            let inv_h = 1.0f32 / h as f32;
+            for py in c.y0..c.y1 {
+                let v = v0 + (v1 - v0) * ((py - y) as f32 + 0.5) * inv_h;
+                let ty = ((v * shf) as i32).clamp(0, sh_max);
+                for px in c.x0..c.x1 {
+                    let u = u0 + (u1 - u0) * ((px - x) as f32 + 0.5) * inv_w;
+                    let tx = ((u * swf) as i32).clamp(0, sw_max);
+                    let o = ((ty * s.w as i32 + tx) as usize) * 4;
+                    blend_px(fb, px, py, pixels[o] as u32, pixels[o + 1] as u32, pixels[o + 2] as u32, ma);
+                }
+            }
+        }
+        None => {
+            // 16px two-tone slate checker so the box reads as a video surface.
+            for py in c.y0..c.y1 {
+                for px in c.x0..c.x1 {
+                    let checker = (((px >> 4) ^ (py >> 4)) & 1) == 1;
+                    let (r, g, b) = if checker { (30, 41, 59) } else { (51, 65, 85) };
+                    blend_px(fb, px, py, r, g, b, ma);
                 }
             }
         }


### PR DESCRIPTION
Native `<Video>` component: a 480×272 H.264 stream on the dev host, reached as `host0:/clip.pmf` over PSPLink, decoded on the **PSP Media Engine** (`scePsmfPlayer`) on a dedicated poll thread, composited **zero-copy** as a node in the flexbox tree — so QuickJS + Taffy layout stay at 60 fps while frames arrive.

> **Draft.** The platform-agnostic + web layers are test-verified; the PSP-native Rust passed an adversarial review but has **not been built or run on hardware** yet. See _Status_ below.

## What's in it
- **Core (codec-agnostic):** `NODE_TYPE.video=3`, ops 17–20, `DRAW_OP.videoQuad`, `Node.vid` (opaque decoder handle), `set_video`, shared `emit_sampled_quad`.
- **Native PSP** (`native/src/video.rs`): `scePsmfPlayer` on the ME; dedicated poll thread; triple-buffered arena frame surfaces with atomic front/back handoff; `ge.rs` `VIDEO_QUAD` arm binds the front buffer (`sceGuTexImage` 512² decl, clamp+nearest, opaque). AV modules loaded at boot; arena margin 2→6 MB.
- **JS** (`src/components.ts`): managed `<Video>` — open+bind on mount, reactive pause, **Close on unmount**, `onEnded` poll. Ops optional on `HostOps`.
- **Web/wasm fallback:** HTML5 `<video>` → raster surface; deterministic checker for headless goldens (keeps the closed op-set in sync). One draw path, three hosts.
- **Demo** `demos/video/` + `scripts/video-encode.ts` (ffmpeg recipe); contract in `DESIGN.md` "Video".

## Status / what's verified

| Layer | Verified how | State |
|---|---|---|
| spec + core contract | `bun test/contract.ts` (spec.rs regen byte-match) | ✅ green |
| JS `<Video>` lifecycle | 39 renderer tests incl. create→open→bind→pause→**Close-on-unmount** + no-decode fallback | ✅ pass |
| full suite | `bun run test` | ✅ 83 pass |
| demos build | `bun scripts/build.ts video-main` + hero regression | ✅ build |
| native Rust (`video.rs`, `ge.rs`, `ffi.rs`) | adversarial review vs rust-psp bindings — 0 compile errors, 6 logic bugs found + fixed | ⚠️ **not compiled / not run on HW** |
| wasm/web fallback | JS syntax-checked; Rust not built | ⚠️ **not compiled** |

The native Rust and wasm can't be built in CI here (no rustup / wasm target / PSP toolchain).

## Biggest blockers to real use (Phase-0, must validate on hardware first)
1. **PMF authoring** — no ffmpeg game-`.pmf` muxer exists; need a PSMF muxer, and to confirm the ME accepts our x264 Main/CABAC L3.0 stream (may need SEI or Baseline fallback).
2. **`scePsmfPlayer` streaming smoothness over `host0:`/PSPLink** — mechanism confirmed, sustained throughput not; may need to cap bitrate / pre-stage to `ms0:` / fall back to low-level `sceMpeg`.
3. **First on-hardware boot** — compile the EBOOT, confirm decode+composite actually renders (arena/EDRAM partition headroom, GE texture-cache freshness without `sceGuTexFlush`).
4. **Audio** — v1 is silent (video-only PMF). ATRAC3+ + A/V sync (audio-clock master) is v2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
