### PR TITLE
fix: align nav logo and repository URL

### DIFF
--- a/site/assets/tailwind.css
+++ b/site/assets/tailwind.css
@@ -104,10 +104,10 @@
     align-items: center;
     justify-content: space-between;
     width: 100%;
-    max-width: 72rem;
+    max-width: 1160px;
     height: 62px;
     margin: 0 auto;
-    padding: 0 1.25rem;
+    padding: 0 clamp(1.25rem, 4vw, 2.75rem);
   }
   .site-brand {
     display: inline-flex;

--- a/site/content/docs/getting-started.md
+++ b/site/content/docs/getting-started.md
@@ -26,7 +26,7 @@ stay on the JS side and let the dev host compile the wasm core for us.
 ## Install
 
 ```sh
-git clone https://github.com/pocketjs/pocketjs
+git clone https://github.com/pocket-stack/pocketjs
 cd pocketjs
 bun install
 ```


### PR DESCRIPTION
## Summary

- Align the shared docs/playground nav container with the landing page container so the PocketJS logo no longer shifts horizontally between Home and Docs.
- Replace the stale `git clone https://github.com/pocketjs/pocketjs` command with `https://github.com/pocket-stack/pocketjs`.
- Sweep the repository for old `github.com/pocketjs` references.

## Validation

- `bun site/build.ts`
- `bunx tsc --noEmit`
- `bun run test`
- `git diff --check`
- `rg --pcre2 -n "github\\.com/pocketjs|git clone https://github\\.com/(?!pocket-stack/pocketjs)" ...` returned no matches
- Local browser probes measured Home and Docs nav logo at the same x-coordinate: `brandX=184`, `svgX=184`
