### PR TITLE
fix(site): render Vue Vapor text in playground

### DIFF
--- a/demos/cards/app.vue-vapor.tsx
+++ b/demos/cards/app.vue-vapor.tsx
@@ -11,6 +11,10 @@ interface Card {
   bar: string;
 }
 
+function propValue<T>(value: T | (() => T)): T {
+  return typeof value === "function" ? (value as () => T)() : value;
+}
+
 const CARDS: Card[] = [
   {
     title: "Layout",
@@ -38,7 +42,8 @@ const CARDS: Card[] = [
   },
 ];
 
-const Detail = defineVaporComponent((props: { card: Card }) => {
+const Detail = defineVaporComponent((_props: unknown, { attrs }: { attrs: { card: Card | (() => Card) } }) => {
+  const card = () => propValue(attrs.card);
   let el: NodeMirror | undefined;
   onMounted(() => {
     if (el) spring(el, "translateY", 0);
@@ -51,10 +56,10 @@ const Detail = defineVaporComponent((props: { card: Card }) => {
       style={{ translateY: 22 }}
       class="flex-row items-center gap-3 p-3 rounded-xl shadow-md bg-white border-slate-200"
     >
-      <View class={props.card.bar} />
+      <View class={card().bar} />
       <View class="flex-col gap-1">
-        <Text class="text-sm text-slate-950 font-bold">{props.card.title}</Text>
-        <Text class="text-xs text-slate-600">{props.card.detail}</Text>
+        <Text class="text-sm text-slate-950 font-bold">{card().title}</Text>
+        <Text class="text-xs text-slate-600">{card().detail}</Text>
       </View>
     </View>
   );

--- a/src/components-vue-vapor.ts
+++ b/src/components-vue-vapor.ts
@@ -18,6 +18,7 @@ import { getOverlayRoot } from "./overlay.ts";
 import {
   createCommentNode,
   createElement,
+  createTextNode,
   detachNode,
   insertNode,
   setProp,
@@ -84,8 +85,14 @@ function valueOf<T>(value: T): T {
   return typeof value === "function" ? (value as () => T)() : value;
 }
 
-function callbackOf<T extends (...args: never[]) => unknown>(value: unknown): T | undefined {
-  return typeof value === "function" ? (value as T) : undefined;
+function callbackOf<T extends (...args: any[]) => unknown>(value: unknown): T | undefined {
+  if (typeof value !== "function") return undefined;
+  return ((...args: unknown[]) => {
+    const resolved = (value as (...innerArgs: unknown[]) => unknown)(...args);
+    return typeof resolved === "function"
+      ? (resolved as (...innerArgs: unknown[]) => unknown)(...args)
+      : resolved;
+  }) as T;
 }
 
 function booleanOption(value: unknown): boolean | undefined {
@@ -96,13 +103,41 @@ function booleanOption(value: unknown): boolean | undefined {
 function assignRef(refValue: unknown, node: NodeMirror | null): void {
   const ref = refValue as NodeRef;
   if (!ref) return;
-  if (typeof ref === "function") ref(node);
-  else ref.current = node;
+  if (typeof ref === "function") {
+    const resolved = (ref as (node: NodeMirror | null) => unknown)(node);
+    if (typeof resolved === "function") resolved(node);
+  } else {
+    ref.current = node;
+  }
 }
 
 function slotDefault(slots: SlotBag, ...args: unknown[]): unknown {
-  if (typeof slots === "function") return slots(...args);
-  return slots?.default?.(...args);
+  return withNativeTextDocument(() => {
+    if (typeof slots === "function") return slots(...args);
+    return slots?.default?.(...args);
+  });
+}
+
+function withNativeTextDocument<T>(fn: () => T): T {
+  const doc = (globalThis as { document?: unknown }).document as
+    | {
+        createTextNode?: (value?: string) => unknown;
+        createComment?: (value?: string) => unknown;
+      }
+    | undefined;
+  if (!doc) return fn();
+  const prevCreateTextNode = doc.createTextNode;
+  const prevCreateComment = doc.createComment;
+  try {
+    doc.createTextNode = (value = "") => createTextNode(String(value));
+    doc.createComment = (value = "") => createCommentNode(String(value));
+    return fn();
+  } finally {
+    if (prevCreateTextNode) doc.createTextNode = prevCreateTextNode;
+    else delete doc.createTextNode;
+    if (prevCreateComment) doc.createComment = prevCreateComment;
+    else delete doc.createComment;
+  }
 }
 
 function normalizeVaporBlock(block: unknown): unknown | null {
@@ -155,7 +190,7 @@ function cleanProps(props: Record<string, unknown>, omit: Set<string>): HostProp
     if (omit.has(key)) continue;
     if (key === "class" || key === "className") out[key] = normalizeClassValue(props[key]);
     else if (key === "style") out[key] = normalizeStyleValue(props[key]);
-    else if (key === "onPress" || key === "on:press") out[key] = props[key];
+    else if (key === "onPress" || key === "on:press") out[key] = callbackOf<() => void>(props[key]);
     else out[key] = valueOf(props[key]);
   }
   if (out.class == null && out.className != null) out.class = out.className;


### PR DESCRIPTION
## Summary

- route Vue Vapor slot text/comment creation through the PocketJS native document while evaluating primitive children
- unwrap Vue Vapor callback props at call time so focus/press and Gallery callbacks work in the playground
- adjust the Vue Vapor cards detail panel to read dynamic card props through attrs getter semantics

## Validation

- `bunx tsc --noEmit --pretty false`
- `bun site/build.ts`
- `bun scripts/build.ts demos/cards/app.vue-vapor.tsx --framework=vue-vapor`
- all Vue Vapor demo CLI build loop for `hero cards music notifications stats settings library gallery`
- `bun run test`
- local Playwright playground matrix: 8 demos x 2 frameworks, all ok/nonblank/no console errors
- local Playwright interaction smoke: Vue Vapor cards detail opens; Vue Vapor gallery R trigger flips without console errors