### PR TITLE
feat(site): landscape handheld layout with flanking controls

### DIFF
--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -346,7 +346,7 @@ a.lp-btn--primary:hover {
 .lp-stage {
   position: relative;
   width: 100%;
-  max-width: 660px;
+  max-width: 760px;
   margin: clamp(2.75rem, 7vw, 5rem) auto 0;
 }
 .lp-stage__glow {

--- a/site/assets/screen.css
+++ b/site/assets/screen.css
@@ -1,94 +1,104 @@
 /* ======================================================================
-   PocketJS live demo — a compact "square handheld" shell around the live
-   480×272 display. The controls live in the DEVICE BODY (a shoulder row above
-   the screen and a control deck below it), NOT overlaid on the screen — so the
-   rendered UI is never occluded. Tapping a control drives the WebAssembly demo
-   (see assets/home.js / playground.js). Shared by the homepage hero and the
-   playground; sizes in container-query units so it scales to any width.
+   PocketJS live demo — a LANDSCAPE handheld shell around the 480×272 display.
+   Controls FLANK the screen (d-pad + analog nub on the left, face-button
+   diamond on the right), L/R at the top corners, SELECT/START below — so the
+   rendered UI is never occluded. Warm amber control accents over a dark navy
+   body, thin border. Shared by the homepage hero and the playground; sizes in
+   container-query units so it scales to any width. Tapping a control drives
+   the WebAssembly demo (assets/home.js / playground.js).
    ====================================================================== */
 
 .screen-emu {
+  --emu-amber: #e6a94b;
+  --emu-amber-hi: #ffc766;
   container-type: inline-size;
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  gap: 3.4cqw;
-  padding: 4.4cqw 5.2cqw 5.2cqw;
-  border-radius: 8cqw / 6.4cqw;
-  /* molded device body: top-lit gradient + faint vertical brushed sheen */
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  grid-template-rows: auto auto auto;
+  grid-template-areas:
+    "sl    .        sr"
+    "dpad  screen   faces"
+    "sys   sys      sys";
+  align-items: center;
+  column-gap: 2.4cqw;
+  row-gap: 1.6cqw;
+  padding: 1.8cqw 2cqw 2cqw;
+  border-radius: 3.6cqw;
+  /* molded navy body: top-lit gradient + faint vertical brushed sheen */
   background:
-    radial-gradient(128% 74% at 50% -12%, rgba(86, 108, 142, 0.34), transparent 56%),
-    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.014) 0 1px, transparent 1px 3px),
-    linear-gradient(180deg, #1c2536 0%, #151d2c 44%, #0e1420 100%);
+    radial-gradient(122% 60% at 50% -8%, rgba(96, 116, 156, 0.32), transparent 58%),
+    repeating-linear-gradient(90deg, rgba(255, 255, 255, 0.013) 0 1px, transparent 1px 3px),
+    linear-gradient(180deg, #2a3150 0%, #20263c 46%, #161b2b 100%);
   box-shadow:
-    inset 0 1.5px 0 rgba(255, 255, 255, 0.11),
-    inset 0 -3.4cqw 5cqw rgba(3, 8, 18, 0.4),
-    inset 0 0 0 1px rgba(255, 255, 255, 0.045),
-    0 40px 80px -38px rgba(0, 0, 0, 0.92),
-    0 0 0 1px rgba(43, 58, 85, 0.85);
+    inset 0 1.5px 0 rgba(255, 255, 255, 0.1),
+    inset 0 -3cqw 5cqw rgba(3, 8, 18, 0.4),
+    inset 0 0 0 1px rgba(255, 255, 255, 0.04),
+    0 40px 80px -40px rgba(0, 0, 0, 0.92),
+    0 0 0 1px rgba(43, 58, 85, 0.8);
 }
 
-/* ---- shoulder row (L / brand / R) ----------------------------------------- */
-.emu-top {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  padding: 0 0.6cqw;
-}
-.emu-brand {
-  font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 2.3cqw;
-  font-weight: 700;
-  letter-spacing: 0.34em;
-  text-transform: uppercase;
-  color: rgba(148, 163, 184, 0.42);
-  text-shadow: 0 1px 0 rgba(0, 0, 0, 0.55);
-  padding-left: 0.34em; /* optical centering vs. the letter-spacing */
-  user-select: none;
-}
+/* ---- shoulder bumpers (top corners) --------------------------------------- */
 .emu-shoulder {
-  min-width: 15cqw;
-  padding: 1.5cqw 3cqw;
+  min-width: 12cqw;
+  padding: 1.2cqw 2.6cqw;
   cursor: pointer;
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 2.6cqw;
+  font-size: 2.5cqw;
   font-weight: 700;
-  letter-spacing: 0.14em;
-  color: rgba(226, 232, 240, 0.82);
-  background: linear-gradient(180deg, #26324a, #161e2e);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  border-radius: 2.4cqw;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.17),
-    0 2px 5px rgba(0, 0, 0, 0.42);
-  transition: background 0.1s ease, transform 0.06s ease, box-shadow 0.1s ease, color 0.1s ease;
+  letter-spacing: 0.16em;
+  color: var(--emu-amber);
+  background: linear-gradient(180deg, #333b5a, #1d2338);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  border-radius: 1.8cqw;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 2px 4px rgba(0, 0, 0, 0.4);
+  transition: color 0.1s ease, background 0.1s ease, transform 0.06s ease, box-shadow 0.1s ease, border-color 0.1s ease;
 }
-.emu-shoulder.l { border-top-left-radius: 4.4cqw; }   /* wrap-around bumper hint */
-.emu-shoulder.r { border-top-right-radius: 4.4cqw; }
-.emu-shoulder:hover { background: linear-gradient(180deg, #2c3a56, #1a2334); color: #eef2f8; }
-.emu-shoulder.is-down,
-.emu-shoulder:active {
-  background: linear-gradient(180deg, #2f66b8, #2551a0);
-  border-color: rgba(147, 197, 253, 0.6);
-  color: #fff;
-  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.5);
-  transform: translateY(1px);
+.emu-shoulder.l { grid-area: sl; justify-self: start; border-top-left-radius: 3cqw; }
+.emu-shoulder.r { grid-area: sr; justify-self: end; border-top-right-radius: 3cqw; }
+.emu-shoulder:hover { background: linear-gradient(180deg, #3a4363, #222941); }
+
+/* ---- d-pad + analog nub (left) -------------------------------------------- */
+.emu-pad {
+  grid-area: dpad;
+  justify-self: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2.6cqw;
+}
+.emu-dpad {
+  position: relative;
+  width: 16cqw;
+  aspect-ratio: 1;
+}
+.emu-nub {
+  width: 6.4cqw;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: radial-gradient(58% 54% at 42% 34%, #3d4a68, #212a41 68%, #131a29);
+  border: 1px solid rgba(255, 255, 255, 0.07);
+  box-shadow:
+    inset 0 1.5px 2px rgba(255, 255, 255, 0.16),
+    inset 0 -2px 4px rgba(0, 0, 0, 0.5),
+    0 2px 5px rgba(0, 0, 0, 0.45);
 }
 
-/* ---- the recessed screen -------------------------------------------------- */
+/* ---- the recessed screen (center) ----------------------------------------- */
 .emu-screen {
+  grid-area: screen;
   position: relative;
+  width: 100%;
   aspect-ratio: 480 / 272;
-  border-radius: 2.4cqw;
+  border-radius: 1.6cqw;
   overflow: hidden;
   background: #04060c;
-  /* black bezel ring + inner recess shadow (screen sits below the surface) */
+  /* slim dark bezel ring + inner recess + cyan screen glow */
   box-shadow:
     inset 0 0 0 1px rgba(0, 0, 0, 0.9),
-    inset 0 2px 12px rgba(0, 0, 0, 0.85),
-    0 0 0 1.1cqw #090d16,
-    0 0 0 1.5cqw rgba(255, 255, 255, 0.04),
-    0 0 30px -6px rgba(56, 189, 248, 0.16);
+    inset 0 2px 10px rgba(0, 0, 0, 0.82),
+    0 0 0 0.7cqw #0c1120,
+    0 0 0 1cqw rgba(255, 255, 255, 0.03),
+    0 0 28px -4px rgba(56, 189, 248, 0.3);
 }
 .emu-screen canvas {
   display: block;
@@ -107,29 +117,7 @@
   color: #5b6b86;
 }
 
-/* ---- control deck: d-pad · SELECT/START · face buttons -------------------- */
-.emu-deck {
-  display: grid;
-  grid-template-columns: 1fr auto 1fr;
-  align-items: center;
-  gap: 3cqw;
-  padding: 0.6cqw 1.4cqw 0;
-}
-.emu-dpad {
-  position: relative;
-  justify-self: start;
-  width: 30cqw;
-  aspect-ratio: 1;
-}
-.emu-faces {
-  position: relative;
-  justify-self: end;
-  width: 30cqw;
-  aspect-ratio: 1;
-}
-
-/* shared key base (individual d-pad arms + face buttons are absolutely placed
-   inside their own square container) */
+/* ---- shared key base (d-pad arms + face buttons) -------------------------- */
 .emu-key {
   position: absolute;
   border: 0;
@@ -137,24 +125,24 @@
   padding: 0;
   display: grid;
   place-items: center;
-  color: rgba(255, 255, 255, 0.92);
-  background: linear-gradient(180deg, #2a3852, #131a28);
-  border: 1px solid rgba(255, 255, 255, 0.1);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18), 0 2px 5px rgba(0, 0, 0, 0.45);
-  transition: background 0.1s ease, transform 0.06s ease, border-color 0.1s ease, box-shadow 0.1s ease;
+  color: rgba(226, 232, 240, 0.9);
+  background: linear-gradient(180deg, #333b5a, #1a2033);
+  border: 1px solid rgba(255, 255, 255, 0.09);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.16), 0 2px 5px rgba(0, 0, 0, 0.45);
+  transition: color 0.1s ease, background 0.1s ease, transform 0.06s ease, border-color 0.1s ease, box-shadow 0.1s ease;
 }
 .emu-key svg { width: 46%; height: 46%; }
-.emu-key:hover { background: linear-gradient(180deg, #33445f, #18202f); }
+.emu-key:hover { background: linear-gradient(180deg, #3c456524, #1d2534); }
 .emu-key.is-down,
 .emu-key:active {
-  background: linear-gradient(180deg, #2f66b8, #2551a0);
-  border-color: rgba(147, 197, 253, 0.66);
-  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.5);
+  color: var(--emu-amber-hi);
+  border-color: var(--emu-amber);
+  box-shadow: inset 0 2px 6px rgba(0, 0, 0, 0.5), 0 0 9px rgba(230, 169, 75, 0.4);
   transform: translateY(1px) scale(0.97);
 }
 
-/* d-pad — ONE molded cross (inline SVG, recolored via CSS), transparent arm
-   hit-areas over it */
+/* d-pad — ONE molded cross (inline SVG, recolored via CSS), amber arrows over
+   transparent arm hit-areas */
 .emu-cross {
   position: absolute;
   inset: 0;
@@ -164,66 +152,72 @@
   filter: drop-shadow(0 2px 3px rgba(0, 0, 0, 0.5));
 }
 .emu-cross path {
-  fill: #0f1728;
-  stroke: rgba(255, 255, 255, 0.12);
+  fill: #2c3350;
+  stroke: rgba(255, 255, 255, 0.1);
 } /* CSS overrides the inline fill/stroke attributes */
 .emu-dpad .emu-key {
   background: transparent;
   border: 0;
   box-shadow: none;
-  color: rgba(226, 232, 240, 0.86);
+  color: var(--emu-amber);
 }
 .emu-dpad .emu-key svg { width: 42%; height: 42%; }
 .emu-dpad .up    { top: 2%;    left: 35%; width: 30%; height: 34%; }
 .emu-dpad .down  { bottom: 2%; left: 35%; width: 30%; height: 34%; }
 .emu-dpad .left  { left: 2%;   top: 35%;  height: 30%; width: 34%; }
 .emu-dpad .right { right: 2%;  top: 35%;  height: 30%; width: 34%; }
-.emu-dpad .emu-key:hover { background: rgba(96, 165, 250, 0.12); border-radius: 8%; }
+.emu-dpad .emu-key:hover { background: rgba(230, 169, 75, 0.12); border-radius: 10%; }
 .emu-dpad .emu-key.is-down,
 .emu-dpad .emu-key:active {
-  background: rgba(96, 165, 250, 0.32);
-  border-radius: 8%;
+  background: rgba(230, 169, 75, 0.28);
+  color: var(--emu-amber-hi);
+  border-radius: 10%;
+  box-shadow: none;
   transform: none;
 }
 
-/* face buttons diamond */
-.emu-faces .emu-key { width: 34%; aspect-ratio: 1; border-radius: 50%; }
-.emu-faces .tri,
-.emu-faces .sq,
-.emu-faces .ci,
-.emu-faces .cross { color: rgba(255, 255, 255, 0.92); }
-.emu-faces .tri   { top: 0;    left: 33%; }
-.emu-faces .sq    { top: 33%;  left: 0;   }
-.emu-faces .ci    { top: 33%;  right: 0;  }
-.emu-faces .cross { bottom: 0; left: 33%; }
+/* face buttons diamond (right) */
+.emu-faces {
+  grid-area: faces;
+  justify-self: center;
+  position: relative;
+  width: 16cqw;
+  aspect-ratio: 1;
+}
+.emu-faces .emu-key { width: 40%; aspect-ratio: 1; border-radius: 50%; }
+.emu-faces .tri   { top: 0;    left: 30%; }
+.emu-faces .sq    { top: 30%;  left: 0;   }
+.emu-faces .ci    { top: 30%;  right: 0;  }
+.emu-faces .cross { bottom: 0; left: 30%; }
 
-/* SELECT / START — center of the deck */
+/* SELECT / START — centered below the screen */
 .emu-sys {
+  grid-area: sys;
   justify-self: center;
   display: flex;
-  flex-direction: column;
+  flex-direction: row;
   align-items: center;
-  gap: 2cqw;
+  gap: 3cqw;
 }
 .emu-sys-btn {
   cursor: pointer;
   font-family: var(--font-mono, ui-monospace, monospace);
-  font-size: 2cqw;
-  font-weight: 600;
-  letter-spacing: 0.1em;
-  padding: 1.3cqw 3.2cqw;
+  font-size: 1.9cqw;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  color: var(--emu-amber);
+  padding: 1.2cqw 3.4cqw;
   border-radius: 999px;
-  color: rgba(203, 213, 225, 0.8);
-  background: linear-gradient(180deg, #232f45, #141c2b);
-  border: 1px solid rgba(255, 255, 255, 0.09);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.13), 0 2px 4px rgba(0, 0, 0, 0.4);
-  transition: background 0.1s ease, transform 0.06s ease, color 0.1s ease, box-shadow 0.1s ease;
+  background: linear-gradient(180deg, #2c3450, #1a2033);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 2px 4px rgba(0, 0, 0, 0.4);
+  transition: color 0.1s ease, background 0.1s ease, transform 0.06s ease, box-shadow 0.1s ease, border-color 0.1s ease;
 }
-.emu-sys-btn:hover { background: linear-gradient(180deg, #293751, #1a2333); color: #e4ebf5; }
+.emu-sys-btn:hover { background: linear-gradient(180deg, #323b58, #1e2539); }
 .emu-sys-btn.is-down,
 .emu-sys-btn:active {
-  background: linear-gradient(180deg, #2f66b8, #2551a0);
-  color: #fff;
-  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.5);
+  color: var(--emu-amber-hi);
+  border-color: var(--emu-amber);
+  box-shadow: inset 0 2px 5px rgba(0, 0, 0, 0.5), 0 0 9px rgba(230, 169, 75, 0.4);
   transform: translateY(1px);
 }

--- a/site/home.html
+++ b/site/home.html
@@ -54,16 +54,9 @@
           <div class="lp-stage__glow" aria-hidden="true"></div>
           <div class="lp-stage__frame">
             <div class="screen-emu">
-              <div class="emu-top">
-                <button class="emu-shoulder l" data-btn="0x0100" aria-label="Left shoulder — previous page">L</button>
-                <span class="emu-brand" aria-hidden="true">PocketJS</span>
-                <button class="emu-shoulder r" data-btn="0x0200" aria-label="Right shoulder — next page">R</button>
-              </div>
-              <div class="emu-screen">
-                <canvas id="hero-canvas" width="480" height="272" tabindex="0"></canvas>
-                <div id="hero-loading" class="emu-loading">booting core…</div>
-              </div>
-              <div class="emu-deck">
+              <button class="emu-shoulder l" data-btn="0x0100" aria-label="Left shoulder — previous page">L</button>
+              <button class="emu-shoulder r" data-btn="0x0200" aria-label="Right shoulder — next page">R</button>
+              <div class="emu-pad">
                 <div class="emu-dpad">
                   <svg class="emu-cross" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M36 3 H64 V36 H97 V64 H64 V97 H36 V64 H3 V36 H36 Z" fill="rgba(20,29,49,0.68)" stroke="rgba(255,255,255,0.28)" stroke-width="2.5" stroke-linejoin="round"/></svg>
                   <button class="emu-key up" data-btn="0x0010" aria-label="Up"><svg viewBox="0 0 24 24"><path d="M12 8 l6 8 h-12 z" fill="currentColor"/></svg></button>
@@ -71,16 +64,21 @@
                   <button class="emu-key left" data-btn="0x0080" aria-label="Left"><svg viewBox="0 0 24 24"><path d="M8 12 l8 -6 v12 z" fill="currentColor"/></svg></button>
                   <button class="emu-key right" data-btn="0x0020" aria-label="Right"><svg viewBox="0 0 24 24"><path d="M16 12 l-8 -6 v12 z" fill="currentColor"/></svg></button>
                 </div>
-                <div class="emu-sys">
-                  <button class="emu-sys-btn" data-btn="0x0001">SELECT</button>
-                  <button class="emu-sys-btn" data-btn="0x0008">START</button>
-                </div>
-                <div class="emu-faces">
-                  <button class="emu-key tri" data-btn="0x1000" aria-label="Triangle"><svg viewBox="0 0 24 24"><path d="M12 5 L19.5 18.5 L4.5 18.5 Z" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linejoin="round"/></svg></button>
-                  <button class="emu-key sq" data-btn="0x8000" aria-label="Square"><svg viewBox="0 0 24 24"><rect x="5.5" y="5.5" width="13" height="13" rx="1.6" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
-                  <button class="emu-key ci" data-btn="0x2000" aria-label="Circle"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
-                  <button class="emu-key cross" data-btn="0x4000" aria-label="Cross"><svg viewBox="0 0 24 24"><path d="M6.5 6.5 L17.5 17.5 M17.5 6.5 L6.5 17.5" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/></svg></button>
-                </div>
+                <span class="emu-nub" aria-hidden="true"></span>
+              </div>
+              <div class="emu-screen">
+                <canvas id="hero-canvas" width="480" height="272" tabindex="0"></canvas>
+                <div id="hero-loading" class="emu-loading">booting core…</div>
+              </div>
+              <div class="emu-faces">
+                <button class="emu-key tri" data-btn="0x1000" aria-label="Triangle"><svg viewBox="0 0 24 24"><path d="M12 5 L19.5 18.5 L4.5 18.5 Z" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linejoin="round"/></svg></button>
+                <button class="emu-key sq" data-btn="0x8000" aria-label="Square"><svg viewBox="0 0 24 24"><rect x="5.5" y="5.5" width="13" height="13" rx="1.6" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
+                <button class="emu-key ci" data-btn="0x2000" aria-label="Circle"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
+                <button class="emu-key cross" data-btn="0x4000" aria-label="Cross"><svg viewBox="0 0 24 24"><path d="M6.5 6.5 L17.5 17.5 M17.5 6.5 L6.5 17.5" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/></svg></button>
+              </div>
+              <div class="emu-sys">
+                <button class="emu-sys-btn" data-btn="0x0001">SELECT</button>
+                <button class="emu-sys-btn" data-btn="0x0008">START</button>
               </div>
             </div>
           </div>

--- a/site/playground/page.html
+++ b/site/playground/page.html
@@ -19,15 +19,9 @@
     <div class="pg-preview-pane">
       <div class="w-full max-w-[620px]">
         <div class="screen-emu" aria-label="480×272 screen, rendered live by the Rust core in WebAssembly">
-          <div class="emu-top">
-            <button class="emu-shoulder l" data-btn="0x0100" aria-label="Left shoulder (L trigger)">L</button>
-            <span class="emu-brand" aria-hidden="true">PocketJS</span>
-            <button class="emu-shoulder r" data-btn="0x0200" aria-label="Right shoulder (R trigger)">R</button>
-          </div>
-          <div class="emu-screen">
-            <canvas id="pg-canvas" width="480" height="272" tabindex="0"></canvas>
-          </div>
-          <div class="emu-deck">
+          <button class="emu-shoulder l" data-btn="0x0100" aria-label="Left shoulder (L trigger)">L</button>
+          <button class="emu-shoulder r" data-btn="0x0200" aria-label="Right shoulder (R trigger)">R</button>
+          <div class="emu-pad">
             <div class="emu-dpad">
               <svg class="emu-cross" viewBox="0 0 100 100" preserveAspectRatio="none" aria-hidden="true"><path d="M36 3 H64 V36 H97 V64 H64 V97 H36 V64 H3 V36 H36 Z" fill="rgba(51,66,97,0.55)" stroke="rgba(255,255,255,0.34)" stroke-width="2.5" stroke-linejoin="round"/></svg>
               <button class="emu-key up" data-btn="0x0010" aria-label="Up"><svg viewBox="0 0 24 24"><path d="M12 8 l6 8 h-12 z" fill="currentColor"/></svg></button>
@@ -35,16 +29,20 @@
               <button class="emu-key left" data-btn="0x0080" aria-label="Left"><svg viewBox="0 0 24 24"><path d="M8 12 l8 -6 v12 z" fill="currentColor"/></svg></button>
               <button class="emu-key right" data-btn="0x0020" aria-label="Right"><svg viewBox="0 0 24 24"><path d="M16 12 l-8 -6 v12 z" fill="currentColor"/></svg></button>
             </div>
-            <div class="emu-sys">
-              <button class="emu-sys-btn" data-btn="0x0001">SELECT</button>
-              <button class="emu-sys-btn" data-btn="0x0008">START</button>
-            </div>
-            <div class="emu-faces">
-              <button class="emu-key tri" data-btn="0x1000" aria-label="Triangle"><svg viewBox="0 0 24 24"><path d="M12 5 L19.5 18.5 L4.5 18.5 Z" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linejoin="round"/></svg></button>
-              <button class="emu-key sq" data-btn="0x8000" aria-label="Square"><svg viewBox="0 0 24 24"><rect x="5.5" y="5.5" width="13" height="13" rx="1.6" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
-              <button class="emu-key ci" data-btn="0x2000" aria-label="Circle"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
-              <button class="emu-key cross" data-btn="0x4000" aria-label="Cross"><svg viewBox="0 0 24 24"><path d="M6.5 6.5 L17.5 17.5 M17.5 6.5 L6.5 17.5" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/></svg></button>
-            </div>
+            <span class="emu-nub" aria-hidden="true"></span>
+          </div>
+          <div class="emu-screen">
+            <canvas id="pg-canvas" width="480" height="272" tabindex="0"></canvas>
+          </div>
+          <div class="emu-faces">
+            <button class="emu-key tri" data-btn="0x1000" aria-label="Triangle"><svg viewBox="0 0 24 24"><path d="M12 5 L19.5 18.5 L4.5 18.5 Z" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linejoin="round"/></svg></button>
+            <button class="emu-key sq" data-btn="0x8000" aria-label="Square"><svg viewBox="0 0 24 24"><rect x="5.5" y="5.5" width="13" height="13" rx="1.6" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
+            <button class="emu-key ci" data-btn="0x2000" aria-label="Circle"><svg viewBox="0 0 24 24"><circle cx="12" cy="12" r="7.2" fill="none" stroke="currentColor" stroke-width="2.4"/></svg></button>
+            <button class="emu-key cross" data-btn="0x4000" aria-label="Cross"><svg viewBox="0 0 24 24"><path d="M6.5 6.5 L17.5 17.5 M17.5 6.5 L6.5 17.5" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round"/></svg></button>
+          </div>
+          <div class="emu-sys">
+            <button class="emu-sys-btn" data-btn="0x0001">SELECT</button>
+            <button class="emu-sys-btn" data-btn="0x0008">START</button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Follow-up to the handheld shell: switch from a **controls-below** layout to the intended **landscape** handheld where the controls **flank** the screen.

## Layout (per reference)
- **D-pad + a decorative analog nub** on the **left**, **face-button diamond** on the **right**, **L/R** bumpers at the top corners, **SELECT/START** centered **below** the screen. The screen stays in the middle — nothing overlaps the rendered UI.
- **Narrower border (收窄):** tighter body padding + gaps and slimmer control columns, so the screen fills more of the device (hero screen ≈ 412px wide, up from 362) and the outer frame is thin. Device is now ~1.9:1 landscape.
- **Look:** warm **amber** accents on the L/R · d-pad · SELECT/START, a **cyan screen glow**, over a dark navy molded body — its own handheld, not a PSP replica.

## Markup
`home.html` + `playground/page.html` flattened to grid children — `L`, `R`, `.emu-pad` (d-pad + `.emu-nub`), `.emu-screen`, `.emu-faces`, `.emu-sys`. Dropped the brand wordmark and the `emu-top`/`emu-deck` wrappers. All `data-btn` attributes preserved. `.lp-stage` widened to 760px.

## Verification (headless Chrome, both pages)
- Renders as a landscape handheld with controls clear of the screen; no horizontal overflow.
- Every control type still latches on press — **L/R, d-pad, face buttons, SELECT/START** (12 buttons wired); the analog **nub is decorative** (no `data-btn`).
- Canvas renders (gallery hero 100% non-black; playground demo compiles `ok`), HUD intact.

Presentational only (CSS + HTML markup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)