### PR TITLE
feat(site): update retargeted device copy

### DIFF
--- a/site/home.html
+++ b/site/home.html
@@ -264,20 +264,30 @@
             <span class="lp-target__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="7" width="20" height="10" rx="3"/><circle cx="6.5" cy="12" r="1.6"/><path d="M15.5 10v4M13.5 12h4"/></svg></span>
             <div class="lp-target__body">
               <div class="lp-target__head">
-                <h3 class="lp-target__name">Sony PSP</h3>
+                <h3 class="lp-target__name">Sony PSP (CFW)</h3>
                 <span class="lp-target__status lp-target__status--live">Available now</span>
               </div>
-              <p class="lp-target__desc">The reference target — a MIPS handheld rendering through the native core today.</p>
+              <p class="lp-target__desc">The reference MIPS handheld, rendering through the native core today.</p>
             </div>
           </li>
           <li class="lp-target lp-reveal">
             <span class="lp-target__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="4" y="3" width="16" height="8" rx="1.6"/><rect x="4" y="13" width="16" height="8" rx="1.6"/><path d="M9 17h6"/></svg></span>
             <div class="lp-target__body">
               <div class="lp-target__head">
-                <h3 class="lp-target__name">Nintendo 3DS</h3>
+                <h3 class="lp-target__name">Nintendo 3DS (CFW)</h3>
                 <span class="lp-target__status">Coming soon</span>
               </div>
               <p class="lp-target__desc">A dual-screen ARM11 handheld, wired into the same layout and draw pipeline.</p>
+            </div>
+          </li>
+          <li class="lp-target lp-reveal">
+            <span class="lp-target__ic" aria-hidden="true"><svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="6" width="20" height="12" rx="4"/><circle cx="6.5" cy="12" r="1.8"/><circle cx="17.5" cy="10" r="1.2"/><circle cx="17.5" cy="14" r="1.2"/><path d="M10 9.5h4v5h-4z"/></svg></span>
+            <div class="lp-target__body">
+              <div class="lp-target__head">
+                <h3 class="lp-target__name">Steam Deck</h3>
+                <span class="lp-target__status">Coming soon</span>
+              </div>
+              <p class="lp-target__desc">A Linux gaming handheld, targeting the same compiled UI through a native backend.</p>
             </div>
           </li>
           <li class="lp-target lp-reveal">


### PR DESCRIPTION
## Summary

- Add Steam Deck to the landing page retargeted devices section.
- Mark Sony PSP and Nintendo 3DS as CFW-related targets.
- Keep the device descriptions short and aligned with the existing card copy length.

## Validation

- `bun scripts/wasm.ts`
- `bun scripts/build.ts settings-main`
- `bun site/build.ts`
- `git diff --check`