### PR TITLE
fix(playground): restore gallery demos and polish shell HUD

### DIFF
--- a/demos/gallery/app.vue-vapor.tsx
+++ b/demos/gallery/app.vue-vapor.tsx
@@ -48,23 +48,47 @@ const TILE_LABEL = [
 const TILE_FRAME =
   "w-[68] h-[68] rounded-lg items-center justify-center bg-slate-900 border-slate-700 focus:scale-110 focus:border-white transition-transform duration-150 ease-out";
 
-const Loading = defineVaporComponent((props: { title: string }) => {
+function propValue<T>(value: T | (() => T)): T {
+  return typeof value === "function" ? (value as () => T)() : value;
+}
+
+function callbackProp<T extends (...args: any[]) => unknown>(value: T | (() => T)): T {
+  if (typeof value !== "function") return value;
+  if (value.length === 0) {
+    const resolved = (value as () => T)();
+    if (typeof resolved === "function") return resolved;
+  }
+  return value as T;
+}
+
+const Loading = defineVaporComponent((_props: { title: string }, { attrs }) => {
   const frame = createSpriteAnimation(SPINNER_FRAMES, { frameStep: 3 });
+  const title = () => propValue(attrs.title as string | (() => string));
   return (
     <View class="flex-col items-center justify-center gap-2 grow">
       <Image class="w-9 h-9" src={frame.value} />
-      <Text class="text-xs text-slate-300 tracking-wide">LOADING {props.title}</Text>
+      <Text class="text-xs text-slate-300 tracking-wide">LOADING {title()}</Text>
     </View>
   );
 });
 
-const TileGrid = defineVaporComponent((props: { page: number; current: number; onSelect: (label: string) => void }) => {
-  const start = props.page * TILES_PER_PAGE;
+const TileGrid = defineVaporComponent((
+  _props: {
+    page: number | (() => number);
+    current: number | (() => number);
+    onSelect: ((label: string) => void) | (() => (label: string) => void);
+  },
+  { attrs },
+) => {
+  const page = () => propValue(attrs.page as number | (() => number));
+  const current = () => propValue(attrs.current as number | (() => number));
+  const onSelect = () => callbackProp(attrs.onSelect as ((label: string) => void) | (() => (label: string) => void));
+  const start = page() * TILES_PER_PAGE;
   const srcs = TILE_SRCS.slice(start, start + TILES_PER_PAGE);
   const refs: (NodeMirror | undefined)[] = [];
 
   watchEffect(() => {
-    if (props.current === props.page) focusNode(refs[0] ?? null);
+    if (current() === page()) focusNode(refs[0] ?? null);
   });
 
   return (
@@ -77,7 +101,7 @@ const TileGrid = defineVaporComponent((props: { page: number; current: number; o
             }}
             class={TILE_FRAME}
             focusable
-            onPress={() => props.onSelect(TILE_LABEL[start + k])}
+            onPress={() => onSelect()(TILE_LABEL[start + k])}
           >
             <Sprite class="w-[64] h-[64] rounded-lg" sprite={src} />
           </View>
@@ -88,20 +112,30 @@ const TileGrid = defineVaporComponent((props: { page: number; current: number; o
   );
 });
 
-const Page = defineVaporComponent((props: { index: number; current: number; onSelect: (label: string) => void }) => {
-  const isCurrent = () => props.current === props.index;
+const Page = defineVaporComponent((
+  _props: {
+    index: number | (() => number);
+    current: number | (() => number);
+    onSelect: ((label: string) => void) | (() => (label: string) => void);
+  },
+  { attrs },
+) => {
+  const index = () => propValue(attrs.index as number | (() => number));
+  const current = () => propValue(attrs.current as number | (() => number));
+  const onSelect = () => callbackProp(attrs.onSelect as ((label: string) => void) | (() => (label: string) => void));
+  const isCurrent = () => current() === index();
   return (
-    <View class={PAGE_BG[props.index]}>
+    <View class={PAGE_BG[index()]}>
       <View class="w-full flex-row items-end justify-between px-4 pt-2 pb-1">
         <View class="flex-col">
-          <Text class="text-xs text-slate-300 tracking-wide">{PAGE_SUB[props.index]}</Text>
-          <Text class="text-xl text-white font-bold">{PAGE_TITLE[props.index]}</Text>
+          <Text class="text-xs text-slate-300 tracking-wide">{PAGE_SUB[index()]}</Text>
+          <Text class="text-xl text-white font-bold">{PAGE_TITLE[index()]}</Text>
         </View>
-        <Text class="text-xs text-slate-300">{PAGE_COUNT_LABEL[props.index]}</Text>
+        <Text class="text-xs text-slate-300">{PAGE_COUNT_LABEL[index()]}</Text>
       </View>
       <FocusScope active={isCurrent} restoreFocus={false} class="grow w-full flex-col items-center justify-center">
-        <Lazy when={true} reveal={REVEAL_FRAMES} fallback={() => <Loading title={PAGE_TITLE[props.index]} />}>
-          {() => <TileGrid page={props.index} current={props.current} onSelect={props.onSelect} />}
+        <Lazy when={true} reveal={REVEAL_FRAMES} fallback={() => <Loading title={PAGE_TITLE[index()]} />}>
+          {() => <TileGrid page={index()} current={current()} onSelect={onSelect()} />}
         </Lazy>
       </FocusScope>
       <View class="w-full h-9 shrink-0" />

--- a/host-web/hud.js
+++ b/host-web/hud.js
@@ -21,11 +21,11 @@ function fmtMem(bytes) {
 /** Draw one pill (translucent plate + colored label) anchored at a corner. */
 function pill(ctx, x, y, text, color, alignRight) {
   const w = Math.ceil(ctx.measureText(text).width);
-  const px = alignRight ? x - w - 6 : x;
-  ctx.fillStyle = "rgba(8, 11, 20, 0.6)";
-  ctx.fillRect(px, y, w + 6, 13);
+  const px = alignRight ? x - w - 8 : x;
+  ctx.fillStyle = "rgba(8, 11, 20, 0.68)";
+  ctx.fillRect(px, y, w + 8, 16);
   ctx.fillStyle = color;
-  ctx.fillText(text, px + 3, y + 2);
+  ctx.fillText(text, px + 4, y + 2);
 }
 
 /**
@@ -36,7 +36,7 @@ function pill(ctx, x, y, text, color, alignRight) {
  */
 export function drawHud(ctx, w, _h, fps, memBytes) {
   ctx.save();
-  ctx.font = "700 9px ui-monospace, SFMono-Regular, Menlo, monospace";
+  ctx.font = "700 11px ui-monospace, SFMono-Regular, Menlo, monospace";
   ctx.textBaseline = "top";
   pill(ctx, 3, 3, "FPS " + (fps | 0), "#34d399", false); // top-left
   pill(ctx, w - 3, 3, "MEM " + fmtMem(memBytes), "#60a5fa", true); // top-right

--- a/site/assets/screen.css
+++ b/site/assets/screen.css
@@ -48,12 +48,10 @@
 }
 
 /* ---- shoulder bumpers — flush in the top corners, outer corner radius EXACTLY
-   matching the body's so the two curves coincide (no double curve). Kept flush
-   at top:0 / left|right:0; the button is tall enough that CSS never scales the
-   3.6cqw corner down. Body border-radius is 3.6cqw (keep them equal). --------- */
+   matching the body's so the two curves coincide (no double curve). --------- */
 .emu-shoulder {
   position: absolute;
-  top: 0.6cqw; /* nudged in a few px; radius below drops to stay concentric */
+  top: 0cqw;
   min-width: 11cqw;
   padding: 1cqw 2.4cqw;
   cursor: pointer;
@@ -68,8 +66,8 @@
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.15), 0 2px 4px rgba(0, 0, 0, 0.4);
   transition: color 0.1s ease, background 0.1s ease, transform 0.06s ease, box-shadow 0.1s ease, border-color 0.1s ease;
 }
-.emu-shoulder.l { left: 0.6cqw; border-top-left-radius: var(--emu-radius); border-bottom-left-radius: 0.4cqw; }
-.emu-shoulder.r { right: 0.6cqw; border-top-right-radius: var(--emu-radius); border-bottom-right-radius: 0.4cqw; }
+.emu-shoulder.l { left: 0cqw; border-top-left-radius: var(--emu-radius); border-bottom-left-radius: 0.4cqw; }
+.emu-shoulder.r { right: 0cqw; border-top-right-radius: var(--emu-radius); border-bottom-right-radius: 0.4cqw; }
 .emu-shoulder:hover { background: linear-gradient(180deg, #3a4363, #222941); }
 
 /* ---- d-pad (left) --------------------------------------------------------- */

--- a/site/build.ts
+++ b/site/build.ts
@@ -157,6 +157,27 @@ async function bundleSolid(outfile: string) {
   console.log(`  ${outfile}  (${(code.length / 1024).toFixed(0)} KiB)`);
 }
 
+async function bundleSolidUniversal(outfile: string) {
+  const entry = Bun.resolveSync("solid-js/universal", ROOT);
+  const res = await Bun.build({
+    entrypoints: [entry],
+    target: "browser",
+    format: "esm",
+    conditions: ["browser"],
+    define: { "process.env.NODE_ENV": '"production"' },
+    external: ["solid-js"],
+    minify: true,
+    sourcemap: "none",
+  });
+  if (!res.success) {
+    for (const l of res.logs) console.error(String(l));
+    throw new Error("bundle failed: solid-js/universal");
+  }
+  const code = await res.outputs[0].text();
+  write(outfile, code);
+  console.log(`  ${outfile}  (${(code.length / 1024).toFixed(0)} KiB)`);
+}
+
 async function bundleVueVapor(outfile: string) {
   const entry = Bun.resolveSync("vue/dist/vue.runtime-with-vapor.esm-browser.prod.js", ROOT);
   const res = await Bun.build({
@@ -289,9 +310,10 @@ async function main() {
 
   // 1. bundles
   await bundleSolid("pg/solid.js");
+  await bundleSolidUniversal("pg/solid-universal.js");
   await bundleVueVapor("pg/vue-vapor.js");
   writeVueVaporHelpers();
-  await bundle("playground/runtime-entry.ts", "pg/runtime.js");
+  await bundle("playground/runtime-entry.ts", "pg/runtime.js", { external: ["solid-js", "solid-js/universal"] });
   await bundle("playground/runtime-vue-vapor-entry.ts", "pg/runtime-vue-vapor.js", { external: ["vue"] });
   await bundle("playground/compiler-entry.ts", "pg/compiler.js", { shims: true, prelude: PROCESS_PRELUDE });
   await bundle("playground/playground.js", "pg/playground.bundle.js");
@@ -434,6 +456,7 @@ async function compileCss() {
 const IMPORT_MAP = `<script type="importmap">
 {"imports":{
   "solid-js":"/pg/solid.js",
+  "solid-js/universal":"/pg/solid-universal.js",
   "vue":"/pg/vue-vapor.js",
   "/vue-jsx-vapor/props":"/pg/vue-jsx-vapor/props.js",
   "/vue-jsx-vapor/vdom":"/pg/vue-jsx-vapor/vdom.js",

--- a/src/components-vue-vapor.ts
+++ b/src/components-vue-vapor.ts
@@ -141,6 +141,9 @@ function withNativeTextDocument<T>(fn: () => T): T {
 }
 
 function normalizeVaporBlock(block: unknown): unknown | null {
+  while (typeof block === "function" && block.length === 0) {
+    block = withNativeTextDocument(() => (block as () => unknown)());
+  }
   if (block == null || typeof block === "boolean") return null;
   if (!Array.isArray(block)) return block;
   const out: unknown[] = [];

--- a/src/renderer-vue-vapor.ts
+++ b/src/renderer-vue-vapor.ts
@@ -68,6 +68,9 @@ export interface RenderRoot {
 }
 
 function normalizeVaporBlock(block: unknown): unknown | undefined {
+  while (typeof block === "function" && block.length === 0) {
+    block = (block as () => unknown)();
+  }
   if (block == null || typeof block === "boolean") return undefined;
   if (!Array.isArray(block)) return block;
   const out: unknown[] = [];


### PR DESCRIPTION
## What changed

- Enlarged the canvas HUD FPS and memory pills for better legibility.
- Made the game shell shoulder bumpers flush to their top corners using `0cqw` offsets.
- Fixed playground Solid runtime bundling so demo code and the native renderer share the same Solid reactive graph.
- Fixed Vue Vapor gallery rendering by normalizing nested zero-arg Vapor blocks and reading dynamic attrs in the gallery's Vapor components.

## Root cause

The Solid playground runtime had its own bundled Solid copy while edited demo modules imported `solid-js` from the import map, so gallery state updates were not observed by the renderer. Vue Vapor also passed some dynamic component inputs through attrs/block factories, leaving the gallery root/tile content unresolved unless those values were unwrapped.

## Validation

- `git fetch origin main && git rebase origin/main`
- `bunx tsc --noEmit --pretty false`
- `bun site/build.ts`
- `bun run test`
- Local Playwright check on `http://127.0.0.1:8140/playground/?demo=gallery` for both `solid` and `vue-vapor`: held `KeyR` flips to page 2, held `KeyL` returns to page 1, Vue Vapor renders tile textures, and right shoulder computed `top/right` are `0px`.
