### PR TITLE
feat(site): reframe the live demo as a handheld console shell

### DIFF
--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -360,21 +360,11 @@ a.lp-btn--primary:hover {
   filter: blur(48px);
   pointer-events: none;
 }
+/* The handheld shell (.screen-emu, in screen.css) is now the frame — this
+   wrapper just holds it above the ambient glow, no second bezel. */
 .lp-stage__frame {
   position: relative;
   z-index: 1;
-  padding: clamp(9px, 1.6vw, 15px);
-  border-radius: 24px;
-  background:
-    linear-gradient(160deg, rgba(20, 29, 49, 0.92), #0b0f1a),
-    var(--panel);
-  border: 1px solid var(--line-2);
-  box-shadow:
-    0 48px 96px -44px rgba(0, 0, 0, 0.94),
-    0 0 0 1px rgba(255, 255, 255, 0.05),
-    inset 0 1px 0 rgba(255, 255, 255, 0.1),
-    0 0 0 1px rgba(56, 189, 248, 0.05),
-    inset 0 -22px 30px rgba(3, 9, 20, 0.2);
 }
 /* ---- Section scaffolding -------------------------------------------------- */
 .lp-section { padding: clamp(4.5rem, 10vw, 8rem) 0; }

--- a/site/assets/screen.css
+++ b/site/assets/screen.css
@@ -1,24 +1,96 @@
 /* ======================================================================
-   PocketJS hero — the 480×272 display, enlarged, with translucent
-   emulator-style virtual controls overlaid on top. Tapping a control drives
-   the live WebAssembly demo (see assets/home.js). No device shell.
-   Everything scoped under .screen-emu; sizes in container-query units.
+   PocketJS live demo — a compact "square handheld" shell around the live
+   480×272 display. The controls live in the DEVICE BODY (a shoulder row above
+   the screen and a control deck below it), NOT overlaid on the screen — so the
+   rendered UI is never occluded. Tapping a control drives the WebAssembly demo
+   (see assets/home.js / playground.js). Shared by the homepage hero and the
+   playground; sizes in container-query units so it scales to any width.
    ====================================================================== */
 
 .screen-emu {
-  position: relative;
-  width: 100%;
-  aspect-ratio: 480 / 272;
   container-type: inline-size;
-  border-radius: 14px;
-  overflow: hidden;
-  background: #05070d;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 3.4cqw;
+  padding: 4.4cqw 5.2cqw 5.2cqw;
+  border-radius: 8cqw / 6.4cqw;
+  /* molded device body: top-lit gradient + faint vertical brushed sheen */
+  background:
+    radial-gradient(128% 74% at 50% -12%, rgba(86, 108, 142, 0.34), transparent 56%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.014) 0 1px, transparent 1px 3px),
+    linear-gradient(180deg, #1c2536 0%, #151d2c 44%, #0e1420 100%);
   box-shadow:
-    0 0 0 1px rgba(43, 58, 85, 0.95),
-    0 28px 56px -22px rgba(0, 0, 0, 0.7),
-    0 0 42px -28px rgba(56, 189, 248, 0.24);
+    inset 0 1.5px 0 rgba(255, 255, 255, 0.11),
+    inset 0 -3.4cqw 5cqw rgba(3, 8, 18, 0.4),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.045),
+    0 40px 80px -38px rgba(0, 0, 0, 0.92),
+    0 0 0 1px rgba(43, 58, 85, 0.85);
 }
