### PR TITLE
fix(psp): return to XMB on PSPLINK quit

### DIFF
--- a/native/src/bin/exit-to-xmb.rs
+++ b/native/src/bin/exit-to-xmb.rs
@@ -1,0 +1,38 @@
+#![no_std]
+#![no_main]
+#![feature(alloc_error_handler)]
+
+//! Tiny PSPLINK helper loaded by `bun psplink` when quitting the Mac-side
+//! switcher. It returns the PSP to the XMB instead of leaving it at the PSPLINK
+//! loader or inside the last launched PocketJS demo.
+
+use core::alloc::{GlobalAlloc, Layout};
+
+psp::module!("pocketjs_exit", 1, 1);
+
+struct NoAlloc;
+
+unsafe impl GlobalAlloc for NoAlloc {
+    unsafe fn alloc(&self, _layout: Layout) -> *mut u8 {
+        core::ptr::null_mut()
+    }
+
+    unsafe fn dealloc(&self, _ptr: *mut u8, _layout: Layout) {}
+}
+
+#[global_allocator]
+static ALLOC: NoAlloc = NoAlloc;
+
+#[alloc_error_handler]
+fn alloc_error(_layout: Layout) -> ! {
+    unsafe {
+        psp::sys::sceKernelExitGame();
+    }
+    loop {}
+}
+
+fn psp_main() {
+    unsafe {
+        psp::sys::sceKernelExitGame();
+    }
+}

--- a/scripts/psp.ts
+++ b/scripts/psp.ts
@@ -71,6 +71,7 @@ const argv = Bun.argv.slice(2);
 let appArg = "";
 let capture = false;
 let bench = false;
+let nativeBin: string | undefined;
 let frameworkFlag: string | undefined;
 let configPath = pspUiDir + "pocket.config.ts";
 let useConfig = true;
@@ -86,6 +87,9 @@ for (const a of argv) {
     frameworkFlag = a.slice("--framework=".length);
     buildFlags.push(a);
   }
