### PR TITLE
feat(site): add device-targets section to the landing page

### DIFF
--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -520,6 +520,122 @@ a.lp-btn--primary:hover {
   color: #cbd5e1;
 }
 
+/* ---- Targets / devices ---------------------------------------------------- */
+.lp-targets {
+  border-top: 1px solid var(--line);
+  background:
+    radial-gradient(40% 52% at 100% 6%, rgba(96, 165, 250, 0.05), transparent 70%),
+    radial-gradient(38% 48% at 0% 12%, rgba(157, 229, 199, 0.035), transparent 72%);
+}
+.lp-targets__grid {
+  list-style: none;
+  padding: 0;
+  margin: clamp(2.5rem, 5vw, 3.75rem) auto 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(288px, 1fr));
+  gap: 1.1rem;
+}
+.lp-target {
+  position: relative;
+  display: flex;
+  gap: 1rem;
+  padding: 1.4rem 1.5rem;
+  border-radius: 16px;
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.62), rgba(9, 12, 20, 0.9)),
+    var(--bg-2);
+  transition: transform 0.3s ease, border-color 0.3s ease, box-shadow 0.3s ease;
+}
+.lp-target:hover {
+  transform: translateY(-3px);
+  border-color: var(--line-2);
+  box-shadow: 0 24px 48px -32px rgba(3, 9, 20, 0.9), inset 0 1px 0 rgba(255, 255, 255, 0.05);
+}
+.lp-target.is-live {
+  border-color: rgba(157, 229, 199, 0.34);
+  background:
+    linear-gradient(180deg, rgba(22, 43, 39, 0.5), rgba(9, 14, 16, 0.9)),
+    var(--bg-2);
+}
+.lp-target.is-more {
+  border-style: dashed;
+  background: rgba(9, 12, 20, 0.42);
+}
+.lp-target__ic {
+  flex: none;
+  display: inline-grid;
+  place-items: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  color: #dbeafe;
+  background: rgba(20, 29, 49, 0.78);
+  border: 1px solid rgba(43, 58, 85, 0.95);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+}
+.lp-target.is-live .lp-target__ic {
+  color: #bff3dd;
+  border-color: rgba(157, 229, 199, 0.42);
+}
+.lp-target.is-more .lp-target__ic {
+  color: var(--muted);
+  background: transparent;
+  border-style: dashed;
+}
+.lp-target__body { min-width: 0; }
+.lp-target__head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.45rem 0.7rem;
+  margin-bottom: 0.4rem;
+}
+.lp-target__name {
+  font-size: 1.08rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--ink);
+}
+.lp-target__status {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.42rem;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  padding: 0.2rem 0.58rem;
+  border-radius: 999px;
+  border: 1px solid var(--line-2);
+  color: var(--muted);
+  background: rgba(20, 29, 49, 0.6);
+  white-space: nowrap;
+}
+.lp-target__status::before {
+  content: "";
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: currentColor;
+}
+.lp-target__status--live {
+  color: #9de5c7;
+  border-color: rgba(157, 229, 199, 0.42);
+  background: rgba(22, 43, 39, 0.62);
+}
+.lp-target__status--live::before {
+  box-shadow: 0 0 8px rgba(157, 229, 199, 0.85);
+}
+.lp-target__status--open {
+  color: #a9b7cb;
+  border-style: dashed;
+}
+.lp-target__desc {
+  font-size: 0.9rem;
+  line-height: 1.55;
+  color: var(--ink-2);
+}
+
 /* ---- Split (code) section ------------------------------------------------- */
 .lp-split {
   display: grid;

--- a/site/home.html
+++ b/site/home.html
@@ -252,6 +252,79 @@
       </div>
     </section>
 
+    <!-- TARGETS -->
+    <section class="lp-section lp-targets">
+      <div class="lp-container">
+        <div class="lp-secthead lp-reveal">
+          <span class="lp-kicker">One core, many devices</span>
+          <h2 class="lp-h2">The same core, retargeted device by device.</h2>
+          <p class="lp-lead">The <span class="lp-mono">no_std</span> Rust core needs only a framebuffer and a few buttons, so it travels. The PSP path ships today; the rest come online as their native backends land — and the list keeps growing.</p>
+        </div>
+        <ul class="lp-targets__grid" aria-label="Supported and planned devices">
+          <li class="lp-target is-live lp-reveal">
+            <span class="lp-target__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="10" rx="3"/><circle cx="6.5" cy="12" r="1.6"/><path d="M15.5 10v4M13.5 12h4"/></svg></span>
+            <div class="lp-target__body">
+              <div class="lp-target__head">
+                <h3 class="lp-target__name">Sony PSP</h3>
+                <span class="lp-target__status lp-target__status--live">Available now</span>
+              </div>
+              <p class="lp-target__desc">The reference target — a MIPS handheld rendering through the native core today.</p>
+            </div>
+          </li>
+          <li class="lp-target lp-reveal">
+            <span class="lp-target__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="3" width="16" height="8" rx="1.6"/><rect x="4" y="13" width="16" height="8" rx="1.6"/><path d="M9 17h6"/></svg></span>
+            <div class="lp-target__body">
+              <div class="lp-target__head">
+                <h3 class="lp-target__name">Nintendo 3DS</h3>
+                <span class="lp-target__status">Coming soon</span>
+              </div>
+              <p class="lp-target__desc">A dual-screen ARM11 handheld, wired into the same layout and draw pipeline.</p>
+            </div>
+          </li>
+          <li class="lp-target lp-reveal">
+            <span class="lp-target__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="6" y="2" width="12" height="20" rx="3"/><path d="M10.5 5h3"/><path d="M10 18.5h4"/></svg></span>
+            <div class="lp-target__body">
+              <div class="lp-target__head">
+                <h3 class="lp-target__name">iOS</h3>
+                <span class="lp-target__status">Coming soon</span>
+              </div>
+              <p class="lp-target__desc">iPhone and iPad through a native rendering backend for the portable core.</p>
+            </div>
+          </li>
+          <li class="lp-target lp-reveal">
+            <span class="lp-target__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M6 11a6 6 0 0 1 12 0z"/><path d="M6 11h12v6a1 1 0 0 1-1 1H7a1 1 0 0 1-1-1z"/><path d="M8.5 7 7 5M15.5 7 17 5"/><path d="M4 13v3M20 13v3"/><circle cx="9.6" cy="8.6" r=".55" fill="currentColor" stroke="none"/><circle cx="14.4" cy="8.6" r=".55" fill="currentColor" stroke="none"/></svg></span>
+            <div class="lp-target__body">
+              <div class="lp-target__head">
+                <h3 class="lp-target__name">Android</h3>
+                <span class="lp-target__status">Coming soon</span>
+              </div>
+              <p class="lp-target__desc">Phones, tablets and gaming handhelds running the same compiled UI.</p>
+            </div>
+          </li>
+          <li class="lp-target lp-reveal">
+            <span class="lp-target__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="13" rx="2"/><rect x="7.5" y="8" width="5" height="5" rx="1"/><path d="M15 9.5h2.5M15 12.5h2.5"/><path d="M7 17v3M11 17v3M15 17v3"/></svg></span>
+            <div class="lp-target__body">
+              <div class="lp-target__head">
+                <h3 class="lp-target__name">Embedded Linux</h3>
+                <span class="lp-target__status">Coming soon</span>
+              </div>
+              <p class="lp-target__desc">Framebuffer boards, kiosks and single-board computers with a few inputs.</p>
+            </div>
+          </li>
+          <li class="lp-target is-more lp-reveal">
+            <span class="lp-target__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><path d="M12 5v14M5 12h14"/></svg></span>
+            <div class="lp-target__body">
+              <div class="lp-target__head">
+                <h3 class="lp-target__name">…and beyond</h3>
+                <span class="lp-target__status lp-target__status--open">On the roadmap</span>
+              </div>
+              <p class="lp-target__desc">Anything with a framebuffer and a few buttons. Bring a backend and the core follows.</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </section>
+
     <!-- CLOSING CTA -->
     <section class="lp-section lp-cta">
       <div class="lp-cta__glow" aria-hidden="true"></div>


### PR DESCRIPTION
## What

Adds a new **"One core, many devices"** section to the pocketjs.dev landing page (`site/home.html`), placed between the feature grid and the closing CTA. It pays off the existing *"one portable core"* feature card by showing the hardware that core targets.

## Devices shown

| Device | Status |
| --- | --- |
| Sony PSP | **Available now** (mint accent) |
| Nintendo 3DS | Coming soon |
| iOS | Coming soon |
| Android | Coming soon |
| Embedded Linux | Coming soon |
| …and beyond | On the roadmap (dashed "wildcard" card) |

The trailing *"…and beyond"* card keeps the list illustrative rather than exhaustive — the core targets "anything with a framebuffer and a few buttons."

## Implementation notes

- New markup reuses the existing `.lp-*` design system (kicker / section head / scroll-reveal), plus a small `.lp-targets*` block in `site/assets/home.css` that mirrors the feature-card gradient/hover/border language.
- The live PSP card and its status pill carry a mint accent; coming-soon cards stay muted; the wildcard card is dashed.
- Each device has a distinct inline SVG glyph (handheld / dual-screen / phone / robot / board / plus).
- No changes to the JSON-LD `runtimePlatform` — unshipped targets are deliberately kept out of structured data.

## Verification

Rendered the page headlessly (Chrome) at desktop and mobile widths and screenshotted the section:
- Desktop: 3-column grid, correct accents and icons.
- Mobile: collapses to a single column (same `repeat(auto-fit, minmax(288px,1fr))` pattern as the shipping `.lp-grid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)