### PR TITLE
[codex] add PSP benchmark memory skill

### DIFF
--- a/native/build.rs
+++ b/native/build.rs
@@ -51,17 +51,27 @@ fn main() {
     // empty -> main.rs defaults (16/32).
     let cap_start = env::var("POCKETJS_CAP_START").unwrap_or_default();
     let cap_n = env::var("POCKETJS_CAP_N").unwrap_or_default();
+    // Optional bench-only knobs. POCKETJS_ARENA_BYTES caps the single arena so
+    // scripts/bench-ppsspp.ts can scan minimum viable heap sizes; empty keeps
+    // the production "free memory minus margin" behavior. Bench runs can also
+    // skip raw frame dumps while still using the capture window to exit.
+    let arena_bytes = env::var("POCKETJS_ARENA_BYTES").unwrap_or_default();
+    let bench_dump_frames = env::var("POCKETJS_BENCH_DUMP_FRAMES").unwrap_or_default();
 
     println!("cargo:rustc-env=POCKETJS_APP={app}");
     println!("cargo:rustc-env=POCKETJS_CAPTURE_INPUT={capture_input}");
     println!("cargo:rustc-env=POCKETJS_TRACE={trace}");
     println!("cargo:rustc-env=POCKETJS_CAP_START={cap_start}");
     println!("cargo:rustc-env=POCKETJS_CAP_N={cap_n}");
+    println!("cargo:rustc-env=POCKETJS_ARENA_BYTES={arena_bytes}");
+    println!("cargo:rustc-env=POCKETJS_BENCH_DUMP_FRAMES={bench_dump_frames}");
     println!("cargo:rerun-if-env-changed=POCKETJS_APP");
     println!("cargo:rerun-if-env-changed=POCKETJS_CAPTURE_INPUT");
     println!("cargo:rerun-if-env-changed=POCKETJS_TRACE");
     println!("cargo:rerun-if-env-changed=POCKETJS_CAP_START");
     println!("cargo:rerun-if-env-changed=POCKETJS_CAP_N");
+    println!("cargo:rerun-if-env-changed=POCKETJS_ARENA_BYTES");
+    println!("cargo:rerun-if-env-changed=POCKETJS_BENCH_DUMP_FRAMES");
     if let Ok(entries) = fs::read_dir(dist) {
         for e in entries.flatten() {
             println!("cargo:rerun-if-changed={}", e.path().display());

--- a/native/src/arena.rs
+++ b/native/src/arena.rs
@@ -40,9 +40,38 @@ const NCLASS: usize = 32;
 const MIN_SHIFT: usize = 4; // smallest class = 16 bytes (>= a free-list next ptr)
 
 static mut FREE: [*mut u8; NCLASS] = [ptr::null_mut(); NCLASS];
+static mut BASE: usize = 0;
 static mut BUMP: usize = 0;
 static mut BUMP_END: usize = 0;
+static mut INIT_FREE: usize = 0;
+static mut CONFIGURED_SIZE: usize = 0;
 static mut INITED: bool = false;
+
+#[derive(Clone, Copy)]
+pub struct Stats {
+    pub capacity_bytes: usize,
+    pub bump_bytes: usize,
+    pub tail_free_bytes: usize,
+    pub init_free_bytes: usize,
+    pub configured_bytes: usize,
+}
+
+fn parse_usize(s: &str) -> usize {
+    let bytes = s.as_bytes();
+    let mut out = 0usize;
+    let mut any = false;
+    let mut i = 0usize;
+    while i < bytes.len() {
+        let c = bytes[i];
+        if c < b'0' || c > b'9' {
+            break;
+        }
+        out = out.saturating_mul(10).saturating_add((c - b'0') as usize);
+        any = true;
+        i += 1;
+    }
+    if any { out } else { 0 }
+}
 
 /// Reserve the arena on first use: take most of the free partition in a single
 /// kernel block, leaving a 2 MB margin for late kernel allocations (utility
@@ -58,8 +87,15 @@ unsafe fn ensure_init() {
     }
     INITED = true;
     let free = sys::sceKernelMaxFreeMemSize() as usize;
+    INIT_FREE = free;
+    CONFIGURED_SIZE = parse_usize(env!("POCKETJS_ARENA_BYTES"));
     let margin = 2 * 1024 * 1024;
-    let size = if free > margin + 1024 * 1024 { free - margin } else { free / 2 };
+    let default_size = if free > margin + 1024 * 1024 { free - margin } else { free / 2 };
+    let size = if CONFIGURED_SIZE > 0 {
+        CONFIGURED_SIZE
+    } else {
+        default_size
+    };
     if size == 0 {
         return;
     }
@@ -76,7 +112,8 @@ unsafe fn ensure_init() {
     }
     let base = sys::sceKernelGetBlockHeadAddr(id) as usize;
     if base != 0 {
-        BUMP = (base + 15) & !15; // 16-align the bump start
+        BASE = (base + 15) & !15; // 16-align the bump start
+        BUMP = BASE;
         BUMP_END = base + size;
     }
 }
@@ -135,4 +172,17 @@ pub unsafe fn dealloc(p: *mut u8, size: usize, align: usize) {
     }
     *(p as *mut *mut u8) = FREE[c]; // push: store the old head in the freed block
     FREE[c] = p;
+}
+
+pub unsafe fn stats() -> Stats {
+    ensure_init();
+    let capacity = BUMP_END.saturating_sub(BASE);
+    let bump = BUMP.saturating_sub(BASE);
+    Stats {
+        capacity_bytes: capacity,
+        bump_bytes: bump,
+        tail_free_bytes: BUMP_END.saturating_sub(BUMP),
+        init_free_bytes: INIT_FREE,
+        configured_bytes: CONFIGURED_SIZE,
+    }
 }

--- a/native/src/main.rs
+++ b/native/src/main.rs
@@ -71,6 +71,8 @@ static POCKETJS_CAPTURE_INPUT: &str = env!("POCKETJS_CAPTURE_INPUT");
 static POCKETJS_CAP_START: &str = env!("POCKETJS_CAP_START");
 #[cfg(feature = "capture")]
 static POCKETJS_CAP_N: &str = env!("POCKETJS_CAP_N");
+#[cfg(feature = "bench")]
+static POCKETJS_BENCH_DUMP_FRAMES: &str = env!("POCKETJS_BENCH_DUMP_FRAMES");
 
 // libquickjs-sys omits JS_NewArrayBuffer + JS_ExecutePendingJob; the linked
 // QuickJS C library provides both (same local-extern pattern as dreamcart
@@ -301,8 +303,9 @@ unsafe fn bench_maybe_flush(frame_count: u32) {
         return;
     }
     let frames = BENCH.frames as u64;
+    let arena_stats = arena::stats();
     let line = alloc::format!(
-        "{{\"app\":\"{}\",\"frames\":{},\"window_start\":{},\"window_n\":{},\"eval_us\":{},\"boot_to_eval_begin_us\":{},\"boot_to_frame0_us\":{},\"avg_js_us\":{},\"avg_jobs_us\":{},\"avg_tick_us\":{},\"avg_draw_us\":{},\"avg_render_us\":{},\"avg_work_us\":{},\"max_work_us\":{},\"bundle_bytes\":{},\"pak_bytes\":{}}}\n",
+        "{{\"app\":\"{}\",\"frames\":{},\"window_start\":{},\"window_n\":{},\"eval_us\":{},\"boot_to_eval_begin_us\":{},\"boot_to_frame0_us\":{},\"avg_js_us\":{},\"avg_jobs_us\":{},\"avg_tick_us\":{},\"avg_draw_us\":{},\"avg_render_us\":{},\"avg_work_us\":{},\"max_work_us\":{},\"bundle_bytes\":{},\"pak_bytes\":{},\"arena_capacity_bytes\":{},\"arena_bump_bytes\":{},\"arena_tail_free_bytes\":{},\"arena_init_free_bytes\":{},\"arena_configured_bytes\":{}}}\n",
         POCKETJS_APP_NAME,
         BENCH.frames,
         start,
@@ -319,6 +322,11 @@ unsafe fn bench_maybe_flush(frame_count: u32) {
         BENCH.max_work_us,
         APP_JS.len().saturating_sub(1),
         APP_PAK.len(),
+        arena_stats.capacity_bytes,
+        arena_stats.bump_bytes,
+        arena_stats.tail_free_bytes,
+        arena_stats.init_free_bytes,
+        arena_stats.configured_bytes,
     );
     bench_write(line.as_bytes());
 }
@@ -703,6 +711,13 @@ unsafe fn cap_dump_frame(frame_count: u32) {
         return;
     }
     let idx = frame_count - cap_start;
+    #[cfg(feature = "bench")]
+    if POCKETJS_BENCH_DUMP_FRAMES != "1" {
+        if idx + 1 == cap_n {
+            sys::sceKernelExitGame();
+        }
+        return;
+    }
     if idx == 0 {
         sys::sceIoMkdir(b"ms0:/dc_cap\0".as_ptr(), 0o777);
     }

--- a/scripts/bench-ppsspp.ts
+++ b/scripts/bench-ppsspp.ts
@@ -1,10 +1,11 @@
-// PPSSPP benchmark runner for the current PocketJS renderer.
+// PPSSPP benchmark runner for the current PocketJS PSP renderer.
 //
-// Builds one bench EBOOT per selected app, then runs PPSSPPHeadless repeatedly
-// and reads PSP-side microsecond timing from ms0:/PocketJS-bench.jsonl.
+// Builds one bench EBOOT per selected app, then runs PPSSPPHeadless and reads
+// PSP-side timing/memory metrics from ms0:/PocketJS-bench.jsonl.
 //
-// Example:
+// Examples:
 //   PSP_SDK=/path/to/mipsel-sony-psp bun scripts/bench-ppsspp.ts --apps=stats --samples=5
+//   PSP_SDK=/path/to/mipsel-sony-psp bun scripts/bench-ppsspp.ts --apps=all --samples=3 --memory-scan
 
 import { $ } from "bun";
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
@@ -34,12 +35,88 @@ interface BenchLine {
   max_work_us: number;
   bundle_bytes: number;
   pak_bytes: number;
+  arena_capacity_bytes: number;
+  arena_bump_bytes: number;
+  arena_tail_free_bytes: number;
+  arena_init_free_bytes: number;
+  arena_configured_bytes: number;
 }
 
 interface Sample extends BenchLine {
   sample: number;
   host_wall_ms: number;
+  arena_limit_bytes: number | null;
 }
+
+interface MemoryAttempt {
+  arena_bytes: number;
+  pass: boolean;
+  avg_work_us?: number;
+  arena_bump_bytes?: number;
+  host_wall_ms?: number;
+  error?: string;
+}
+
+interface MemoryScanApp {
+  uncapped_arena_bump_bytes: number;
+  min_pass_arena_bytes: number;
+  safety_margin_bytes: number;
+  safe_arena_bytes: number;
+  safe_sample: Sample;
+  attempts: MemoryAttempt[];
+}
+
+const KiB = 1024;
+const MiB = 1024 * KiB;
+const FRAME_BUDGET_US = 16_667;
+
+const LAUNCHER_ALL_DEMOS_INPUT = [
+  "0:0",
+  "6:0x2000",
+  "10:0",
+  "30:0x0001",
+  "34:0",
+  "38:0x0020",
+  "42:0",
+  "46:0x2000",
+  "50:0",
+  "70:0x0001",
+  "74:0",
+  "78:0x0080",
+  "82:0",
+  "86:0x0040",
+  "90:0",
+  "94:0x2000",
+  "98:0",
+  "118:0x0001",
+  "122:0",
+  "126:0x0020",
+  "130:0",
+  "134:0x2000",
+  "138:0",
+  "158:0x0001",
+  "162:0",
+  "166:0x0080",
+  "170:0",
+  "174:0x0040",
+  "178:0",
+  "182:0x2000",
+  "186:0",
+  "206:0x0001",
+  "210:0",
+  "214:0x0020",
+  "218:0",
+  "222:0x2000",
+  "226:0",
+  "246:0x0001",
+  "250:0",
+  "254:0x0080",
+  "258:0",
+  "262:0x0040",
+  "266:0",
+  "270:0x2000",
+  "274:0",
+].join(",");
 
 const SPECS: Spec[] = [
   { app: "hero", inputScript: "0:0,58:0x40,62:0,76:0x2000,80:0", capStart: 48, capN: 48 },
@@ -60,6 +137,12 @@ const SPECS: Spec[] = [
     capStart: 0,
     capN: 95,
   },
+  {
+    app: "launcher",
+    inputScript: LAUNCHER_ALL_DEMOS_INPUT,
+    capStart: 0,
+    capN: 286,
+  },
 ];
 
 const pspUiDir = new URL("..", import.meta.url).pathname;
@@ -68,6 +151,12 @@ let samples = 5;
 let apps = ["stats"];
 let timeout = Number(process.env.BENCH_PPSSPP_TIMEOUT || 60);
 let outDir = `${pspUiDir}dist/bench`;
+let dumpFrames = false;
+let memoryScan = false;
+let memoryStepBytes = 256 * KiB;
+let memorySafetyBytes = 512 * KiB;
+let memorySafetyPercent = 20;
+let memoryMaxBytes = 32 * MiB;
 
 for (let i = 0; i < argv.length; i++) {
   const a = argv[i];
@@ -84,6 +173,25 @@ for (let i = 0; i < argv.length; i++) {
   } else if (a.startsWith("--out-dir=") || a === "--out-dir") {
     outDir = value;
     if (a === "--out-dir") i++;
+  } else if (a === "--dump-frames") {
+    dumpFrames = true;
+  } else if (a === "--memory-scan") {
+    memoryScan = true;
+  } else if (a.startsWith("--memory-step-kib=") || a === "--memory-step-kib") {
+    memoryStepBytes = Number(value) * KiB;
+    if (a === "--memory-step-kib") i++;
+  } else if (a.startsWith("--memory-safety-kib=") || a === "--memory-safety-kib") {
+    memorySafetyBytes = Number(value) * KiB;
+    if (a === "--memory-safety-kib") i++;
+  } else if (a.startsWith("--memory-safety-percent=") || a === "--memory-safety-percent") {
+    memorySafetyPercent = Number(value);
+    if (a === "--memory-safety-percent") i++;
+  } else if (a.startsWith("--memory-max-kib=") || a === "--memory-max-kib") {
+    memoryMaxBytes = Number(value) * KiB;
+    if (a === "--memory-max-kib") i++;
+  } else if (a === "--list-apps") {
+    console.log(SPECS.map((s) => s.app).join("\n"));
+    process.exit(0);
   } else {
     throw new Error(`unknown argument ${a}`);
   }
@@ -91,12 +199,18 @@ for (let i = 0; i < argv.length; i++) {
 
 if (!Number.isFinite(samples) || samples < 1) throw new Error("--samples must be >= 1");
 if (!Number.isFinite(timeout) || timeout <= 0) throw new Error("--timeout must be > 0");
+if (!Number.isFinite(memoryStepBytes) || memoryStepBytes < 16 * KiB) throw new Error("--memory-step-kib must be >= 16");
+if (!Number.isFinite(memorySafetyBytes) || memorySafetyBytes < 0) throw new Error("--memory-safety-kib must be >= 0");
+if (!Number.isFinite(memorySafetyPercent) || memorySafetyPercent < 0) throw new Error("--memory-safety-percent must be >= 0");
+if (!Number.isFinite(memoryMaxBytes) || memoryMaxBytes < memoryStepBytes) throw new Error("--memory-max-kib must be >= --memory-step-kib");
 
-const selectedSpecs = apps.map((app) => {
-  const spec = SPECS.find((s) => s.app === app);
-  if (!spec) throw new Error(`unknown app ${app}`);
-  return spec;
-});
+const selectedSpecs = apps.includes("all")
+  ? SPECS
+  : apps.map((app) => {
+      const spec = SPECS.find((s) => s.app === app);
+      if (!spec) throw new Error(`unknown app ${app}`);
+      return spec;
+    });
 
 const headless = process.env.PPSSPP_HEADLESS || `${homedir()}/ppsspp-src/build/PPSSPPHeadless`;
 if (!existsSync(headless)) throw new Error(`PPSSPPHeadless not found at ${headless}`);
@@ -124,62 +238,52 @@ const METRICS = [
   "host_wall_ms",
   "bundle_bytes",
   "pak_bytes",
+  "arena_capacity_bytes",
+  "arena_bump_bytes",
+  "arena_tail_free_bytes",
+  "arena_init_free_bytes",
+  "arena_configured_bytes",
 ] as const;
 
+type Metric = (typeof METRICS)[number];
+
 const samplesOut: Sample[] = [];
+const memoryScans = new Map<string, MemoryScanApp>();
 
 for (const spec of selectedSpecs) {
   console.log(`\n## build ${spec.app}`);
-  await $`bun scripts/psp.ts ${spec.app} --bench`
-    .cwd(pspUiDir)
-    .env({
-      ...process.env,
-      POCKETJS_CAPTURE_INPUT: spec.inputScript,
-      POCKETJS_CAP_START: String(spec.capStart),
-      POCKETJS_CAP_N: String(spec.capN),
-    })
-    .quiet();
+  await buildBenchEboot(spec, null);
 
   for (let sample = 1; sample <= samples; sample++) {
-    rmSync(dccap, { recursive: true, force: true });
-    rmSync(benchFile, { force: true });
-    const t0 = performance.now();
-    const run = await $`${headless} --graphics=software --timeout=${timeout} ${eboot}`.cwd("/tmp").nothrow().quiet();
-    const host_wall_ms = performance.now() - t0;
-
-    const produced = existsSync(dccap)
-      ? readdirSync(dccap).filter((f) => /^f\d{4}\.raw$/.test(f)).length
-      : 0;
-    if (run.exitCode !== 0 && !existsSync(benchFile)) {
-      throw new Error(`${spec.app} sample ${sample}: PPSSPP failed\n${run.stdout}${run.stderr}`);
-    }
-    if (produced !== spec.capN) {
-      throw new Error(`${spec.app} sample ${sample}: produced ${produced}/${spec.capN} frames`);
-    }
-    if (!existsSync(benchFile)) {
-      throw new Error(`${spec.app} sample ${sample}: ${benchFile} missing`);
-    }
-    const lines = readFileSync(benchFile, "utf8").trim().split("\n").filter(Boolean);
-    if (lines.length !== 1) {
-      throw new Error(`${spec.app} sample ${sample}: expected 1 bench line, got ${lines.length}`);
-    }
-    const parsed = JSON.parse(lines[0]) as BenchLine;
-    const row: Sample = { ...parsed, sample, host_wall_ms };
+    const row = await runBenchSample(spec, sample, null);
     samplesOut.push(row);
-    writeFileSync(rawPath, `${JSON.stringify(row)}\n`, { flag: "a" });
+    writeRaw({ kind: "sample", ...row });
     console.log(
-      `${parsed.app} #${sample}: eval=${fmtMs(parsed.eval_us)} frame0=${fmtMs(parsed.boot_to_frame0_us)} ` +
-        `render=${fmtUs(parsed.avg_render_us)} work=${fmtUs(parsed.avg_work_us)} host=${host_wall_ms.toFixed(1)}ms`,
+      `${row.app} #${sample}: eval=${fmtMs(row.eval_us)} frame0=${fmtMs(row.boot_to_frame0_us)} ` +
+        `work=${fmtUs(row.avg_work_us)} render=${fmtUs(row.avg_render_us)} arena=${fmtBytes(row.arena_bump_bytes)}`,
     );
   }
 }
 
+if (memoryScan) {
+  for (const spec of selectedSpecs) {
+    const uncappedRows = samplesOut.filter((r) => isAppRow(r, spec.app));
+    const uncapped = uncappedRows.reduce((best, row) => (row.arena_bump_bytes > best.arena_bump_bytes ? row : best), uncappedRows[0]);
+    if (!uncapped) throw new Error(`no uncapped sample for ${spec.app}`);
+    const scan = await scanMemoryForApp(spec, uncapped);
+    memoryScans.set(spec.app, scan);
+  }
+}
+
+const memoryScanReport = memoryScan ? renderMemoryScanReport(memoryScans) : undefined;
 const report = {
   generated: new Date().toISOString(),
   samples,
   ppsspp_revision: await textOrUnknown($`git -C ${homedir()}/ppsspp-src rev-parse --short HEAD`.quiet()),
   git_revision: await textOrUnknown($`git rev-parse --short HEAD`.cwd(pspUiDir).quiet()),
+  frame_budget_us: FRAME_BUDGET_US,
   apps: Object.fromEntries(selectedSpecs.map((spec) => [spec.app, summarizeApp(samplesOut, spec.app)])),
+  memory_scan: memoryScanReport,
 };
 writeFileSync(summaryPath, JSON.stringify(report, null, 2));
 writeFileSync(mdPath, renderMarkdown(report));
@@ -187,6 +291,178 @@ writeFileSync(mdPath, renderMarkdown(report));
 console.log(`\nraw samples: ${rawPath}`);
 console.log(`summary:     ${summaryPath}`);
 console.log(`report:      ${mdPath}`);
+if (memoryScanReport) {
+  console.log(`suite safe arena: ${fmtBytes(memoryScanReport.suite.safe_arena_bytes)}`);
+}
+
+async function buildBenchEboot(spec: Spec, arenaBytes: number | null): Promise<void> {
+  await $`bun scripts/psp.ts ${spec.app} --bench`
+    .cwd(pspUiDir)
+    .env({
+      ...process.env,
+      POCKETJS_CAPTURE_INPUT: spec.inputScript,
+      POCKETJS_CAP_START: String(spec.capStart),
+      POCKETJS_CAP_N: String(spec.capN),
+      POCKETJS_ARENA_BYTES: arenaBytes == null ? "" : String(arenaBytes),
+      POCKETJS_BENCH_DUMP_FRAMES: dumpFrames ? "1" : "",
+    })
+    .quiet();
+}
+
+async function runBenchSample(spec: Spec, sample: number, arenaBytes: number | null): Promise<Sample> {
+  rmSync(dccap, { recursive: true, force: true });
+  rmSync(benchFile, { force: true });
+  const t0 = performance.now();
+  const run = await $`${headless} --graphics=software --timeout=${timeout} ${eboot}`.cwd("/tmp").nothrow().quiet();
+  const host_wall_ms = performance.now() - t0;
+
+  if (dumpFrames) {
+    const produced = existsSync(dccap)
+      ? readdirSync(dccap).filter((f) => /^f\d{4}\.raw$/.test(f)).length
+      : 0;
+    if (produced !== spec.capN) {
+      throw new Error(`${spec.app} sample ${sample}: produced ${produced}/${spec.capN} frames`);
+    }
+  }
+  if (run.exitCode !== 0 && !existsSync(benchFile)) {
+    throw new Error(`${spec.app} sample ${sample}: PPSSPP failed\n${run.stdout}${run.stderr}`);
+  }
+  if (!existsSync(benchFile)) {
+    throw new Error(`${spec.app} sample ${sample}: ${benchFile} missing`);
+  }
+  const lines = readFileSync(benchFile, "utf8").trim().split("\n").filter(Boolean);
+  if (lines.length !== 1) {
+    throw new Error(`${spec.app} sample ${sample}: expected 1 bench line, got ${lines.length}`);
+  }
+  const parsed = JSON.parse(lines[0]) as BenchLine;
+  if (parsed.frames !== spec.capN || parsed.window_n !== spec.capN) {
+    throw new Error(`${spec.app} sample ${sample}: bench window mismatch (${parsed.frames}/${parsed.window_n}, expected ${spec.capN})`);
+  }
+  return { ...parsed, sample, host_wall_ms, arena_limit_bytes: arenaBytes };
+}
+
+async function scanMemoryForApp(spec: Spec, uncapped: Sample): Promise<MemoryScanApp> {
+  console.log(`\n## memory scan ${spec.app} (uncapped high-water ${fmtBytes(uncapped.arena_bump_bytes)})`);
+  const attempts: MemoryAttempt[] = [];
+  let candidate = alignUp(Math.max(memoryStepBytes, uncapped.arena_bump_bytes), memoryStepBytes);
+  let pass: Sample | null = null;
+
+  while (candidate <= memoryMaxBytes) {
+    const result = await probeMemory(spec, candidate, attempts);
+    if (result) {
+      pass = result;
+      break;
+    }
+    candidate += memoryStepBytes;
+  }
+  if (!pass) {
+    throw new Error(`${spec.app}: no passing arena <= ${fmtBytes(memoryMaxBytes)}`);
+  }
+
+  let minPass = candidate;
+  let minPassSample = pass;
+  let below = candidate - memoryStepBytes;
+  while (below >= memoryStepBytes) {
+    if (below < uncapped.arena_bump_bytes) {
+      const attempt: MemoryAttempt = {
+        arena_bytes: below,
+        pass: false,
+        error: `below uncapped high-water ${fmtBytes(uncapped.arena_bump_bytes)}`,
+      };
+      attempts.push(attempt);
+      writeRaw({ kind: "memory-attempt", app: spec.app, inferred: true, ...attempt });
+      break;
+    }
+    const result = await probeMemory(spec, below, attempts);
+    if (!result) break;
+    minPass = below;
+    minPassSample = result;
+    below -= memoryStepBytes;
+  }
+
+  const safetyMargin = Math.max(memorySafetyBytes, Math.ceil((minPass * memorySafetyPercent) / 100));
+  const safeArena = alignUp(minPass + safetyMargin, memoryStepBytes);
+  let safeSample = minPassSample;
+  if (safeArena !== minPass) {
+    const result = await probeMemory(spec, safeArena, attempts);
+    if (!result) throw new Error(`${spec.app}: safe arena ${fmtBytes(safeArena)} failed after min pass ${fmtBytes(minPass)}`);
+    safeSample = result;
+  }
+
+  console.log(
+    `${spec.app}: min=${fmtBytes(minPass)} safe=${fmtBytes(safeArena)} ` +
+      `(margin ${fmtBytes(safetyMargin)}, high-water ${fmtBytes(uncapped.arena_bump_bytes)})`,
+  );
+
+  return {
+    uncapped_arena_bump_bytes: uncapped.arena_bump_bytes,
+    min_pass_arena_bytes: minPass,
+    safety_margin_bytes: safetyMargin,
+    safe_arena_bytes: safeArena,
+    safe_sample: safeSample,
+    attempts,
+  };
+}
+
+async function probeMemory(spec: Spec, arenaBytes: number, attempts: MemoryAttempt[]): Promise<Sample | null> {
+  console.log(`# probe ${spec.app} arena=${fmtBytes(arenaBytes)}`);
+  try {
+    await buildBenchEboot(spec, arenaBytes);
+    const sample = await runBenchSample(spec, 1, arenaBytes);
+    const attempt: MemoryAttempt = {
+      arena_bytes: arenaBytes,
+      pass: true,
+      avg_work_us: sample.avg_work_us,
+      arena_bump_bytes: sample.arena_bump_bytes,
+      host_wall_ms: sample.host_wall_ms,
+    };
+    attempts.push(attempt);
+    writeRaw({ kind: "memory-attempt", app: spec.app, ...attempt });
+    return sample;
+  } catch (error) {
+    const attempt: MemoryAttempt = {
+      arena_bytes: arenaBytes,
+      pass: false,
+      error: error instanceof Error ? firstLine(error.message) : String(error),
+    };
+    attempts.push(attempt);
+    writeRaw({ kind: "memory-attempt", app: spec.app, ...attempt });
+    console.log(`# fail ${spec.app} arena=${fmtBytes(arenaBytes)}: ${attempt.error}`);
+    return null;
+  }
+}
+
+function renderMemoryScanReport(scans: Map<string, MemoryScanApp>) {
+  const appsReport = Object.fromEntries(scans.entries());
+  const minPass = Math.max(...[...scans.values()].map((s) => s.min_pass_arena_bytes));
+  const safeArena = Math.max(...[...scans.values()].map((s) => s.safe_arena_bytes));
+  return {
+    step_bytes: memoryStepBytes,
+    safety_floor_bytes: memorySafetyBytes,
+    safety_percent: memorySafetyPercent,
+    apps: appsReport,
+    suite: {
+      min_pass_arena_bytes: minPass,
+      safe_arena_bytes: safeArena,
+    },
+  };
+}
+
+function writeRaw(value: unknown): void {
+  writeFileSync(rawPath, `${JSON.stringify(value)}\n`, { flag: "a" });
+}
+
+function isAppRow(row: Sample, app: string): boolean {
+  return row.app === `${app}-main` || row.app === app;
+}
+
+function firstLine(text: string): string {
+  return text.split("\n").find(Boolean)?.slice(0, 240) ?? "unknown error";
+}
+
+function alignUp(n: number, step: number): number {
+  return Math.ceil(n / step) * step;
+}
 
 function fmtUs(us: number): string {
   return `${Math.round(us)}us`;
@@ -194,6 +470,12 @@ function fmtUs(us: number): string {
 
 function fmtMs(us: number): string {
   return `${(us / 1000).toFixed(1)}ms`;
+}
+
+function fmtBytes(bytes: number): string {
+  if (bytes >= MiB) return `${(bytes / MiB).toFixed(bytes % MiB === 0 ? 0 : 2)} MiB`;
+  if (bytes >= KiB) return `${(bytes / KiB).toFixed(bytes % KiB === 0 ? 0 : 1)} KiB`;
+  return `${bytes} B`;
 }
 
 async function textOrUnknown(cmd: ReturnType<typeof $>): Promise<string> {
@@ -233,9 +515,18 @@ function quantile(sorted: number[], q: number): number {
   return sorted[lo] * (1 - t) + sorted[hi] * t;
 }
 
-function summarizeApp(rows: Sample[], app: string) {
-  const subset = rows.filter((r) => r.app === `${app}-main` || r.app === app);
-  return Object.fromEntries(METRICS.map((metric) => [metric, summarize(subset.map((r) => r[metric]))]));
+function summarizeApp(rows: Sample[], app: string): Record<Metric, ReturnType<typeof summarize>> {
+  const subset = rows.filter((r) => isAppRow(r, app));
+  return Object.fromEntries(METRICS.map((metric) => [metric, summarize(subset.map((r) => r[metric]))])) as Record<
+    Metric,
+    ReturnType<typeof summarize>
+  >;
+}
+
+function formatMetric(metric: Metric, value: number): string {
+  if (metric === "host_wall_ms") return `${value.toFixed(1)}ms`;
+  if (metric.endsWith("_bytes")) return fmtBytes(value);
+  return fmtUs(value);
 }
 
 function renderMarkdown(report: {
@@ -243,7 +534,9 @@ function renderMarkdown(report: {
   samples: number;
   ppsspp_revision: string;
   git_revision: string;
-  apps: Record<string, Record<(typeof METRICS)[number], ReturnType<typeof summarize>>>;
+  frame_budget_us: number;
+  apps: Record<string, Record<Metric, ReturnType<typeof summarize>>>;
+  memory_scan?: ReturnType<typeof renderMemoryScanReport>;
 }) {
   const lines = [
     "# PocketJS PPSSPP Benchmark",
@@ -252,6 +545,7 @@ function renderMarkdown(report: {
     `Samples per app: ${report.samples}`,
     `PPSSPP revision: ${report.ppsspp_revision}`,
     `Git revision: ${report.git_revision}`,
+    `Frame budget: ${fmtUs(report.frame_budget_us)}`,
     "",
   ];
   for (const [app, metrics] of Object.entries(report.apps)) {
@@ -260,12 +554,32 @@ function renderMarkdown(report: {
     lines.push("|---|---:|---:|---:|---:|---:|");
     for (const metric of METRICS) {
       const s = metrics[metric];
-      const formatter = metric === "host_wall_ms" ? (v: number) => `${v.toFixed(1)}ms` : fmtUs;
       lines.push(
-        `| ${metric} | ${formatter(s.mean)} | ${formatter(s.sd)} | ${formatter(s.min)} | ${formatter(s.median)} | ${formatter(s.max)} |`,
+        `| ${metric} | ${formatMetric(metric, s.mean)} | ${formatMetric(metric, s.sd)} | ${formatMetric(metric, s.min)} | ${formatMetric(metric, s.median)} | ${formatMetric(metric, s.max)} |`,
       );
     }
     lines.push("");
   }
+
+  if (report.memory_scan) {
+    lines.push("## Memory Scan", "");
+    lines.push(`Step: ${fmtBytes(report.memory_scan.step_bytes)}`);
+    lines.push(
+      `Safety margin: max(${fmtBytes(report.memory_scan.safety_floor_bytes)}, ${report.memory_scan.safety_percent}% of min passing arena)`,
+    );
+    lines.push("");
+    lines.push("| app | uncapped high-water | min passing arena | safety margin | safe arena | attempts |");
+    lines.push("|---|---:|---:|---:|---:|---:|");
+    for (const [app, scan] of Object.entries(report.memory_scan.apps)) {
+      lines.push(
+        `| ${app} | ${fmtBytes(scan.uncapped_arena_bump_bytes)} | ${fmtBytes(scan.min_pass_arena_bytes)} | ${fmtBytes(scan.safety_margin_bytes)} | ${fmtBytes(scan.safe_arena_bytes)} | ${scan.attempts.length} |`,
+      );
+    }
+    lines.push("");
+    lines.push(`Suite min passing arena: ${fmtBytes(report.memory_scan.suite.min_pass_arena_bytes)}`);
+    lines.push(`Suite safe arena: ${fmtBytes(report.memory_scan.suite.safe_arena_bytes)}`);
+    lines.push("");
+  }
+
   return `${lines.join("\n")}\n`;
 }

--- a/scripts/psp.ts
+++ b/scripts/psp.ts
@@ -144,6 +144,8 @@ const env = {
   POCKETJS_TRACE: process.env.POCKETJS_TRACE ?? "",
   POCKETJS_CAP_START: process.env.POCKETJS_CAP_START ?? "",
   POCKETJS_CAP_N: process.env.POCKETJS_CAP_N ?? "",
+  POCKETJS_ARENA_BYTES: process.env.POCKETJS_ARENA_BYTES ?? "",
+  POCKETJS_BENCH_DUMP_FRAMES: process.env.POCKETJS_BENCH_DUMP_FRAMES ?? "",
 };
 
 function outputProfile(args: string[]): string {

--- a/skills/pocketjs-psp-benchmark/SKILL.md
+++ b/skills/pocketjs-psp-benchmark/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: pocketjs-psp-benchmark
+description: Benchmark PocketJS demos on PSP or PPSSPP, including per-frame timing, renderer phase costs, bundle and pak sizes, arena high-water memory, and minimum passing arena scans. Use when asked to profile PSP performance, compare demo frame budgets, measure memory headroom, find the minimum safe heap for demos, or preserve benchmark evidence in dist/bench.
+---
+
+# PocketJS PSP Benchmark
+
+## Overview
+
+Use this skill to produce repeatable PocketJS PSP benchmark evidence instead of ad hoc emulator runs. Prefer `scripts/bench-ppsspp.ts` for local PPSSPP measurements; use `scripts/hw.ts` only when the user explicitly asks for real PSP hardware proof.
+
+## Standard Workflow
+
+1. Confirm the worktree is on the intended branch and inspect local changes with `git status --short --branch`.
+2. Confirm host dependencies before long runs:
+
+```bash
+test -x "${PPSSPP_HEADLESS:-$HOME/ppsspp-src/build/PPSSPPHeadless}"
+test -n "$PSP_SDK" && test -f "$PSP_SDK/psp/lib/libc.a"
+```
+
+3. Run a focused benchmark while iterating:
+
+```bash
+PSP_SDK=/path/to/mipsel-sony-psp BENCH_PPSSPP_TIMEOUT=60 \
+  bun scripts/bench-ppsspp.ts --apps=stats --samples=3
+```
+
+4. Run the full suite and memory scan for release-quality evidence:
+
+```bash
+PSP_SDK=/path/to/mipsel-sony-psp BENCH_PPSSPP_TIMEOUT=60 \
+  bun scripts/bench-ppsspp.ts --apps=all --samples=3 --memory-scan
+```
+
+5. Preserve the generated evidence paths from `dist/bench/` in the final answer, PR body, or handoff. The `.json` file is authoritative; the `.md` file is for human review; `.raw.jsonl` keeps per-sample and memory-probe records.
+
+## Memory Scans
+
+Use `--memory-scan` when the user asks for minimum memory, heap headroom, safe arena sizing, or whether all demos fit. The runner first measures uncapped arena high-water, then probes capped `POCKETJS_ARENA_BYTES` values in `--memory-step-kib` increments. The reported suite requirement is the maximum safe arena across selected apps.
+
+Default safety policy is:
+
+```text
+safe_arena = min_passing_arena + max(512 KiB, 20% of min_passing_arena)
+```
+
+Override it only when the user specifies a different margin:
+
+```bash
+bun scripts/bench-ppsspp.ts --apps=all --samples=3 --memory-scan \
+  --memory-step-kib=128 --memory-safety-kib=1024 --memory-safety-percent=25
+```
+
+## Interpreting Results
+
+Use `avg_work_us` against the 60 Hz budget of about `16667us`. `max_work_us` can spike on transitions, but a sustained average over budget is a performance finding.
+
+Use `arena_bump_bytes` as the allocator high-water for the run. Use `min_pass_arena_bytes` as the probed lower bound at the configured step size, and `safe_arena_bytes` as the answer when the user asks for a minimum with safety margin.
+
+Read `references/metrics.md` when you need field definitions, caveats, or exact wording for a benchmark report.
+
+## Reporting
+
+Always include:
+
+- command run
+- report path
+- selected apps and sample count
+- PPSSPP revision and git revision from the report
+- suite safe arena when `--memory-scan` was used
+- any app whose `avg_work_us` exceeds the frame budget
+
+Do not claim real hardware proof from a PPSSPP run. State PPSSPP evidence as emulator evidence unless `scripts/hw.ts` or a real PSP run was actually used.

--- a/skills/pocketjs-psp-benchmark/agents/openai.yaml
+++ b/skills/pocketjs-psp-benchmark/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "PocketJS PSP Benchmark"
+  short_description: "Benchmark PocketJS demos on PPSSPP"
+  default_prompt: "Use $pocketjs-psp-benchmark to benchmark PocketJS demos in PPSSPP and report timing and memory headroom."

--- a/skills/pocketjs-psp-benchmark/references/metrics.md
+++ b/skills/pocketjs-psp-benchmark/references/metrics.md
@@ -1,0 +1,39 @@
+# PocketJS PSP Benchmark Metrics
+
+Read this reference when explaining `scripts/bench-ppsspp.ts` output.
+
+## Timing
+
+- `eval_us`: QuickJS global bundle evaluation time.
+- `boot_to_eval_begin_us`: host setup time before JavaScript evaluation begins.
+- `boot_to_frame0_us`: elapsed time from native run start to the first completed frame.
+- `avg_js_us`: average time spent in `globalThis.frame(buttons)`.
+- `avg_jobs_us`: average time spent draining QuickJS pending jobs.
+- `avg_tick_us`: average core tick, animation, and layout time.
+- `avg_draw_us`: average draw-list construction time.
+- `avg_render_us`: average PSP GE backend submission time.
+- `avg_work_us`: average frame work from controller read through render submission. Compare this with `16667us` for 60 Hz.
+- `max_work_us`: worst frame work in the measured window.
+- `host_wall_ms`: wall time of the PPSSPPHeadless process on the host machine; use this for runner cost, not PSP frame budget.
+
+## Size And Memory
+
+- `bundle_bytes`: bundled JavaScript size embedded in the EBOOT.
+- `pak_bytes`: asset pack size embedded in the EBOOT.
+- `arena_capacity_bytes`: capacity of the single shared arena used by Rust alloc, QuickJS, and newlib malloc.
+- `arena_bump_bytes`: high-water bytes carved from the arena. This includes allocator size-class fragmentation and is the relevant pressure number for minimum arena scans.
+- `arena_tail_free_bytes`: unused tail capacity in the arena at report time. It does not include blocks held on free lists.
+- `arena_init_free_bytes`: PSP user partition max-free value observed when the arena initialized.
+- `arena_configured_bytes`: requested `POCKETJS_ARENA_BYTES`; `0` means the production default of max free memory minus margin.
+
+## Memory Scan Fields
+
+- `uncapped_arena_bump_bytes`: high-water from the normal uncapped benchmark run.
+- `min_pass_arena_bytes`: smallest probed arena cap that completed the scripted benchmark window at the configured step size.
+- `safety_margin_bytes`: applied margin, usually `max(512 KiB, 20%)`.
+- `safe_arena_bytes`: `min_pass_arena_bytes + safety_margin_bytes`, rounded up to the configured step size.
+- `suite.safe_arena_bytes`: maximum `safe_arena_bytes` across selected apps; use this as the suite-level minimum with safety margin.
+
+## Caveats
+
+PPSSPP measurements are deterministic and useful for regression tracking, but they are not real PSP hardware proof. The arena high-water is a practical capacity requirement for this allocator, not a precise live-object heap profile, because freed blocks remain reserved in size-class free lists.


### PR DESCRIPTION
## Summary

- Add a repo-local `pocketjs-psp-benchmark` skill for repeatable PSP/PPSSPP timing and memory-headroom work.
- Extend the PPSSPP benchmark runner to cover `--apps=all`, include `launcher`, record arena memory high-water metrics, and scan capped `POCKETJS_ARENA_BYTES` values.
- Add native bench plumbing for arena caps, arena stats, and no-frame-dump bench exits so long benchmark windows do not write large raw framebuffer captures.

## Benchmark

Command:

```bash
PSP_SDK=/Users/evan/code/dreamcart/mipsel-sony-psp BENCH_PPSSPP_TIMEOUT=60 \
  bun scripts/bench-ppsspp.ts --apps=all --samples=3 --timeout=60 --memory-scan --memory-step-kib=256
```

Evidence:

- JSON: `dist/bench/ppsspp-bench-2026-07-05T00-53-47-163Z.json`
- Markdown: `dist/bench/ppsspp-bench-2026-07-05T00-53-47-163Z.md`
- PPSSPP revision: `676724ee5e`
- Git revision in report: `7c8de61`

Memory result at 256 KiB scan resolution, with default safety policy `max(512 KiB, 20%)`:

| app | min passing arena | safe arena |
|---|---:|---:|
| hero | 2.50 MiB | 3.00 MiB |
| cards | 1.50 MiB | 2.00 MiB |
| stats | 1.75 MiB | 2.25 MiB |
| library | 2.25 MiB | 2.75 MiB |
| settings | 1.75 MiB | 2.25 MiB |
| notifications | 1.75 MiB | 2.25 MiB |
| music | 1.50 MiB | 2.00 MiB |
| launcher | 4.50 MiB | 5.50 MiB |

Suite requirement: `4.50 MiB` minimum passing arena, `5.50 MiB` with safety margin. The suite maximum comes from the launcher path, which opens demos sequentially in one process.

Frame-budget observations from the same run: `settings` was slightly over 60 Hz budget at `16707us`, while `music` and `launcher` were clearly over budget at `24202us` and `28139us` respectively. The memory requirement above is still valid because all scripted windows completed under both min and safe arena caps.

## Validation

- `git diff --check`
- `bunx tsc --noEmit`
- `bunx tsc --noEmit --target ESNext --module ESNext --moduleResolution bundler --types bun --strict scripts/bench-ppsspp.ts`
- `bun run test`
- `cargo test --manifest-path core/Cargo.toml`
- `PSP_SDK=/Users/evan/code/dreamcart/mipsel-sony-psp E2E_PPSSPP_TIMEOUT=60 bun test/e2e-ppsspp.ts`
- `/tmp/pocketjs-skill-validate-venv/bin/python /Users/evan/.codex/skills/.system/skill-creator/scripts/quick_validate.py skills/pocketjs-psp-benchmark`