+  else if (a.startsWith("--native-bin=")) {
+    nativeBin = a.slice("--native-bin=".length);
+  }
   else if (a.startsWith("--config=")) {
     configPath = resolvePath(pspUiDir, a.slice("--config=".length));
     buildFlags.push(a);
@@ -99,8 +103,13 @@ for (const a of argv) {
 }
 const features = [capture ? "capture" : "", bench ? "bench" : ""].filter(Boolean);
 if (features.length > 0) cargoArgs.push("--features", features.join(","));
-if (!appArg) {
+if (nativeBin && appArg) {
+  console.error("PocketJS psp: --native-bin builds a standalone PSP bin and cannot be combined with an app name");
+  process.exit(1);
+}
+if (!appArg && !nativeBin) {
   console.error("usage: bun scripts/psp.ts <app> [--capture|--bench] [cargo args…]   e.g. bun scripts/psp.ts hero --release");
+  console.error("       bun scripts/psp.ts --native-bin=<bin> [cargo args…]");
   process.exit(1);
 }
 
@@ -130,7 +139,7 @@ function mountedAppName(arg: string): string {
   return arg;
 }
 
-const app = mountedAppName(appArg);
+const app = appArg ? mountedAppName(appArg) : "";
 
 async function loadConfig(): Promise<PocketConfig> {
   if (!useConfig || !existsSync(configPath)) return {};
@@ -140,18 +149,26 @@ async function loadConfig(): Promise<PocketConfig> {
   return mod.default ?? mod.config ?? {};
 }
 
-const config = await loadConfig();
-const framework: PocketFramework = frameworkFlag
-  ? parseFramework(frameworkFlag, "--framework")
-  : parseFramework(config.framework, "pocket.config.ts");
-const outputApp = `${app}${FRAMEWORKS[framework].outputSuffix}`;
+const config = nativeBin ? {} : await loadConfig();
+const framework: PocketFramework | undefined = nativeBin
+  ? undefined
+  : frameworkFlag
+    ? parseFramework(frameworkFlag, "--framework")
+    : parseFramework(config.framework, "pocket.config.ts");
+const outputApp = nativeBin ? "" : `${app}${FRAMEWORKS[framework].outputSuffix}`;
 
 // ---------------------------------------------------------------------------
 // 1. Build the app bundle + pak -> dist/<app>.js + dist/<app>.pak
 // ---------------------------------------------------------------------------
 
-console.log(`PocketJS psp: building app "${app}" (framework=${framework})`);
-await $`bun scripts/build.ts ${app} ${buildFlags}`.cwd(pspUiDir);
+if (nativeBin) {
+  console.log(`PocketJS psp: building native bin "${nativeBin}"`);
+  cargoArgs.push("--bin", nativeBin);
+} else {
+  console.log(`PocketJS psp: building app "${app}" (framework=${framework})`);
+  await $`bun scripts/build.ts ${app} ${buildFlags}`.cwd(pspUiDir);
+  cargoArgs.push("--bin", "pocketjs-psp");
+}
 
 // ---------------------------------------------------------------------------
 // 2. cargo psp with the dreamcart cross env (copied from runtime/build.ts)
@@ -208,9 +225,18 @@ function outputProfile(args: string[]): string {
   return args.includes("--release") || args.includes("-r") ? "release" : "debug";
 }
 
-console.log(`PocketJS psp: cargo psp (app=${outputApp})`);
+console.log(nativeBin ? `PocketJS psp: cargo psp (bin=${nativeBin})` : `PocketJS psp: cargo psp (app=${outputApp})`);
 await $`${rustup} run ${TOOLCHAIN} cargo psp ${cargoArgs}`.cwd(nativeDir).env(env);
 
 const profile = outputProfile(cargoArgs);
-const eboot = `${nativeDir}target/mipsel-sony-psp/${profile}/EBOOT.PBP`;
+const binName = nativeBin ?? "pocketjs-psp";
+const binEboot = `${nativeDir}target/mipsel-sony-psp/${profile}/${binName}.EBOOT.PBP`;
+const conventionalEboot = `${nativeDir}target/mipsel-sony-psp/${profile}/EBOOT.PBP`;
+if (!nativeBin && existsSync(binEboot)) {
+  await Bun.write(conventionalEboot, await Bun.file(binEboot).arrayBuffer());
+}
+const eboot = nativeBin ? binEboot : conventionalEboot;
+if (nativeBin) {
+  console.log(`prx: ${nativeDir}target/mipsel-sony-psp/${profile}/${nativeBin}.prx`);
+}
 console.log(`output: ${eboot}`);

--- a/scripts/psplink.ts
+++ b/scripts/psplink.ts
@@ -30,6 +30,8 @@ const DEMOS_DIR = join(ROOT, "demos");
 const OUT_ROOT = join(ROOT, "dist/psplink");
 const MAIN_SUFFIX = "-main.tsx";
 const DEFAULT_PORT = 10000;
+const EXIT_HELPER_BIN = "exit-to-xmb";
+const EXIT_HELPER_PRX = join(OUT_ROOT, "PocketJS-exit-to-xmb.prx");
 
 const BTN_UP = "\x1b[A";
 const BTN_DOWN = "\x1b[B";
@@ -54,7 +56,7 @@ function usageText(): string {
     "  Up/Down                 Move selection",
     "  Enter                   Reset PSPLINK and start the selected game",
     "  r                       Rebuild selected game PRX",
-    "  q                       Quit",
+    "  q                       Return PSP to XMB and quit",
   ].join("\n");
 }
 
@@ -149,17 +151,34 @@ async function buildDemo(demo: Demo, opts: Options): Promise<void> {
   await Bun.write(demo.prx, await Bun.file(source).arrayBuffer());
 }
 
+async function buildExitHelper(opts: Options): Promise<void> {
+  const profile = opts.release ? "release" : "debug";
+  const source = join(ROOT, "native/target/mipsel-sony-psp", profile, `${EXIT_HELPER_BIN}.prx`);
+  await $`bun scripts/psp.ts --native-bin=${EXIT_HELPER_BIN} ${opts.release ? "--release" : ""}`.cwd(ROOT);
+  if (!existsSync(source)) throw new Error(`expected PSP exit helper PRX was not created: ${source}`);
+  mkdirSync(OUT_ROOT, { recursive: true });
+  await Bun.write(EXIT_HELPER_PRX, await Bun.file(source).arrayBuffer());
+}
+
 async function prepareCache(demos: Demo[], opts: Options, render?: (status: string) => void): Promise<void> {
   if (opts.rebuild) rmSync(OUT_ROOT, { recursive: true, force: true });
   mkdirSync(OUT_ROOT, { recursive: true });
-  if (!opts.buildAll && !opts.noBuild) return;
   if (opts.noBuild) {
-    const missing = demos.filter((demo) => !existsSync(demo.prx));
+    const missing = [
+      ...demos.filter((demo) => !existsSync(demo.prx)).map((demo) => basename(demo.prx)),
+      ...(!existsSync(EXIT_HELPER_PRX) ? [basename(EXIT_HELPER_PRX)] : []),
+    ];
     if (missing.length > 0) {
-      throw new Error(`--no-build requested, but missing PRX files: ${missing.map((demo) => basename(demo.prx)).join(", ")}`);
+      throw new Error(`--no-build requested, but missing PRX files: ${missing.join(", ")}`);
     }
     return;
   }
+
+  if (opts.rebuild || !existsSync(EXIT_HELPER_PRX)) {
+    render?.("building exit-to-XMB helper");
+    await buildExitHelper(opts);
+  }
+  if (!opts.buildAll) return;
 
   for (const [index, demo] of demos.entries()) {
     if (!opts.rebuild && existsSync(demo.prx)) continue;
@@ -244,6 +263,16 @@ class PsplinkSession {
     return true;
   }
 
+  async exitToXmb(helperPrx: string, render: (status: string) => void): Promise<void> {
+    render("starting XMB exit helper");
+    const out = await this.runPspsh(`ldstart host0:/${basename(helperPrx)}`, 8000);
+    if (!out.timedOut && /Failed|Error/i.test(out.text)) {
+      render(out.text || "XMB exit helper failed");
+      return;
+    }
+    render("XMB exit helper launched");
+  }
+
   stop(): void {
     if (this.stopped) return;
     this.stopped = true;
@@ -293,8 +322,8 @@ class PsplinkSession {
       child.kill();
     }, timeoutMs);
     const [stdout, stderr] = await Promise.all([
-      new Response(child.stdout).text(),
-      new Response(child.stderr).text(),
+      new Response(child.stdout).text().catch((error) => String(error)),
+      new Response(child.stderr).text().catch((error) => String(error)),
       child.exited,
     ]);
     clearTimeout(timer);
@@ -310,8 +339,9 @@ class Picker {
 
   constructor(
     private readonly demos: Demo[],
-  private readonly onPick: (demo: Demo, index: number, render: (status: string) => void) => Promise<boolean>,
+    private readonly onPick: (demo: Demo, index: number, render: (status: string) => void) => Promise<boolean>,
     private readonly onRebuild: (demo: Demo, render: (status: string) => void) => Promise<void>,
+    private readonly onQuit: (render: (status: string) => void) => Promise<void>,
   ) {}
 
   async run(initialStatus: string): Promise<void> {
@@ -321,9 +351,15 @@ class Picker {
     process.stdin.resume();
     process.stdin.setEncoding("utf8");
     for await (const key of process.stdin) {
-      if (key === "\u0003") break;
+      if (key === "\u0003") {
+        await this.quit();
+        break;
+      }
       if (this.busy) continue;
-      if (key === "q") break;
+      if (key === "q") {
+        await this.quit();
+        break;
+      }
       if (key === BTN_UP || key === "k") this.move(-1);
       else if (key === BTN_DOWN || key === "j") this.move(1);
       else if (key === "\r" || key === "\n") await this.pick();
@@ -353,6 +389,12 @@ class Picker {
     });
   }
 
+  private async quit(): Promise<void> {
+    await this.withBusy(async (render) => {
+      await this.onQuit(render);
+    });
+  }
+
   private async withBusy(fn: (render: (status: string) => void) => Promise<void>): Promise<void> {
     this.busy = true;
     const render = (status: string) => {
@@ -372,7 +414,7 @@ class Picker {
     process.stdout.write("\x1b[2J\x1b[H");
     console.log("PocketJS PSPLINK Switcher");
     console.log("");
-    console.log("Use Up/Down, Enter to launch, r to rebuild selected, q to quit.");
+    console.log("Use Up/Down, Enter to launch, r to rebuild selected, q to return to XMB and quit.");
     console.log("");
     for (const [index, demo] of this.demos.entries()) {
       const cursor = index === this.cursor ? ">" : " ";
@@ -437,6 +479,9 @@ async function main(): Promise<void> {
       render(`rebuilding ${demo.name}`);
       await buildDemo(demo, opts);
       render(`rebuilt ${demo.name}`);
+    },
+    async (render) => {
+      await session.exitToXmb(EXIT_HELPER_PRX, render);
     },
   );
   await picker.run(`PSP connected on port ${basePort}; host0: ${OUT_ROOT}`);


### PR DESCRIPTION
## Summary
- add a tiny PSP native `exit-to-xmb` helper that calls `sceKernelExitGame()`
- build and cache `PocketJS-exit-to-xmb.prx` when `bun psplink` starts
- make `q` / Ctrl-C load the helper directly so the PSP returns to XMB instead of staying in the last game or the PSPLINK loader
- keep existing app PSP builds compatible by explicitly building `pocketjs-psp` and copying `pocketjs-psp.EBOOT.PBP` back to the legacy `EBOOT.PBP` path

## Validation
- `bunx tsc --noEmit --pretty false --skipLibCheck --types bun --lib ES2023,DOM --module ESNext --moduleResolution Bundler --target ES2022 --allowImportingTsExtensions scripts/psplink.ts scripts/psp.ts`
- `bun scripts/psp.ts --native-bin=exit-to-xmb --release`
- `bun scripts/psp.ts hero --release` and verified `native/target/mipsel-sony-psp/release/EBOOT.PBP`, `pocketjs-psp.EBOOT.PBP`, `pocketjs-psp.prx`, and `exit-to-xmb.prx`
- fake PSPLINK PTY smoke: launch cards, press `q`; fake `pspsh` recorded `ldstart host0:/PocketJS-exit-to-xmb.prx`
- real PSPLink E2E: `bun psplink --rebuild`, connected on port 10000, launched cards, pressed `q`, and CLI loaded the XMB exit helper then exited with code 0
- `bun psplink --help`
- `bun psplink --dry-run`
- `bun run test`

## Notes
- The earlier reset-before-quit variant failed in real testing because reset briefly reopened the USB reconnect window and another stale PSPLINK host process could steal the PSP. This version loads the exit helper directly from the active session.