### PR TITLE
ci: auto-deploy pocketjs.dev to Cloudflare on push to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,9 +47,19 @@ jobs:
         run: bun scripts/wasm.ts
 
       # The site's runtime bundle imports src/styles.generated.ts, a gitignored
-      # artifact that scripts/build.ts writes. Build one demo first so it exists.
+      # artifact that scripts/build.ts writes. On a fresh checkout Bun's bundler
+      # negatively-caches the missing module during pass 1 and then fails pass 2
+      # even after pass 1 writes it, so seed a stub FIRST (positive resolution),
+      # then build a demo to overwrite it with the real table.
       - name: Generate runtime style table
-        run: bun scripts/build.ts hero
+        run: |
+          cat > src/styles.generated.ts <<'STUB'
+          export const STYLE_IDS: Record<string, number> = {};
+          export const STYLE_COUNT = 0;
+          export const FONT_SLOTS: Record<number, { px: number; bold: boolean }> = {};
+          export const DEFAULT_FONT_SLOT = 2;
+          STUB
+          bun scripts/build.ts hero
 
       - name: Build site (docs + playground + showcase bundles)
         run: bun site/build.ts

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Deploy pocketjs.dev
 # Workers" token) and CLOUDFLARE_ACCOUNT_ID.
 on:
   push:
-    branches: [main, ci-cloudflare-deploy]
+    branches: [main]
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -46,6 +46,11 @@ jobs:
       - name: Build wasm (core + software rasterizer)
         run: bun scripts/wasm.ts
 
+      # The site's runtime bundle imports src/styles.generated.ts, a gitignored
+      # artifact that scripts/build.ts writes. Build one demo first so it exists.
+      - name: Generate runtime style table
+        run: bun scripts/build.ts hero
+
       - name: Build site (docs + playground + showcase bundles)
         run: bun site/build.ts
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ name: Deploy pocketjs.dev
 # Workers" token) and CLOUDFLARE_ACCOUNT_ID.
 on:
   push:
-    branches: [main]
+    branches: [main, ci-cloudflare-deploy]
   workflow_dispatch: {}
 
 concurrency:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,56 @@
+name: Deploy pocketjs.dev
+
+# Publish the site to Cloudflare on every push to main (and on demand).
+# Requires two repo secrets: CLOUDFLARE_API_TOKEN (a scoped "Edit Cloudflare
+# Workers" token) and CLOUDFLARE_ACCOUNT_ID.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch: {}
+
+concurrency:
+  group: deploy-pocketjs-dev
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # The site copies host-web/pocketjs.wasm (a gitignored build artifact), so
+      # CI must build it from core/wasm first. Stable Rust is enough (no nightly
+      # features); wasm32-unknown-unknown is the target.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo + wasm target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            wasm/target
+          key: ${{ runner.os }}-wasm-${{ hashFiles('wasm/Cargo.toml', 'core/Cargo.toml', 'wasm/src/**', 'core/src/**') }}
+          restore-keys: ${{ runner.os }}-wasm-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build wasm (core + software rasterizer)
+        run: bun scripts/wasm.ts
+
+      - name: Build site (docs + playground + showcase bundles)
+        run: bun site/build.ts
+
+      - name: Deploy to Cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: bunx wrangler deploy -c site/wrangler.jsonc


### PR DESCRIPTION
Adds a GitHub Actions workflow that publishes the site on every push to `main` (and via manual dispatch):

1. build the wasm (`bun scripts/wasm.ts` — stable Rust + `wasm32-unknown-unknown`; the site copies the gitignored `host-web/pocketjs.wasm`)
2. build the site (`bun site/build.ts` → `site/dist`)
3. `wrangler deploy -c site/wrangler.jsonc`

**Secrets** (repo-level):
- `CLOUDFLARE_ACCOUNT_ID` — set ✅
- `CLOUDFLARE_API_TOKEN` — **needs a scoped token** (the local wrangler login is OAuth, which can't mint API tokens).

Verified the wasm + site build steps locally. Draft until the API-token secret is set and a dispatch run goes green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)