-.screen-emu canvas {
+
+/* ---- shoulder row (L / brand / R) ----------------------------------------- */
+.emu-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 0.6cqw;
+}
+.emu-brand {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 2.3cqw;
+  font-weight: 700;
+  letter-spacing: 0.34em;
+  text-transform: uppercase;
+  color: rgba(148, 163, 184, 0.42);
+  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
+  padding-left: 0.34em; /* optical centering vs. the letter-spacing */
+  user-select: none;
+}
+.emu-shoulder {
+  min-width: 15cqw;
+  padding: 1.5cqw 3cqw;
+  cursor: pointer;
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 2.6cqw;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: rgba(226, 232, 240, 0.82);
+  background: linear-gradient(180deg, #26324a, #161e2e);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  border-radius: 2.4cqw;
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.17),
+    0 2px 5px rgba(0, 0, 0, 0.42);
+  transition: background 0.1s ease, transform 0.06s ease, box-shadow 0.1s ease, color 0.1s ease;
+}
+.emu-shoulder.l { border-top-left-radius: 4.4cqw; }   /* wrap-around bumper hint */
+.emu-shoulder.r { border-top-right-radius: 4.4cqw; }
+.emu-shoulder:hover { background: linear-gradient(180deg, #2c3a56, #1a2334); color: #eef2f8; }
+.emu-shoulder.is-down,
+.emu-shoulder:active {
+  background: linear-gradient(180deg, #2f66b8, #2551a0);
+  border-color: rgba(147, 197, 253, 0.6);
+  color: #fff;
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.5);
+  transform: translateY(1px);
+}
+
+/* ---- the recessed screen -------------------------------------------------- */
+.emu-screen {
+  position: relative;
+  aspect-ratio: 480 / 272;
+  border-radius: 2.4cqw;
+  overflow: hidden;
+  background: #04060c;
+  /* black bezel ring + inner recess shadow (screen sits below the surface) */
+  box-shadow:
+    inset 0 0 0 1px rgba(0, 0, 0, 0.9),
+    inset 0 2px 12px rgba(0, 0, 0, 0.85),
+    0 0 0 1.1cqw #090d16,
+    0 0 0 1.5cqw rgba(255, 255, 255, 0.04),
+    0 0 30px -6px rgba(56, 189, 248, 0.16);
+}
+.emu-screen canvas {
   display: block;
   width: 100%;
   height: 100%;
@@ -35,18 +107,29 @@
   color: #5b6b86;
 }
 
-/* translucent control clusters — bottom corners, like a phone emulator */
-.emu-dpad,
-.emu-faces {
-  position: absolute;
-  bottom: 5%;
-  width: 22%;
-  aspect-ratio: 1;
-  z-index: 2;
+/* ---- control deck: d-pad · SELECT/START · face buttons -------------------- */
+.emu-deck {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 3cqw;
+  padding: 0.6cqw 1.4cqw 0;
 }
-.emu-dpad { left: 3.5%; }
-.emu-faces { right: 3.5%; }
+.emu-dpad {
+  position: relative;
+  justify-self: start;
+  width: 30cqw;
+  aspect-ratio: 1;
+}
+.emu-faces {
+  position: relative;
+  justify-self: end;
+  width: 30cqw;
+  aspect-ratio: 1;
+}
 
+/* shared key base (individual d-pad arms + face buttons are absolutely placed
+   inside their own square container) */
 .emu-key {
   position: absolute;
   border: 0;
@@ -55,115 +138,92 @@
   display: grid;
   place-items: center;
   color: rgba(255, 255, 255, 0.92);
-  background: rgba(20, 29, 49, 0.56);
-  border: 1px solid rgba(255, 255, 255, 0.4);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  transition: background 0.1s ease, transform 0.05s ease, border-color 0.1s ease;
+  background: linear-gradient(180deg, #2a3852, #131a28);
+  border: 1px solid rgba(255, 255, 255, 0.1);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), 0 2px 5px rgba(0, 0, 0, 0.45);
+  transition: background 0.1s ease, transform 0.06s ease, border-color 0.1s ease, box-shadow 0.1s ease;
 }
 .emu-key svg { width: 46%; height: 46%; }
-.emu-key:hover { background: rgba(30, 41, 59, 0.68); }
+.emu-key:hover { background: linear-gradient(180deg, #33445f, #18202f); }
 .emu-key.is-down,
 .emu-key:active {
-  background: rgba(96, 165, 250, 0.3);
-  border-color: rgba(147, 197, 253, 0.68);
-  transform: scale(0.9);
+  background: linear-gradient(180deg, #2f66b8, #2551a0);
+  border-color: rgba(147, 197, 253, 0.66);
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.5);
+  transform: translateY(1px) scale(0.97);
 }
 
-/* d-pad — ONE connected cross (inline SVG), transparent arm hit-areas over it */
+/* d-pad — ONE molded cross (inline SVG, recolored via CSS), transparent arm
+   hit-areas over it */
 .emu-cross {
   position: absolute;
   inset: 0;
   width: 100%;
   height: 100%;
   overflow: visible;
-  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.3));
+  filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.5));
 }
+.emu-cross path {
+  fill: #0f1728;
+  stroke: rgba(255, 255, 255, 0.12);
+} /* CSS overrides the inline fill/stroke attributes */
 .emu-dpad .emu-key {
   background: transparent;
   border: 0;
   box-shadow: none;
-  color: rgba(255, 255, 255, 0.92);
+  color: rgba(226, 232, 240, 0.86);
 }
 .emu-dpad .emu-key svg { width: 42%; height: 42%; }
 .emu-dpad .up    { top: 2%;    left: 35%; width: 30%; height: 34%; }
 .emu-dpad .down  { bottom: 2%; left: 35%; width: 30%; height: 34%; }
 .emu-dpad .left  { left: 2%;   top: 35%;  height: 30%; width: 34%; }
 .emu-dpad .right { right: 2%;  top: 35%;  height: 30%; width: 34%; }
+.emu-dpad .emu-key:hover { background: rgba(96, 165, 250, 0.12); border-radius: 8%; }
 .emu-dpad .emu-key.is-down,
 .emu-dpad .emu-key:active {
-  background: rgba(96, 165, 250, 0.24);
-  border-radius: 6px;
+  background: rgba(96, 165, 250, 0.32);
+  border-radius: 8%;
   transform: none;
 }
 
 /* face buttons diamond */
-.emu-faces .emu-key { width: 36%; aspect-ratio: 1; border-radius: 50%; }
+.emu-faces .emu-key { width: 34%; aspect-ratio: 1; border-radius: 50%; }
 .emu-faces .tri,
 .emu-faces .sq,
 .emu-faces .ci,
 .emu-faces .cross { color: rgba(255, 255, 255, 0.92); }
-.emu-faces .tri   { top: 0;     left: 32%; }
-.emu-faces .sq    { top: 32%; left: 0;     }
-.emu-faces .ci    { top: 32%; right: 0;    }
-.emu-faces .cross { bottom: 0;  left: 32%; }
+.emu-faces .tri   { top: 0;    left: 33%; }
+.emu-faces .sq    { top: 33%;  left: 0;   }
+.emu-faces .ci    { top: 33%;  right: 0;  }
+.emu-faces .cross { bottom: 0; left: 33%; }
 
-/* L / R shoulder buttons — page the gallery. Sit just below the top corners
-   so they clear the in-canvas FPS / MEM HUD pills (see host-web/hud.js). */
-.emu-shoulder {
-  position: absolute;
-  top: 7%;
-  z-index: 2;
-  width: 13%;
-  height: 8.5%;
-  display: grid;
-  place-items: center;
-  cursor: pointer;
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 2.4cqw;
-  font-weight: 700;
-  letter-spacing: 0.06em;
-  color: rgba(255, 255, 255, 0.82);
-  background: rgba(20, 29, 49, 0.56);
-  border: 1px solid rgba(255, 255, 255, 0.34);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.1);
-  transition: background 0.1s ease, transform 0.05s ease, border-color 0.1s ease;
-}
-.emu-shoulder.l { left: 3.5%; border-radius: 7px 7px 13px 5px; }
-.emu-shoulder.r { right: 3.5%; border-radius: 7px 7px 5px 13px; }
-.emu-shoulder:hover { background: rgba(30, 41, 59, 0.68); }
-.emu-shoulder.is-down,
-.emu-shoulder:active {
-  background: rgba(96, 165, 250, 0.3);
-  border-color: rgba(147, 197, 253, 0.68);
-  color: #fff;
-  transform: scale(0.94);
-}
-
-/* SELECT / START */
+/* SELECT / START — center of the deck */
 .emu-sys {
-  position: absolute;
-  bottom: 6%;
-  left: 50%;
-  transform: translateX(-50%);
-  z-index: 2;
+  justify-self: center;
   display: flex;
+  flex-direction: column;
+  align-items: center;
   gap: 2cqw;
 }
 .emu-sys-btn {
-  border: 0;
   cursor: pointer;
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 2.2cqw;
-  letter-spacing: 0.08em;
-  padding: 1cqw 2.4cqw;
+  font-size: 2cqw;
+  font-weight: 600;
+  letter-spacing: 0.1em;
+  padding: 1.3cqw 3.2cqw;
   border-radius: 999px;
-  color: rgba(255, 255, 255, 0.82);
-  background: rgba(20, 29, 49, 0.56);
-  border: 1px solid rgba(255, 255, 255, 0.34);
-  transition: background 0.1s ease;
+  color: rgba(203, 213, 225, 0.8);
+  background: linear-gradient(180deg, #232f45, #141c2b);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.13), 0 2px 4px rgba(0, 0, 0, 0.4);
+  transition: background 0.1s ease, transform 0.06s ease, color 0.1s ease, box-shadow 0.1s ease;
 }
+.emu-sys-btn:hover { background: linear-gradient(180deg, #293751, #1a2333); color: #e4ebf5; }
 .emu-sys-btn.is-down,
 .emu-sys-btn:active {
-  background: rgba(96, 165, 250, 0.3);
+  background: linear-gradient(180deg, #2f66b8, #2551a0);
   color: #fff;
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.5);
+  transform: translateY(1px);
 }

--- a/site/home.html
+++ b/site/home.html
@@ -54,28 +54,33 @@
           <div class="lp-stage__glow" aria-hidden="true"></div>
           <div class="lp-stage__frame">
             <div class="screen-emu">
-              <canvas id="hero-canvas" width="480" height="272" tabindex="0"></canvas>
-              <div id="hero-loading" class="emu-loading">booting core…</div>
-              <div class="emu-shoulders">
+              <div class="emu-top">
                 <button class="emu-shoulder l" data-btn="0x0100" aria-label="Left shoulder — previous page">L</button>
+                <span class="emu-brand" aria-hidden="true">PocketJS</span>
                 <button class="emu-shoulder r" data-btn="0x0200" aria-label="Right shoulder — next page">R</button>
               </div>
-              <div class="emu-dpad">
-                <svg class="emu-cross" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M36 3 H64 V36 H97 V64 H64 V97 H36 V64 H3 V36 H36 Z" fill="rgba(20,29,49,0.68)" stroke="rgba(255,255,255,0.28)" stroke-width="2.5" stroke-linejoin="round"/></svg>
-                <button class="emu-key up" data-btn="0x0010" aria-label="Up"><svg viewBox="0 0 24 24"><path d="M12 8 l6 8 h-12 z" fill="currentColor"/></svg></button>
-                <button class="emu-key down" data-btn="0x0040" aria-label="Down"><svg viewBox="0 0 24 24"><path d="M12 16 l6 -8 h-12 z" fill="currentColor"/></svg></button>
-                <button class="emu-key left" data-btn="0x0080" aria-label="Left"><svg viewBox="0 0 24 24"><path d="M8 12 l8 -6 v12 z" fill="currentColor"/></svg></button>
-                <button class="emu-key right" data-btn="0x0020" aria-label="Right"><svg viewBox="0 0 24 24"><path d="M16 12 l-8 -6 v12 z" fill="currentColor"/></svg></button>
+              <div class="emu-screen">
+                <canvas id="hero-canvas" width="480" height="272" tabindex="0"></canvas>
+                <div id="hero-loading" class="emu-loading">booting core…</div>
               </div>
-              <div class="emu-faces">
-                <button class="emu-key tri" data-btn="0x1000" aria-label="Triangle"><svg viewBox="0 0 24 24"><path d="M12 5 L19.5 18.5 L4.5 18.5 Z" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linejoin="round"/></svg></button>
-                <button class="emu-key sq" data-btn="0x8000" aria-label="Square"><svg viewBox="0 0 24 24"><rect x="5.5" y="5.5" width="13" height="13" rx="1.6" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
-                <button class="emu-key ci" data-btn="0x2000" aria-label="Circle"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
-                <button class="emu-key cross" data-btn="0x4000" aria-label="Cross"><svg viewBox="0 0 24 24"><path d="M6.5 6.5 L17.5 17.5 M17.5 6.5 L6.5 17.5" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/></svg></button>
-              </div>
-              <div class="emu-sys">
-                <button class="emu-sys-btn" data-btn="0x0001">SELECT</button>
-                <button class="emu-sys-btn" data-btn="0x0008">START</button>
+              <div class="emu-deck">
+                <div class="emu-dpad">
+                  <svg class="emu-cross" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M36 3 H64 V36 H97 V64 H64 V97 H36 V64 H3 V36 H36 Z" fill="rgba(20,29,49,0.68)" stroke="rgba(255,255,255,0.28)" stroke-width="2.5" stroke-linejoin="round"/></svg>
+                  <button class="emu-key up" data-btn="0x0010" aria-label="Up"><svg viewBox="0 0 24 24"><path d="M12 8 l6 8 h-12 z" fill="currentColor"/></svg></button>
+                  <button class="emu-key down" data-btn="0x0040" aria-label="Down"><svg viewBox="0 0 24 24"><path d="M12 16 l6 -8 h-12 z" fill="currentColor"/></svg></button>
+                  <button class="emu-key left" data-btn="0x0080" aria-label="Left"><svg viewBox="0 0 24 24"><path d="M8 12 l8 -6 v12 z" fill="currentColor"/></svg></button>
+                  <button class="emu-key right" data-btn="0x0020" aria-label="Right"><svg viewBox="0 0 24 24"><path d="M16 12 l-8 -6 v12 z" fill="currentColor"/></svg></button>
+                </div>
+                <div class="emu-sys">
+                  <button class="emu-sys-btn" data-btn="0x0001">SELECT</button>
+                  <button class="emu-sys-btn" data-btn="0x0008">START</button>
+                </div>
+                <div class="emu-faces">
+                  <button class="emu-key tri" data-btn="0x1000" aria-label="Triangle"><svg viewBox="0 0 24 24"><path d="M12 5 L19.5 18.5 L4.5 18.5 Z" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linejoin="round"/></svg></button>
+                  <button class="emu-key sq" data-btn="0x8000" aria-label="Square"><svg viewBox="0 0 24 24"><rect x="5.5" y="5.5" width="13" height="13" rx="1.6" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
+                  <button class="emu-key ci" data-btn="0x2000" aria-label="Circle"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
+                  <button class="emu-key cross" data-btn="0x4000" aria-label="Cross"><svg viewBox="0 0 24 24"><path d="M6.5 6.5 L17.5 17.5 M17.5 6.5 L6.5 17.5" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/></svg></button>
+                </div>
               </div>
             </div>
           </div>

--- a/site/playground/page.html
+++ b/site/playground/page.html
@@ -19,23 +19,32 @@
     <div class="pg-preview-pane">
       <div class="w-full max-w-[620px]">
         <div class="screen-emu" aria-label="480×272 screen, rendered live by the Rust core in WebAssembly">
-          <canvas id="pg-canvas" width="480" height="272" tabindex="0"></canvas>
-          <div class="emu-dpad">
-            <svg class="emu-cross" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M36 3 H64 V36 H97 V64 H64 V97 H36 V64 H3 V36 H36 Z" fill="rgba(51,66,97,0.55)" stroke="rgba(255,255,255,0.34)" stroke-width="2.5" stroke-linejoin="round"/></svg>
-            <button class="emu-key up" data-btn="0x0010" aria-label="Up"><svg viewBox="0 0 24 24"><path d="M12 8 l6 8 h-12 z" fill="currentColor"/></svg></button>
-            <button class="emu-key down" data-btn="0x0040" aria-label="Down"><svg viewBox="0 0 24 24"><path d="M12 16 l6 -8 h-12 z" fill="currentColor"/></svg></button>
-            <button class="emu-key left" data-btn="0x0080" aria-label="Left"><svg viewBox="0 0 24 24"><path d="M8 12 l8 -6 v12 z" fill="currentColor"/></svg></button>
-            <button class="emu-key right" data-btn="0x0020" aria-label="Right"><svg viewBox="0 0 24 24"><path d="M16 12 l-8 -6 v12 z" fill="currentColor"/></svg></button>
+          <div class="emu-top">
+            <button class="emu-shoulder l" data-btn="0x0100" aria-label="Left shoulder (L trigger)">L</button>
+            <span class="emu-brand" aria-hidden="true">PocketJS</span>
+            <button class="emu-shoulder r" data-btn="0x0200" aria-label="Right shoulder (R trigger)">R</button>
           </div>
-          <div class="emu-faces">
-            <button class="emu-key tri" data-btn="0x1000" aria-label="Triangle"><svg viewBox="0 0 24 24"><path d="M12 5 L19.5 18.5 L4.5 18.5 Z" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linejoin="round"/></svg></button>
-            <button class="emu-key sq" data-btn="0x8000" aria-label="Square"><svg viewBox="0 0 24 24"><rect x="5.5" y="5.5" width="13" height="13" rx="1.6" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
-            <button class="emu-key ci" data-btn="0x2000" aria-label="Circle"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
-            <button class="emu-key cross" data-btn="0x4000" aria-label="Cross"><svg viewBox="0 0 24 24"><path d="M6.5 6.5 L17.5 17.5 M17.5 6.5 L6.5 17.5" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/></svg></button>
+          <div class="emu-screen">
+            <canvas id="pg-canvas" width="480" height="272" tabindex="0"></canvas>
           </div>
-          <div class="emu-sys">
-            <button class="emu-sys-btn" data-btn="0x0001">SELECT</button>
-            <button class="emu-sys-btn" data-btn="0x0008">START</button>
+          <div class="emu-deck">
+            <div class="emu-dpad">
+              <svg class="emu-cross" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M36 3 H64 V36 H97 V64 H64 V97 H36 V64 H3 V36 H36 Z" fill="rgba(51,66,97,0.55)" stroke="rgba(255,255,255,0.34)" stroke-width="2.5" stroke-linejoin="round"/></svg>
+              <button class="emu-key up" data-btn="0x0010" aria-label="Up"><svg viewBox="0 0 24 24"><path d="M12 8 l6 8 h-12 z" fill="currentColor"/></svg></button>
+              <button class="emu-key down" data-btn="0x0040" aria-label="Down"><svg viewBox="0 0 24 24"><path d="M12 16 l6 -8 h-12 z" fill="currentColor"/></svg></button>
+              <button class="emu-key left" data-btn="0x0080" aria-label="Left"><svg viewBox="0 0 24 24"><path d="M8 12 l8 -6 v12 z" fill="currentColor"/></svg></button>
+              <button class="emu-key right" data-btn="0x0020" aria-label="Right"><svg viewBox="0 0 24 24"><path d="M16 12 l-8 -6 v12 z" fill="currentColor"/></svg></button>
+            </div>
+            <div class="emu-sys">
+              <button class="emu-sys-btn" data-btn="0x0001">SELECT</button>
+              <button class="emu-sys-btn" data-btn="0x0008">START</button>
+            </div>
+            <div class="emu-faces">
+              <button class="emu-key tri" data-btn="0x1000" aria-label="Triangle"><svg viewBox="0 0 24 24"><path d="M12 5 L19.5 18.5 L4.5 18.5 Z" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linejoin="round"/></svg></button>
+              <button class="emu-key sq" data-btn="0x8000" aria-label="Square"><svg viewBox="0 0 24 24"><rect x="5.5" y="5.5" width="13" height="13" rx="1.6" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
+              <button class="emu-key ci" data-btn="0x2000" aria-label="Circle"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
+              <button class="emu-key cross" data-btn="0x4000" aria-label="Cross"><svg viewBox="0 0 24 24"><path d="M6.5 6.5 L17.5 17.5 M17.5 6.5 L6.5 17.5" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/></svg></button>
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
The virtual controls were drawn **on top of** the 480×272 canvas and occluded parts of the rendered UI (the demo's bottom hint bar, bottom rows). This moves them **out of the screen** into a compact **square-handheld** body, so nothing covers the demo.

## What changed
- **Shared `.screen-emu` is now a device shell** (`screen.css`): a textured, top-lit molded body (~square, ratio ≈ 0.93) with
  - a **shoulder row** above the screen — `L` · `POCKETJS` wordmark · `R`
  - a **recessed black-bezel screen** in the middle (the canvas, with only the built-in FPS/MEM HUD on it)
  - a **control deck** below — d-pad · SELECT/START · face-button diamond
- **Material quality (质感):** beveled keys (inset highlight + drop shadow, press = push-in), a molded d-pad cross (recolored via CSS over the inline SVG), a recessed screen with a bezel ring, and a faint brushed sheen. Its own dark handheld look — **not a PSP replica**.
- **Markup** (`home.html` + `playground/page.html`) moved to the `.emu-top` / `.emu-screen` / `.emu-deck` structure. The **playground gains on-screen L/R shoulders** too. All `data-btn` attributes preserved → the existing `[data-btn]` auto-wiring is unchanged.
- **Neutralized** the homepage's outer `.lp-stage__frame` so the shell is the only frame (no double bezel).

## Verification (headless Chrome, both pages)
- Homepage hero + playground both render the handheld with **controls fully clear of the screen** — the demo's bottom hint bar is no longer covered.
- **Input intact after the DOM restructure:** synthetic press events latch/clear on the R shoulder, d-pad, and face buttons; 12 buttons wired.
- No page/console errors; canvas renders (gallery hero 99.9% non-black, playground demo compiles `ok`).

Both changes are **presentational only** (CSS + HTML markup) — no JS/build/runtime changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)