### PR TITLE
[codex] update landing copy to 8MB RAM

### DIFF
--- a/site/assets/og-image.svg
+++ b/site/assets/og-image.svg
@@ -64,7 +64,7 @@
 
   <g transform="translate(760 476)">
     <rect x="0" y="0" width="118" height="44" rx="22" fill="#101827" stroke="#2b3a55"/>
-    <text x="59" y="29" text-anchor="middle" fill="#dbe8f6" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="18" font-weight="700">8 MB heap</text>
+    <text x="59" y="29" text-anchor="middle" fill="#dbe8f6" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="18" font-weight="700">8MB RAM</text>
     <rect x="136" y="0" width="102" height="44" rx="22" fill="#101827" stroke="#2b3a55"/>
     <text x="187" y="29" text-anchor="middle" fill="#dbe8f6" font-family="Inter, -apple-system, BlinkMacSystemFont, Segoe UI, sans-serif" font-size="18" font-weight="700">QuickJS</text>
     <rect x="256" y="0" width="176" height="44" rx="22" fill="#101827" stroke="#2b3a55"/>

--- a/site/content/docs/architecture.md
+++ b/site/content/docs/architecture.md
@@ -272,11 +272,11 @@ global allocator (`native/src/alloc.rs`) backed by a single arena
 retained core buffers live in that arena too. JS runs on the 2 MB `USER|VFPU`
 worker; a 2 MB margin is kept for the GE display list and stack safety.
 
-Clarification: the public "8 MB heap" line describes this PocketJS application
-arena with safety headroom, not the PSP's whole main-memory budget. Code and
-embedded `.pak`/JS bytes live in the EBOOT image, the worker stack is separate,
-and PSP display framebuffers are allocated from VRAM. On a unified memory
-machine you would add those pieces back to estimate total process memory.
+Clarification: the public "8MB RAM" line is shorthand for this PocketJS
+application arena with safety headroom, not the PSP's whole main-memory budget.
+Code and embedded `.pak`/JS bytes live in the EBOOT image, the worker stack is
+separate, and PSP display framebuffers are allocated from VRAM. On a unified
+memory machine you would add those pieces back to estimate total process memory.
 
 The full allocator setup, the per-frame vertex bump pool, and the exact PSP
 frame order are covered on the [Native contract](/docs/native-contract/) page.

--- a/site/home.html
+++ b/site/home.html
@@ -34,7 +34,7 @@
       <div class="lp-container lp-hero__in">
         <a class="lp-eyebrow" href="/docs/architecture/">
           <span class="lp-eyebrow__tag">Now</span>
-          The modern web, in an 8&nbsp;MB app heap
+          The Modern Web Under 8MB RAM
           <span class="lp-eyebrow__arw" aria-hidden="true">&rarr;</span>
         </a>
         <h1 class="lp-h1">Bare Metal<span class="lp-grad">Modern Web</span></h1>
@@ -79,12 +79,12 @@
       </div>
     </section>
 
-    <!-- 8 MB APP HEAP -->
+    <!-- 8MB RAM -->
     <section class="lp-section lp-hardware">
       <div class="lp-container">
         <div class="lp-secthead lp-reveal">
           <span class="lp-kicker">Familiar tools, constrained hardware</span>
-          <h2 class="lp-h2">Tailwind, flexbox and Solid signals in an 8&nbsp;MB heap.</h2>
+          <h2 class="lp-h2">Tailwind, flexbox and Solid signals under 8MB RAM.</h2>
           <p class="lp-lead">PocketJS keeps the authoring model modern while moving the expensive work to build time and to a tiny Rust core. The result is a real interface stack that can run smoothly on a Sony PSP.</p>
         </div>
         <div class="lp-tools__row lp-reveal" aria-label="PocketJS frontend stack">
@@ -255,7 +255,7 @@
             </svg>
             <span>PocketJS</span>
           </a>
-          <p>Solid and Tailwind UI in an 8&nbsp;MB app heap, rendered through a tiny native core.</p>
+          <p>Solid and Tailwind UI under 8MB RAM, rendered through a tiny native core.</p>
         </div>
         <div>
           <h4>Docs</h4>

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -58,7 +58,7 @@ const footer = `<footer class="mt-24 border-t border-line/70 bg-ink-2/60">
     <div class="grid gap-10 sm:grid-cols-2 lg:grid-cols-4">
       <div>
         <div class="flex items-center gap-2 font-semibold text-slate-100">${LOGO}<span>PocketJS</span></div>
-        <p class="mt-3 max-w-xs text-sm text-slate-400">Solid and Tailwind UI in an 8 MB app heap, rendered through a tiny native core.</p>
+        <p class="mt-3 max-w-xs text-sm text-slate-400">Solid and Tailwind UI under 8MB RAM, rendered through a tiny native core.</p>
       </div>
       <div class="text-sm">
         <h4 class="mb-3 font-semibold text-slate-200">Docs</h4>


### PR DESCRIPTION
## Summary
- update the landing eyebrow to `The Modern Web Under 8MB RAM`
- align homepage section/footer copy and OG badge with `8MB RAM`
- keep the architecture clarification while explaining the public phrase as shorthand

## Validation
- `bun site/build.ts`
- deployed with `bunx wrangler deploy -c site/wrangler.jsonc`
- verified `https://pocketjs.dev/` and `https://www.pocketjs.dev/` contain the new title
