### PR TITLE
fix(vue-vapor): restore demo interactions

### DIFF
--- a/compiler/jsx-plugin.ts
+++ b/compiler/jsx-plugin.ts
@@ -5,6 +5,7 @@ import type { ParserOptions } from "@babel/parser";
 import solidPreset from "babel-preset-solid";
 import tsPreset from "@babel/preset-typescript"; // untyped - see compiler/ambient.d.ts
 import { transformVueJsxVapor } from "vue-jsx-vapor/api";
+import { existsSync } from "node:fs";
 import {
   propsHelperCode,
   propsHelperId,
@@ -276,6 +277,12 @@ export function packagePath(spec: string, framework: PocketFramework): string | 
   return FRAMEWORKS[framework].subpaths[subpath] ?? null;
 }
 
+export function frameworkVariantPath(path: string, framework: PocketFramework): string {
+  if (framework !== "vue-vapor" || path.includes("/node_modules/") || path.endsWith(".d.ts")) return path;
+  const variant = path.replace(/(\.tsx?)$/, ".vue-vapor$1");
+  return variant !== path && existsSync(variant) ? variant : path;
+}
+
 function transformOptions(framework: PocketFramework) {
   if (framework === "solid") {
     return {
@@ -363,6 +370,16 @@ export function jsxPlugin(framework: PocketFramework, opts: { entry?: string } =
         return path ? { path } : undefined;
       });
       if (framework === "vue-vapor") {
+        build.onResolve({ filter: /^\.{1,2}\// }, (args) => {
+          let resolved: string;
+          try {
+            resolved = Bun.resolveSync(args.path, args.resolveDir);
+          } catch {
+            return undefined;
+          }
+          const variant = frameworkVariantPath(resolved, framework);
+          return variant !== resolved ? { path: variant } : undefined;
+        });
         build.onResolve({ filter: /^vue$/ }, () => ({ path: VUE_VAPOR_RUNTIME_PATH }));
         build.onResolve({ filter: /^\/vue-jsx-vapor\/(?:props|vdom|vapor|ssr)$/ }, (args) => ({
           path: args.path,

--- a/demos/settings/app.vue-vapor.tsx
+++ b/demos/settings/app.vue-vapor.tsx
@@ -1,4 +1,4 @@
-import { defineVaporComponent, ref, watchEffect } from "vue";
+import { defineVaporComponent, ref } from "vue";
 import { Text, View, type NodeMirror } from "@pocketjs/framework/vue-vapor/components";
 import { animate } from "@pocketjs/framework/vue-vapor/animation";
 
@@ -112,20 +112,54 @@ function themeByName(name: ThemeName): ThemeOption {
   return THEMES.find((t) => t.name === name) ?? THEMES[0];
 }
 
-const Toggle = defineVaporComponent((props: { label: string; value: boolean; themeName: ThemeName; onToggle: () => void }) => {
+function propValue<T>(value: T | (() => T)): T {
+  return typeof value === "function" ? (value as () => T)() : value;
+}
+
+function callbackProp<T extends (...args: any[]) => unknown>(value: T | (() => T)): T {
+  if (typeof value !== "function") return value;
+  if (value.length === 0) {
+    const resolved = (value as () => T)();
+    if (typeof resolved === "function") return resolved;
+  }
+  return value as T;
+}
+
+const Toggle = defineVaporComponent((
+  _props: { label: string; value: boolean; themeName: ThemeName; onToggle: () => void },
+  { attrs },
+) => {
   let knob: NodeMirror | undefined;
-  let initialized = false;
-  const palette = () => themeByName(props.themeName);
-  watchEffect(() => {
+  const label = () => propValue(attrs.label as string | (() => string));
+  const value = () => propValue(attrs.value as boolean | (() => boolean));
+  const current = ref(value());
+  const themeName = () => propValue(attrs.themeName as ThemeName | (() => ThemeName));
+  const onToggle = () => callbackProp(attrs.onToggle as (() => void) | (() => () => void));
+  const palette = () => themeByName(themeName());
+  const moveKnob = (dur: number) => {
     if (!knob) return;
-    animate(knob, "translateX", props.value ? 15.5 : 0.5, { dur: initialized ? 160 : 1, easing: "out" });
-    initialized = true;
-  });
+    animate(knob, "translateX", current.value ? 15.5 : 0.5, { dur, easing: "out" });
+  };
   return (
-    <View class={palette().rowCls} focusable onPress={props.onToggle}>
-      <Text class={palette().rowLabelCls}>{props.label}</Text>
-      <View class={props.value ? palette().switchOnCls : palette().switchOffCls}>
-        <View nodeRef={(node: NodeMirror | null) => { knob = node ?? undefined; }} class={palette().knobCls} />
+    <View
+      class={palette().rowCls}
+      focusable
+      onPress={() => {
+        current.value = !current.value;
+        moveKnob(160);
+        onToggle()();
+      }}
+    >
+      <Text class={palette().rowLabelCls}>{label()}</Text>
+      <View class={current.value ? palette().switchOnCls : palette().switchOffCls}>
+        <View
+          nodeRef={(node: NodeMirror | null) => {
+            knob = node ?? undefined;
+            moveKnob(1);
+          }}
+          class={palette().knobCls}
+          style={{ translateX: current.value ? 15.5 : 0.5 }}
+        />
       </View>
     </View>
   );
@@ -138,30 +172,50 @@ const brightnessWidth = (level: number): number => (level / 5) * BRIGHTNESS_TRAC
 const brightnessScale = (level: number): number => level / 5;
 const brightnessFillOffset = (level: number): number => -(BRIGHTNESS_TRACK_W * (1 - brightnessScale(level))) / 2;
 
-const Brightness = defineVaporComponent((props: { themeName: ThemeName }) => {
+const Brightness = defineVaporComponent((_props: { themeName: ThemeName }, { attrs }) => {
   const level = ref(BRIGHTNESS_INITIAL_LEVEL);
-  const palette = () => themeByName(props.themeName);
+  const themeName = () => propValue(attrs.themeName as ThemeName | (() => ThemeName));
+  const palette = () => themeByName(themeName());
   let fill: NodeMirror | undefined;
   let thumb: NodeMirror | undefined;
-  let initialized = false;
-  watchEffect(() => {
+  const moveLevel = (dur: number) => {
     const target = brightnessWidth(level.value);
     const scale = brightnessScale(level.value);
     const fillOffset = brightnessFillOffset(level.value);
     if (!fill || !thumb) return;
-    animate(fill, "scaleX", scale, { dur: initialized ? 150 : 1, easing: "out" });
-    animate(fill, "translateX", fillOffset, { dur: initialized ? 150 : 1, easing: "out" });
-    animate(thumb, "translateX", target - BRIGHTNESS_THUMB_W, { dur: initialized ? 150 : 1, easing: "out" });
-    initialized = true;
-  });
+    animate(fill, "scaleX", scale, { dur, easing: "out" });
+    animate(fill, "translateX", fillOffset, { dur, easing: "out" });
+    animate(thumb, "translateX", target - BRIGHTNESS_THUMB_W, { dur, easing: "out" });
+  };
 
   return (
-    <View class={palette().rowCls} focusable onPress={() => { level.value = level.value >= 5 ? 1 : level.value + 1; }}>
+    <View
+      class={palette().rowCls}
+      focusable
+      onPress={() => {
+        level.value = level.value >= 5 ? 1 : level.value + 1;
+        moveLevel(150);
+      }}
+    >
       <Text class={palette().rowLabelCls}>BRIGHTNESS</Text>
       <View class="flex-row items-center gap-2">
         <View class={palette().sliderTrackCls}>
-          <View nodeRef={(node: NodeMirror | null) => { fill = node ?? undefined; }} class={palette().sliderFillCls} style={{ scaleX: brightnessScale(BRIGHTNESS_INITIAL_LEVEL), translateX: brightnessFillOffset(BRIGHTNESS_INITIAL_LEVEL) }} />
-          <View nodeRef={(node: NodeMirror | null) => { thumb = node ?? undefined; }} class={palette().sliderThumbCls} style={{ translateX: brightnessWidth(BRIGHTNESS_INITIAL_LEVEL) - BRIGHTNESS_THUMB_W }} />
+          <View
+            nodeRef={(node: NodeMirror | null) => {
+              fill = node ?? undefined;
+              moveLevel(1);
+            }}
+            class={palette().sliderFillCls}
+            style={{ scaleX: brightnessScale(BRIGHTNESS_INITIAL_LEVEL), translateX: brightnessFillOffset(BRIGHTNESS_INITIAL_LEVEL) }}
+          />
+          <View
+            nodeRef={(node: NodeMirror | null) => {
+              thumb = node ?? undefined;
+              moveLevel(1);
+            }}
+            class={palette().sliderThumbCls}
+            style={{ translateX: brightnessWidth(BRIGHTNESS_INITIAL_LEVEL) - BRIGHTNESS_THUMB_W }}
+          />
         </View>
         <View class="w-9 flex-row justify-end">
           <Text class={palette().valueCls}>{level.value}/5</Text>
@@ -171,15 +225,21 @@ const Brightness = defineVaporComponent((props: { themeName: ThemeName }) => {
   );
 });
 
-const ThemeRow = defineVaporComponent((props: { value: ThemeName; themeName: ThemeName; onPick: (t: ThemeName) => void }) => {
-  const palette = () => themeByName(props.themeName);
+const ThemeRow = defineVaporComponent((
+  _props: { value: ThemeName; themeName: ThemeName; onPick: (t: ThemeName) => void },
+  { attrs },
+) => {
+  const value = () => propValue(attrs.value as ThemeName | (() => ThemeName));
+  const themeName = () => propValue(attrs.themeName as ThemeName | (() => ThemeName));
+  const onPick = () => callbackProp(attrs.onPick as ((t: ThemeName) => void) | (() => (t: ThemeName) => void));
+  const palette = () => themeByName(themeName());
   return (
     <View class={palette().panelCls}>
       <Text class={palette().rowLabelCls}>THEME</Text>
       <View class="flex-row gap-2">
         {THEMES.map((t) => (
-          <View class={props.value === t.name ? t.selectedCls : t.swatchCls} focusable onPress={() => props.onPick(t.name)}>
-            {props.value === t.name ? <View class="w-2 h-2 rounded-full bg-white shadow" /> : null}
+          <View class={value() === t.name ? t.selectedCls : t.swatchCls} focusable onPress={() => onPick()(t.name)}>
+            {value() === t.name ? <View class="w-2 h-2 rounded-full bg-white shadow" /> : null}
           </View>
         ))}
       </View>

--- a/demos/stats/app.vue-vapor.tsx
+++ b/demos/stats/app.vue-vapor.tsx
@@ -104,8 +104,9 @@ const Overview = defineVaporComponent(() => {
   );
 });
 
-const Systems = defineVaporComponent((props: { frame: number }) => {
-  const rowT = (i: number) => easeOutCubic((props.frame - i * SYSTEMS_STAGGER_FRAMES) / SYSTEMS_REVEAL_FRAMES);
+const Systems = defineVaporComponent((_props: { frame: number }, { attrs }) => {
+  const frame = () => (typeof attrs.frame === "function" ? (attrs.frame as () => number)() : (attrs.frame as number));
+  const rowT = (i: number) => easeOutCubic((frame() - i * SYSTEMS_STAGGER_FRAMES) / SYSTEMS_REVEAL_FRAMES);
   return (
     <View class="flex-col gap-1">
       {SYSTEMS.map((sys, i) => (

--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -24,6 +24,7 @@ import { pathToFileURL } from "node:url";
 import { PSM } from "../spec/spec.ts";
 import {
   FRAMEWORKS,
+  frameworkVariantPath,
   jsxPlugin,
   packagePath,
   parseFramework,
@@ -125,7 +126,8 @@ function resolveEntry(arg: string): string {
   process.exit(1);
 }
 
-const entry = resolveEntry(appArg);
+const requestedEntry = resolveEntry(appArg);
+const entry = frameworkVariantPath(requestedEntry, framework);
 function outputName(file: string): string {
   const rel = file.startsWith(ROOT) ? file.slice(ROOT.length) : file;
   const demo = rel.match(/^demos\/([^/]+)\/(app|main)\.tsx?$/);
@@ -133,7 +135,7 @@ function outputName(file: string): string {
   return file.split("/").pop()!.replace(/\.tsx?$/, "");
 }
 
-const appName = outputName(entry);
+const appName = outputName(requestedEntry);
 const outName = `${appName}${frameworkConfig.outputSuffix}`;
 console.log(`PocketJS build: ${appName} (${entry}, framework=${framework})`);
 
@@ -165,7 +167,7 @@ function resolveImport(fromFile: string, spec: string): string | null {
   } catch {
     return null;
   }
-  return /\.tsx?$/.test(resolved) && !resolved.endsWith(".d.ts") ? resolved : null;
+  return /\.tsx?$/.test(resolved) && !resolved.endsWith(".d.ts") ? frameworkVariantPath(resolved, framework) : null;
 }
 
 const classStrings: string[] = [];

--- a/src/components-vue-vapor.ts
+++ b/src/components-vue-vapor.ts
@@ -4,7 +4,6 @@ import {
   defineVaporComponent,
   insert as vaporInsert,
   onScopeDispose,
-  renderEffect,
   shallowRef,
   watchEffect,
 } from "vue";
@@ -233,7 +232,7 @@ function createPrimitiveNode(
   mountChildren(node, slots);
   const omit = new Set(["children", "key", "ref", "nodeRef", ...(opts.omit ?? [])]);
   let prev: HostProps = {};
-  renderEffect(() => {
+  const apply = () => {
     const extra = typeof opts.extra === "function" ? opts.extra() : (opts.extra ?? {});
     const next = { ...cleanProps(rawProps, omit), ...cleanExtraProps(extra) };
     for (const key of Object.keys(next)) setProp(node, key, next[key], prev[key]);
@@ -242,7 +241,12 @@ function createPrimitiveNode(
     }
     prev = next;
     assignRef(rawProps.nodeRef ?? rawProps.ref, node);
-  });
+  };
+  const hasFrameDynamicProps =
+    typeof opts.extra === "function" ||
+    Object.keys(rawProps).some((key) => !omit.has(key) && typeof rawProps[key] === "function");
+  watchEffect(apply);
+  if (hasFrameDynamicProps) onFrame(apply);
   return node;
 }
 
@@ -375,7 +379,7 @@ function createPortalRoot(): { marker: NodeMirror; host: NodeMirror; root: Rende
 
 export const Portal = definePocketVaporComponent((_props: PortalProps, { slots }: { slots: SlotBag }) => {
   const state = createPortalRoot();
-  renderEffect(() => {
+  watchEffect(() => {
     state.root.update(defaultBlock(slots));
   });
   onScopeDispose(() => {
@@ -510,31 +514,42 @@ export const Lazy = definePocketVaporComponent((_props: LazyProps, { attrs, slot
               grow: 1,
               width: SCREEN_W,
               flexDir: ENUMS.FlexDir.Col,
+              justify: ENUMS.Justify.Center,
+              align: ENUMS.Align.Center,
             },
           },
   });
   const renderRoot = createRenderRoot(root);
   const active = () => resolveActive(attrs.when);
-
-  if (reveal > 0) {
-    onFrame(() => {
-      if (ready.value || !active()) return;
-      if (++elapsed >= reveal) ready.value = true;
-    });
-  }
-
-  renderEffect(() => {
-    if (!active()) {
+  let renderedState: "hidden" | "fallback" | "ready" | undefined;
+  const renderLazy = (): void => {
+    const nextState = !active() ? "hidden" : ready.value ? "ready" : "fallback";
+    if (nextState === renderedState) return;
+    renderedState = nextState;
+    if (nextState === "hidden") {
       renderRoot.update(null);
       return;
     }
-    if (!ready.value) {
+    if (nextState === "fallback") {
       const fallback = attrs.fallback;
       renderRoot.update(typeof fallback === "function" ? (fallback as () => VNodeChild)() : fallback);
       return;
     }
     renderRoot.update(slotDefault(slots));
-  });
+  };
+
+  if (reveal > 0) {
+    onFrame(() => {
+      if (!ready.value && active()) {
+        if (++elapsed >= reveal) ready.value = true;
+      }
+      renderLazy();
+    });
+  } else {
+    onFrame(renderLazy);
+  }
+
+  renderLazy();
   onScopeDispose(() => renderRoot.dispose());
   return root;
 }, NO_FALLTHROUGH);
@@ -564,9 +579,13 @@ export const Gallery = definePocketVaporComponent((_props: GalleryProps, { attrs
     booleanOption(attrs.wrap)
       ? ((n % count()) + count()) % count()
       : Math.max(0, Math.min(count() - 1, n));
+  let currentPage = page();
   const go = (delta: number): void => {
-    const next = clampPage(page() + delta);
-    if (next !== page()) onPageChange()?.(next);
+    const next = clampPage(currentPage + delta);
+    if (next === currentPage) return;
+    currentPage = next;
+    renderCurrent(currentPage, true);
+    onPageChange()?.(next);
   };
 
   if (attrs.bindTriggers !== false) {
@@ -583,7 +602,7 @@ export const Gallery = definePocketVaporComponent((_props: GalleryProps, { attrs
   } else {
     setProp(viewport, "style", { width: SCREEN_W, height: SCREEN_H, overflow: ENUMS.Overflow.Hidden }, undefined);
   }
-  setProp(strip, "style", { width: SCREEN_W, height: SCREEN_H, translateX: -page() * SCREEN_W }, undefined);
+  setProp(strip, "style", { width: SCREEN_W, height: SCREEN_H, translateX: -currentPage * SCREEN_W }, undefined);
   insertNode(viewport, strip);
 
   for (let i = 0; i < count(); i++) {
@@ -606,17 +625,24 @@ export const Gallery = definePocketVaporComponent((_props: GalleryProps, { attrs
     roots.push(createRenderRoot(cell));
   }
 
-  let prevPage = page();
-  renderEffect(() => {
-    const current = page();
-    if (current !== prevPage) {
-      prevPage = current;
+  const renderCurrent = (current: number, animated: boolean): void => {
+    if (animated) {
       animate(strip, "translateX", -current * SCREEN_W, { dur: dur(), easing: easing() });
+    } else {
+      setProp(strip, "style", { width: SCREEN_W, height: SCREEN_H, translateX: -current * SCREEN_W }, undefined);
     }
     const render = renderPage();
     for (let i = 0; i < cells.length; i++) {
       roots[i].update(render && Math.abs(i - current) <= win() ? render(i) : null);
     }
+  };
+
+  renderCurrent(currentPage, false);
+  onFrame(() => {
+    const externalPage = page();
+    if (externalPage === currentPage) return;
+    currentPage = externalPage;
+    renderCurrent(currentPage, true);
   });
   onScopeDispose(() => roots.forEach((root) => root.dispose()));
   return viewport;


### PR DESCRIPTION
## What changed

- Resolve Vue Vapor demo imports to sibling `*.vue-vapor.tsx` sources during both graph scan and bundling.
- Make Vue Vapor component props/Lazy/Gallery refresh paths explicit enough for native-frame updates.
- Fix Settings and Mission Control local Vapor components to read attrs instead of undeclared props.

## Root cause

Vue Vapor builds scanned variant demo files but bundled the Solid `app.tsx` through `main.tsx` relative imports. After that was corrected, several Vapor component paths still depended on one-shot render effects or undeclared props, which left Gallery paging, Settings rows, and Mission Control tab content stale.

## Validation

- `bunx tsc --noEmit`
- `bun run test`
- `git diff --check`
- `bun scripts/build.ts gallery-main --framework=vue-vapor`
- `bun scripts/build.ts settings-main --framework=vue-vapor`
- `bun scripts/build.ts stats-main --framework=vue-vapor`
- WASM host replay for Gallery L/R/L, Settings toggles/brightness, and Stats left/right/left with microtask flush: all completed without throws.
