### PR TITLE
feat(web): ship gallery hero + built-in on-canvas FPS/memory HUD

### DIFF
--- a/host-web/engine.js
+++ b/host-web/engine.js
@@ -15,6 +15,7 @@
 //   A = SQUARE         S = TRIANGLE        Shift = SELECT   Space = START
 
 import { createWasmUi, FB_W, FB_H } from "./wasm-ops.js";
+import { drawHud, wasmMemoryBytes } from "./hud.js";
 
 // spec/spec.ts BTN (plain module — keep the literal in sync with the spec).
 export const BTN = {
@@ -66,6 +67,8 @@ let logSink = () => {};
 let fpsSink = () => {};
 let statsFrames = 0;
 let statsT = 0;
+let hudFps = 0; // on-canvas HUD, sampled once/second (see hud.js)
+let hudMem = 0;
 
 function safeFrame() {
   if (!frameCb) return;
@@ -82,6 +85,7 @@ function blit() {
   if (!wasm || !ctx) return;
   imageData.data.set(wasm.render());
   ctx.putImageData(imageData, 0, 0);
+  drawHud(ctx, FB_W, FB_H, hudFps, hudMem); // built-in on-canvas overlay
 }
 
 function tick(now) {
@@ -101,7 +105,10 @@ function tick(now) {
   if (steps > 0) blit();
   statsT += dt;
   if (statsT >= 1000) {
-    fpsSink(Math.round((statsFrames * 1000) / statsT));
+    // Sample FPS + memory once per second for the on-canvas HUD.
+    hudFps = Math.round((statsFrames * 1000) / statsT);
+    hudMem = wasmMemoryBytes(wasm);
+    fpsSink(hudFps);
     statsFrames = 0;
     statsT = 0;
   }
@@ -197,6 +204,7 @@ export async function load(name) {
     return e;
   }
   logSink("loaded " + name);
+  hudMem = wasmMemoryBytes(wasm); // so MEM shows before the first 1s sample
   safeFrame(); // one immediate frame so the canvas isn't blank
   blit();
   start();

--- a/host-web/hud.js
+++ b/host-web/hud.js
@@ -1,0 +1,44 @@
+// host-web/hud.js — the web host's built-in on-canvas diagnostics overlay.
+//
+// FPS + live memory are drawn DIRECTLY onto the 480x272 framebuffer canvas
+// (not into external page UI), so the readout travels with the screen wherever
+// the host is embedded. The values are sampled once per second by the host loop
+// and drawn every blit. This is a first-class part of the Web host (both
+// host-web/engine.js and site/playground/host.js draw it, on by default).
+
+/** Total wasm linear memory in bytes — the running app's RAM (core arena +
+ *  uploaded textures + heap; grows in 64 KiB pages as the app allocates). */
+export function wasmMemoryBytes(wasm) {
+  const mem = wasm && wasm.exports && wasm.exports.memory;
+  return mem ? mem.buffer.byteLength : 0;
+}
+
+function fmtMem(bytes) {
+  if (bytes >= 1024 * 1024) return (bytes / (1024 * 1024)).toFixed(1) + " MB";
+  return Math.round(bytes / 1024) + " KB";
+}
+
+/** Draw one pill (translucent plate + colored label) anchored at a corner. */
+function pill(ctx, x, y, text, color, alignRight) {
+  const w = Math.ceil(ctx.measureText(text).width);
+  const px = alignRight ? x - w - 6 : x;
+  ctx.fillStyle = "rgba(8, 11, 20, 0.6)";
+  ctx.fillRect(px, y, w + 6, 13);
+  ctx.fillStyle = color;
+  ctx.fillText(text, px + 3, y + 2);
+}
+
+/**
+ * Draw the FPS + memory HUD onto the framebuffer canvas. Call from the host's
+ * blit, AFTER putImageData (so it sits on top of the rendered frame).
+ *   fps      — frames/second (host-sampled once per second)
+ *   memBytes — wasmMemoryBytes(wasm) (host-sampled once per second)
+ */
+export function drawHud(ctx, w, _h, fps, memBytes) {
+  ctx.save();
+  ctx.font = "700 9px ui-monospace, SFMono-Regular, Menlo, monospace";
+  ctx.textBaseline = "top";
+  pill(ctx, 3, 3, "FPS " + (fps | 0), "#34d399", false); // top-left
+  pill(ctx, w - 3, 3, "MEM " + fmtMem(memBytes), "#60a5fa", true); // top-right
+  ctx.restore();
+}

--- a/host-web/index.html
+++ b/host-web/index.html
@@ -33,7 +33,6 @@
     background: #0f172a; border: 1px solid #1e293b; border-radius: 6px;
     padding: 8px; white-space: pre-wrap; font-size: 12px; color: #94a3b8;
   }
-  #fps { color: #34d399; min-width: 60px; }
 </style>
 </head>
 <body>
@@ -41,7 +40,6 @@
 <div class="row">
   <select id="demo"></select>
   <button id="run">Run</button>
-  <span id="fps"></span>
 </div>
 <canvas id="screen" width="480" height="272"></canvas>
 <div class="row pad">
@@ -69,7 +67,6 @@
   import { mount, load, listDemos, pressVirtual } from "./engine.js";
 
   const logEl = document.getElementById("log");
-  const fpsEl = document.getElementById("fps");
   const demoEl = document.getElementById("demo");
 
   function log(msg) {
@@ -77,10 +74,8 @@
     logEl.scrollTop = logEl.scrollHeight;
   }
 
-  await mount(document.getElementById("screen"), {
-    onLog: log,
-    onFps: (f) => (fpsEl.textContent = f ? f + " fps" : ""),
-  });
+  // FPS + memory are drawn on the canvas by the host (see host-web/hud.js).
+  await mount(document.getElementById("screen"), { onLog: log });
 
   const demos = await listDemos();
   if (demos.length === 0) {

--- a/site/assets/home.js
+++ b/site/assets/home.js
@@ -4,7 +4,8 @@
 import { PocketHost } from "../playground/host.js";
 
 const PG = "/pg/";
-const SHOWCASE = "settings-main";
+// The hero runs the animated gallery — L/R (or Q/E) pages between shader covers.
+const SHOWCASE = "gallery-main";
 
 function setupCodeTabs() {
   const tabs = [...document.querySelectorAll("[data-code-tab]")];
@@ -30,15 +31,12 @@ async function boot() {
 
   const canvas = document.getElementById("hero-canvas");
   if (!canvas) return;
-  const fpsEl = document.getElementById("hero-fps");
   const loadEl = document.getElementById("hero-loading");
 
+  // FPS + memory are drawn on the canvas by the host (see host-web/hud.js).
   const host = new PocketHost();
   await host.mount(canvas, {
     wasmUrl: PG + "pocketjs.wasm",
-    onFps: (f) => {
-      if (fpsEl) fpsEl.textContent = f ? f + " fps" : "";
-    },
     onError: () => {},
   });
 

--- a/site/assets/screen.css
+++ b/site/assets/screen.css
@@ -107,6 +107,38 @@
 .emu-faces .ci    { top: 32%; right: 0;    }
 .emu-faces .cross { bottom: 0;  left: 32%; }
 
+/* L / R shoulder buttons — page the gallery. Sit just below the top corners
+   so they clear the in-canvas FPS / MEM HUD pills (see host-web/hud.js). */
+.emu-shoulder {
+  position: absolute;
+  top: 7%;
+  z-index: 2;
+  width: 13%;
+  height: 8.5%;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 2.4cqw;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  color: rgba(255, 255, 255, 0.82);
+  background: rgba(20, 29, 49, 0.56);
+  border: 1px solid rgba(255, 255, 255, 0.34);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
+  transition: background 0.1s ease, transform 0.05s ease, border-color 0.1s ease;
+}
+.emu-shoulder.l { left: 3.5%; border-radius: 7px 7px 13px 5px; }
+.emu-shoulder.r { right: 3.5%; border-radius: 7px 7px 5px 13px; }
+.emu-shoulder:hover { background: rgba(30, 41, 59, 0.68); }
+.emu-shoulder.is-down,
+.emu-shoulder:active {
+  background: rgba(96, 165, 250, 0.3);
+  border-color: rgba(147, 197, 253, 0.68);
+  color: #fff;
+  transform: scale(0.94);
+}
+
 /* SELECT / START */
 .emu-sys {
   position: absolute;

--- a/site/assets/tailwind.css
+++ b/site/assets/tailwind.css
@@ -345,7 +345,6 @@
   .pg-status[data-kind="ok"] { color: #34d399; }
   .pg-status[data-kind="err"] { color: #f87171; }
   .pg-status[data-kind="busy"] { color: var(--color-brand-2); }
-  .pg-fps { font-family: var(--font-mono); font-size: 0.75rem; color: #34d399; min-width: 3.5rem; text-align: right; }
   .pg-split { flex: 1; display: grid; grid-template-columns: 1fr; min-height: 0; }
   @media (min-width: 900px) { .pg-split { grid-template-columns: 1fr 1fr; } }
   .pg-editor-pane { min-height: 0; border-bottom: 1px solid var(--color-line); overflow: hidden; }

--- a/site/build.ts
+++ b/site/build.ts
@@ -185,7 +185,7 @@ async function main() {
 
   // 4. prebuilt showcase bundles for the homepage hero. Reuse dist/ when
   //    present, and build missing bundles so the site never emits 404 demos.
-  const showcase = ["settings-main", "launcher-main", "music-main"];
+  const showcase = ["gallery-main", "settings-main", "launcher-main", "music-main"];
   for (const s of showcase) {
     copyShowcaseBundle(s);
   }

--- a/site/home.html
+++ b/site/home.html
@@ -56,6 +56,10 @@
             <div class="screen-emu">
               <canvas id="hero-canvas" width="480" height="272" tabindex="0"></canvas>
               <div id="hero-loading" class="emu-loading">booting core…</div>
+              <div class="emu-shoulders">
+                <button class="emu-shoulder l" data-btn="0x0100" aria-label="Left shoulder — previous page">L</button>
+                <button class="emu-shoulder r" data-btn="0x0200" aria-label="Right shoulder — next page">R</button>
+              </div>
               <div class="emu-dpad">
                 <svg class="emu-cross" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M36 3 H64 V36 H97 V64 H64 V97 H36 V64 H3 V36 H36 Z" fill="rgba(20,29,49,0.68)" stroke="rgba(255,255,255,0.28)" stroke-width="2.5" stroke-linejoin="round"/></svg>
                 <button class="emu-key up" data-btn="0x0010" aria-label="Up"><svg viewBox="0 0 24 24"><path d="M12 8 l6 8 h-12 z" fill="currentColor"/></svg></button>

--- a/site/playground/host.js
+++ b/site/playground/host.js
@@ -11,6 +11,7 @@
 // Both end up driving the same globalThis.frame(buttons) contract.
 
 import { createWasmUi, FB_W, FB_H } from "../../host-web/wasm-ops.js";
+import { drawHud, wasmMemoryBytes } from "../../host-web/hud.js";
 
 // spec/spec.ts BTN — the PSP button bitmask.
 export const BTN = {
@@ -44,6 +45,8 @@ export class PocketHost {
     this.onError = () => {};
     this._statsFrames = 0;
     this._statsT = 0;
+    this._hudFps = 0; // on-canvas HUD, sampled once/second (see hud.js)
+    this._hudMem = 0;
   }
 
   /** Bind to a canvas + instantiate the wasm. Call once. `wasmUrl` defaults to
@@ -110,6 +113,7 @@ export class PocketHost {
       );
     }
     this.frameCb = globalThis.frame;
+    this._hudMem = wasmMemoryBytes(this.wasm); // so MEM shows before the first 1s sample
     this._safeFrame();
     this._blit();
     this._start();
@@ -140,6 +144,7 @@ export class PocketHost {
     if (!this.wasm || !this.ctx) return;
     this.imageData.data.set(this.wasm.render());
     this.ctx.putImageData(this.imageData, 0, 0);
+    drawHud(this.ctx, FB_W, FB_H, this._hudFps, this._hudMem); // built-in on-canvas overlay
   }
 
   _tick = (now) => {
@@ -159,7 +164,10 @@ export class PocketHost {
     if (steps > 0) this._blit();
     this._statsT += dt;
     if (this._statsT >= 1000) {
-      this.onFps(Math.round((this._statsFrames * 1000) / this._statsT));
+      // Sample FPS + memory once per second for the on-canvas HUD.
+      this._hudFps = Math.round((this._statsFrames * 1000) / this._statsT);
+      this._hudMem = wasmMemoryBytes(this.wasm);
+      this.onFps(this._hudFps);
       this._statsFrames = 0;
       this._statsT = 0;
     }

--- a/site/playground/page.html
+++ b/site/playground/page.html
@@ -8,7 +8,6 @@
     </div>
     <div class="pg-tb-right">
       <span id="pg-status" class="pg-status"></span>
-      <span id="pg-fps" class="pg-fps"></span>
     </div>
   </div>
 

--- a/site/playground/playground.js
+++ b/site/playground/playground.js
@@ -33,7 +33,6 @@ async function main() {
   const canvas = $("#pg-canvas");
   const statusEl = $("#pg-status");
   const errorEl = $("#pg-error");
-  const fpsEl = $("#pg-fps");
   const demoSel = $("#pg-demo");
   const runBtn = $("#pg-run");
   const resetBtn = $("#pg-reset");
@@ -51,7 +50,6 @@ async function main() {
   const host = new PocketHost();
   await host.mount(canvas, {
     wasmUrl: PG + "pocketjs.wasm",
-    onFps: (f) => (fpsEl.textContent = f ? f + " fps" : ""),
     onError: (e) => showError(String(e && e.stack ? e.stack : e)),
     onLog: () => {},
   });

--- a/site/verify.ts
+++ b/site/verify.ts
@@ -10,10 +10,11 @@ const waitMs = Number(process.argv[3] ?? 4000);
 const probe =
   process.argv[4] ??
   `(() => {
-     const out = { status: null, error: null, fps: null, canvases: [] };
+     // FPS + memory are drawn IN the canvas now (host-web/hud.js), not in the
+     // DOM — so they show up in the canvas pixel stats below, not a text probe.
+     const out = { status: null, error: null, canvases: [] };
      const s = document.querySelector('#pg-status'); if (s) out.status = s.textContent;
      const e = document.querySelector('#pg-error'); if (e && !e.hidden) out.error = e.textContent;
-     const f = document.querySelector('#pg-fps,#hero-fps'); if (f) out.fps = f.textContent;
      for (const c of document.querySelectorAll('canvas')) {
        try {
          const ctx = c.getContext('2d');


### PR DESCRIPTION
Makes the animated **gallery** experienceable on pocketjs.dev and adds a first-class, in-canvas FPS + memory HUD to the Web host. Both are Web-host-only changes — no core/renderer/Rust touched.

## Gallery hero
- `gallery-main` is now a prebuilt showcase bundle and the **homepage hero demo** (was `settings-main`). Hero copy was already demo-neutral, so this just swaps which `.pak`/`.js` the hero boots.
- Added **L / R shoulder buttons** to the hero emulator (`LTRIGGER` `0x0100` / `RTRIGGER` `0x0200`) so visitors can page through the shader-baked covers. They auto-wire via the existing `[data-btn]` loop and sit just below the top corners to clear the HUD.

## On-canvas HUD (`host-web/hud.js`)
- New shared module drawn **directly onto the 480×272 framebuffer canvas** after `putImageData`: **FPS** top-left (green), **live wasm memory** top-right (blue), **sampled once per second** by the host loop.
- Wired into **both** Web hosts — `site/playground/host.js` (`PocketHost`, the homepage + playground host) and `host-web/engine.js` (dev host) — **on by default**, so the readout travels with the screen wherever it's embedded.
- Removed the old external-DOM FPS spans/CSS from the playground and dev host now that the readout lives in the canvas.

## Verification
- **Gallery renders byte-exact**: 6/6 `gallery-main` goldens pass (`bun test/golden.ts`).
- **80/80 unit tests** pass + contract green.
- **Headless-Chrome pass** on the built site: gallery hero renders (99.9% non-black, 0 page/console errors) with `FPS 60` / `MEM x.x MB` in the canvas corners.

<details><summary>Hero HUD (headless capture)</summary>

Top band of the live hero canvas — `FPS 60` (green, top-left) and `MEM` (blue, top-right), drawn in-canvas.
</details>

> Note: the non-gallery demo goldens (`hero`/`cards`/`library`/`settings`/`notifications`/`music`) are drifted from committed PNGs on `main` already (pre-existing, unrelated to this PR — the golden harness doesn't import any file this PR touches, and goldens aren't gated in CI). Left untouched to avoid masking a possible upstream rendering change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)