### PR TITLE
docs(readme): align heading logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="./site/assets/favicon.svg" width="40" height="40" alt=""> PocketJS
+<h1><img src="./site/assets/favicon.svg" width="40" height="40" alt="" align="absmiddle" /> PocketJS</h1>
 
 High-performance JSX UI outside the browser, with native rendering, standard
 Vue Vapor and Solid support, a Tailwind design system, and 60 FPS animation


### PR DESCRIPTION
## Summary

- Change the README title from Markdown heading image syntax to an HTML heading.
- Use GitHub-preserved `align="absmiddle"` on the logo image so it lines up vertically with the `PocketJS` heading text.

## Validation

- `git diff --check`
- `gh api markdown ...` confirmed GitHub keeps `align="absmiddle"` in the rendered README HTML.