### PR TITLE
feat(site): add landing hardware video preview

### DIFF
--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -341,6 +341,27 @@ a.lp-btn--primary:hover {
   gap: 0.85rem;
   margin-top: 2.1rem;
 }
+.lp-hero__pip {
+  position: absolute;
+  top: clamp(1.25rem, 2.8vw, 2.5rem);
+  right: clamp(1rem, 3vw, 3rem);
+  z-index: 2;
+  width: clamp(250px, 23vw, 390px);
+  aspect-ratio: 1280 / 684;
+  overflow: hidden;
+  border: 1px solid rgba(148, 163, 184, 0.24);
+  border-radius: 8px;
+  background: #05070d;
+  box-shadow: 0 22px 70px rgba(0, 0, 0, 0.34), 0 0 0 1px rgba(255, 255, 255, 0.04) inset;
+}
+.lp-hero__pip-video {
+  display: block;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  opacity: 0.92;
+  filter: saturate(0.98) contrast(1.02);
+}
 
 /* ---- Live-demo stage ------------------------------------------------------ */
 .lp-stage {
@@ -365,6 +386,15 @@ a.lp-btn--primary:hover {
 .lp-stage__frame {
   position: relative;
   z-index: 1;
+}
+@media (max-width: 1120px) {
+  .lp-hero__pip {
+    position: relative;
+    top: auto;
+    right: auto;
+    width: min(420px, 86vw);
+    margin: 1.6rem auto 0.8rem;
+  }
 }
 /* ---- Section scaffolding -------------------------------------------------- */
 .lp-section { padding: clamp(4.5rem, 10vw, 8rem) 0; }

--- a/site/build.ts
+++ b/site/build.ts
@@ -349,6 +349,7 @@ async function main() {
   for (const asset of ["favicon.svg", "og-image.svg", "og-image.png"]) {
     if (existsSync(SITE + "assets/" + asset)) copy(SITE + "assets/" + asset, asset);
   }
+  copy(SITE + "assets/pocketjs-hardware-demo.mp4", "assets/pocketjs-hardware-demo.mp4");
 
   // 6. playground page
   write("playground/index.html", renderPage({

--- a/site/home.html
+++ b/site/home.html
@@ -31,6 +31,11 @@
     <section class="lp-hero">
       <div class="lp-hero__grid" aria-hidden="true"></div>
       <div class="lp-hero__aurora" aria-hidden="true"></div>
+      <div class="lp-hero__pip" aria-hidden="true">
+        <video class="lp-hero__pip-video" autoplay muted loop playsinline preload="metadata">
+          <source src="/assets/pocketjs-hardware-demo.mp4" type="video/mp4" />
+        </video>
+      </div>
       <div class="lp-container lp-hero__in">
         <a class="lp-eyebrow" href="/docs/architecture/">
           <span class="lp-eyebrow__tag">Now</span>


### PR DESCRIPTION
## Summary

- Add a muted looping hardware demo video asset to the landing page.
- Render the video as a small picture-in-picture preview in the hero instead of a full background.
- Copy the MP4 into the built site assets.

## Validation

- `bun site/build.ts`
- `git diff --check HEAD~1 HEAD`

## Notes

The live emulator UI remains in the hero in its original position. On narrower screens, the video preview moves into the content flow with spacing before the hero pill.
