### PR TITLE
feat(site): add blog with Introducing PocketJS announcement post

### DIFF
--- a/site/assets/tailwind.css
+++ b/site/assets/tailwind.css
@@ -1,8 +1,9 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* Scan every place a class can appear (TS template strings, HTML, JS glue). */
-@source "../**/*.{ts,html,js}";
+/* Scan every place a class can appear (TS template strings, HTML, JS glue,
+   raw HTML embedded in blog/docs markdown). */
+@source "../**/*.{ts,html,js,md}";
 
 @font-face {
   font-family: "Inter";

--- a/site/build.ts
+++ b/site/build.ts
@@ -29,7 +29,7 @@ import {
   vdomHelperId,
 } from "@vue-jsx-vapor/runtime/raw";
 import { OG_IMAGE_URL, SITE_DESC, SITE_TITLE, SITE_URL, renderPage } from "./templates.ts";
-import { AOT_DOC_NAV, DOC_NAV, type DocSection } from "./nav.ts";
+import { AOT_DOC_NAV, BLOG_POSTS, DOC_NAV, type DocSection } from "./nav.ts";
 
 const ROOT = new URL("..", import.meta.url).pathname; // repo root
 const SITE = ROOT + "site/";
@@ -387,8 +387,10 @@ async function main() {
   copy(SITE + "assets/aot-demo.js", "assets/aot-demo.js");
   copyAotAssets();
 
-  // 9. docs
-  await buildDocs();
+  // 9. docs + blog (setupMarkdown installs the shared marked/shiki renderer)
+  const highlight = await setupMarkdown();
+  await buildDocs(highlight);
+  await buildBlog();
 
   // 9b. 404
   write("404.html", renderPage({
@@ -569,10 +571,12 @@ const IMPORT_MAP = `<script type="importmap">
 }}
 </script>`;
 
-async function buildDocs() {
-  // Syntax highlighting: Shiki (build-time, self-contained themed HTML) matched
-  // to the playground editor's one-dark-pro. Override marked's code renderer so
-  // every fenced block becomes a highlighted <pre class="shiki">.
+type Highlight = (text: string, rawLang: string) => string;
+
+// Syntax highlighting: Shiki (build-time, self-contained themed HTML) matched
+// to the playground editor's one-dark-pro. Installs marked's code renderer so
+// every fenced block (docs + blog) becomes a highlighted <pre class="shiki">.
+async function setupMarkdown(): Promise<Highlight> {
   const highlighter = await createHighlighter({
     themes: ["one-dark-pro"],
     langs: ["tsx", "typescript", "jsx", "javascript", "json", "bash", "rust", "toml", "html", "css", "diff"],
@@ -585,6 +589,18 @@ async function buildDocs() {
     const use = loaded.has(lang) ? lang : "text";
     return highlighter.codeToHtml(text, { theme: "one-dark-pro", lang: use });
   };
+  marked.use({
+    renderer: {
+      code(token: { text?: string; lang?: string }) {
+        const text = token.text ?? "";
+        return highlight(text, token.lang ?? "");
+      },
+    },
+  });
+  return highlight;
+}
+
+async function buildDocs(highlight: Highlight) {
   let frameworkCodeId = 0;
   const renderFrameworkCode = (markdown: string) =>
     markdown.replace(/:::framework-code\n([\s\S]*?)\n:::/g, (_match, body: string) => {
@@ -626,15 +642,6 @@ async function buildDocs() {
         .join("");
       return `<div class="doc-fw-code">${inputs}<div class="doc-fw-tabs" role="tablist">${tabs}</div><div class="doc-fw-panels">${panels}</div></div>`;
     });
-  marked.use({
-    renderer: {
-      code(token: { text?: string; lang?: string }) {
-        const text = token.text ?? "";
-        return highlight(text, token.lang ?? "");
-      },
-    },
-  });
-
   type DocsTree = {
     active: string;
     docsDir: string;
@@ -715,6 +722,77 @@ async function buildDocs() {
     robots: "noindex,nofollow",
     transformFrameworkCode: false,
   });
+}
+
+// --- blog: /blog/ index + one page per post from site/content/blog/<slug>.md.
+// Relies on the marked/shiki renderer installed by setupMarkdown().
+const MONTHS = ["January", "February", "March", "April", "May", "June", "July", "August", "September", "October", "November", "December"];
+function formatPostDate(iso: string): string {
+  const [y, m, d] = iso.split("-").map(Number);
+  return `${MONTHS[m - 1]} ${d}, ${y}`;
+}
+
+const BLOG_DESC = "Announcements and engineering notes from the PocketJS team.";
+async function buildBlog() {
+  const dir = SITE + "content/blog/";
+  const posts = [...BLOG_POSTS].sort((a, b) => (a.date < b.date ? 1 : -1));
+  const rendered: typeof posts = [];
+  for (const post of posts) {
+    const md = dir + post.slug + ".md";
+    if (!existsSync(md)) {
+      console.warn(`  blog: MISSING ${post.slug}.md`);
+      continue;
+    }
+    const html = await marked.parse(readFileSync(md, "utf8"));
+    const body =
+      `<article class="mx-auto max-w-3xl px-5 py-14">` +
+      `<a href="/blog/" class="text-sm text-slate-400 hover:text-brand-2">&larr; Blog</a>` +
+      `<header class="mt-4 border-b border-line pb-8">` +
+      `<time datetime="${post.date}" class="font-mono text-xs uppercase tracking-wide text-slate-500">${formatPostDate(post.date)}</time>` +
+      `<h1 class="mt-3 text-4xl font-bold tracking-tight text-slate-100">${post.title}</h1>` +
+      `<p class="mt-4 text-lg text-slate-400">${post.description}</p>` +
+      `</header>` +
+      `<div class="prose prose-invert max-w-none doc-content mt-8">${html}</div>` +
+      `</article>`;
+    write(`blog/${post.slug}/index.html`, renderPage({
+      title: post.title,
+      active: "blog",
+      body,
+      bodyClass: "",
+      head: "",
+      scripts: [],
+      path: `/blog/${post.slug}/`,
+      description: post.description,
+    }));
+    rendered.push(post);
+  }
+  const cards = rendered
+    .map(
+      (p) =>
+        `<a href="/blog/${p.slug}/" class="group block rounded-xl border border-line bg-surface/60 p-6 transition-colors hover:border-brand">` +
+        `<time datetime="${p.date}" class="font-mono text-xs uppercase tracking-wide text-slate-500">${formatPostDate(p.date)}</time>` +
+        `<h2 class="mt-2 text-2xl font-bold text-slate-100 group-hover:text-brand-2">${p.title}</h2>` +
+        `<p class="mt-2 text-slate-400">${p.description}</p>` +
+        `<span class="mt-4 inline-block text-sm font-semibold text-brand-2">Read post &rarr;</span>` +
+        `</a>`,
+    )
+    .join("");
+  write("blog/index.html", renderPage({
+    title: "Blog",
+    active: "blog",
+    body:
+      `<section class="mx-auto max-w-3xl px-5 pb-20 pt-14">` +
+      `<h1 class="text-4xl font-bold tracking-tight text-slate-100">Blog</h1>` +
+      `<p class="mt-3 text-slate-400">${BLOG_DESC}</p>` +
+      `<div class="mt-10 grid gap-5">${cards}</div>` +
+      `</section>`,
+    bodyClass: "",
+    head: "",
+    scripts: [],
+    path: "/blog/",
+    description: BLOG_DESC,
+  }));
+  console.log(`  blog  (${rendered.length} posts)`);
 }
 
 await main();

--- a/site/build.ts
+++ b/site/build.ts
@@ -751,6 +751,7 @@ async function buildBlog() {
       `<time datetime="${post.date}" class="font-mono text-xs uppercase tracking-wide text-slate-500">${formatPostDate(post.date)}</time>` +
       `<h1 class="mt-3 text-4xl font-bold tracking-tight text-slate-100">${post.title}</h1>` +
       `<p class="mt-4 text-lg text-slate-400">${post.description}</p>` +
+      `<p class="mt-4 text-sm text-slate-400">Written by <a class="font-semibold text-slate-200 hover:text-brand-2" href="${post.author.url}" target="_blank" rel="noreferrer">${post.author.name}</a></p>` +
       `</header>` +
       `<div class="prose prose-invert max-w-none doc-content mt-8">${html}</div>` +
       `</article>`;

--- a/site/content/blog/introducing-pocketjs.md
+++ b/site/content/blog/introducing-pocketjs.md
@@ -1,0 +1,114 @@
+PocketJS is a UI stack that runs modern JSX — real [Solid](https://www.solidjs.com/) and Vue Vapor components, styled with Tailwind classes, animated at 60 FPS — on a 2004 Sony PSP, inside an 8 MB memory budget. The same app, unchanged, also runs in the PPSSPP emulator, in the browser through WebAssembly, and headless under Bun.
+
+<video class="w-full rounded-xl border border-line" src="/assets/pocketjs-hardware-demo.mp4" autoplay muted loop playsinline></video>
+
+PocketJS is open source under MIT, and the [playground](/playground/) is live. The engine running in that page is not a web mockup of PocketJS — it is the same Rust core that ships inside the PSP executable, compiled to WebAssembly.
+
+Getting JavaScript to run on retro hardware is not new. What we believe *is* new is the combination PocketJS ships: unmodified mainstream frameworks, a design system that compiles away, animation that runs natively, and a UI engine you can regression-test byte-for-byte — all inside a memory budget smaller than a single browser tab's baseline heap. This post walks through the pieces.
+
+## The premise
+
+Modern frontend ergonomics are not intrinsically expensive. Components, fine-grained reactivity, utility-class styling, declarative springs — nothing about them requires a browser. What requires a browser is the machinery we normally implement them with: a DOM, a CSS cascade, a JIT, and hundreds of megabytes of headroom.
+
+PocketJS splits the ergonomics from the machinery. You write ordinary Solid or Vue Vapor components against React Native-style `<View>`, `<Text>`, and `<Image>` primitives. Everything below the framework — flexbox layout, styling, text, animation, rendering — lives in a single `#![no_std]` Rust crate driven through a tiny mutation-only protocol:
+
+```text
+        app.tsx  (Solid or Vue Vapor + Tailwind classes)
+           │  framework JSX transform  (two-pass build)
+           ▼
+        bundle.js      styles.bin + font atlases + images ──► app.pak
+           │
+   ┌── QuickJS (PSP) ──────────┐   ┌── browser / Bun ─────────┐
+   │ framework runtime         │   │ framework runtime        │
+   │   │ createNode/setStyle…  │   │   │ same ui.* ops        │
+   │   ▼                       │   │   ▼                      │
+   │ pocketjs-core (Rust)      │   │ pocketjs-core (same      │
+   │  tree·flexbox·anim·text   │   │   Rust, → wasm32)        │
+   │   │ DrawList              │   │   │ DrawList             │
+   │   ▼                       │   │   ▼                      │
+   │ sceGu backend (PSP GPU)   │   │ software rasterizer      │
+   └───────────────────────────┘   └──────────────────────────┘
+```
+
+Eight consequences of that split are worth calling out.
+
+## 1. Real frameworks, not lookalikes
+
+The `solid-js` you import in a PocketJS app is the one from npm. So is `vue`. PocketJS forks neither and imitates neither: Solid drives the native tree through its official universal renderer, and Vue Vapor drives it through a Vapor renderer adapter plus a small DOM-shaped facade for Vue's helpers.
+
+```tsx
+import { createSignal } from "solid-js"; // real Solid, from npm
+import { Text, View } from "@pocketjs/framework/components";
+
+export default function Counter() {
+  const [count, setCount] = createSignal(0);
+
+  return (
+    <View class="flex-col items-center gap-4 p-4 bg-slate-50">
+      <Text class="text-xl text-slate-950">Count: {count()}</Text>
+      <View
+        class="p-2 rounded-md bg-blue-600 focus:bg-blue-500 transition-colors duration-150"
+        focusable
+        onPress={() => setCount(count() + 1)}
+      />
+    </View>
+  );
+}
+```
+
+The ownership line is explicit: the framework owns state, lifecycle, and control flow (`<Show>`, `<For>`, computeds — the semantics you already know), while PocketJS owns the host — components, input, focus, animation, assets. Both supported frameworks share the property that makes this viable on a 2004-era MIPS CPU running an interpreter: no virtual DOM. When a signal changes, only the effect closures that read it re-run, and each one becomes a handful of mutations on the native tree. There is no diff pass to pay for.
+
+## 2. One `no_std` Rust core, compiled twice
+
+`pocketjs-core` owns the retained node tree, flexbox layout (via taffy), style resolution, text layout, and animation, and its output is a `DrawList` — a flat list of quads. The crate is `#![no_std]` and platform-blind, and it is compiled twice: to MIPS, wrapped by QuickJS and the PSP's GPU backend; and to `wasm32`, wrapped by a deterministic software rasterizer that serves both the browser host and headless tests.
+
+That is the trick behind "runs everywhere": there is exactly one layout engine, one styling engine, one animation system. The playground, the emulator, CI, and the handheld in your hands compute the same frames because they run the same code.
+
+## 3. A native contract sized for one FFI crossing per frame
+
+JS drives the core through a mutation-only op set — `createNode`, `insertBefore`, `setStyle`, `setText`, `animate`, and friends. The renderer keeps a JS-side mirror of the tree, so framework *reads* never cross the language boundary. Node handles are generation-tagged integers, so a stale reference is a harmless no-op instead of a use-after-free.
+
+The result is a steady-state frame that crosses the FFI once, and a draw budget that fits the hardware: on the PSP, a frame targets ≤ ~40 GPU draw calls and ~2,000 quads.
+
+## 4. Tailwind as a compiler, not a stylesheet
+
+There is no CSS engine at runtime, because there is no CSS at runtime. During the build, PocketJS collects every class string in your app straight from the AST, validates each literal all-or-nothing against a pinned [Tailwind subset](/docs/tailwind/) (unsupported tokens are loud compile errors, not silent no-ops), and compiles the survivors into a binary style table shipped next to your bundle. At runtime, styling a node is `setStyle(node, styleId)` — an integer.
+
+Interaction states come along for free: `focus:` and `active:` variants are part of the compiled style record and are switched *inside the native core*. When focus moves in a PocketJS app, zero JavaScript styling code runs.
+
+## 5. Frames are pure functions — so UI is testable byte-for-byte
+
+Animation is declared in JS (`animate()`, springs, `transition-*` utilities) but executed in Rust, ticked once per vblank at a fixed dt of 1/60 s. Nothing about a frame depends on wall-clock time: frame N is a pure function of the op history and the frame index.
+
+That property turns UI testing from screenshot-fuzz-matching into compiler-style verification. CI drives scripted input through the wasm build's deterministic rasterizer and asserts *byte-exact* PNG goldens — animated transitions included — and an end-to-end suite boots the real PSP executable in headless PPSSPP and compares dumped frames the same way.
+
+## 6. Fonts baked to exactly what your app renders
+
+The same AST pass that harvests class strings also harvests text codepoints. The font baker then rasterizes atlas slots — supersampled 8-bit coverage, proportional metrics — for exactly the characters your app can display, at exactly the sizes your styles use. No font parsing, no shaping engine, no glyph rasterization on device: text drawing decodes coverage runs into batched GPU sprites.
+
+## 7. An allocator story for 8 MB
+
+The whole app — QuickJS heap, Rust-core allocations, uploaded textures — lives in a single arena claimed from the OS once at boot. Per-frame vertex memory comes from a bump pool that resets after the GPU finishes each frame, at around 48 KB per frame. Budgets in PocketJS are contracts rather than aspirations; the demos hold 60 FPS on hardware inside 8 MB, transitions and all.
+
+## 8. The toolchain runs in the browser too
+
+The [playground](/playground/) does not talk to a build server. Babel with the framework JSX transforms, the Tailwind-subset compiler, and the font baker are all bundled to run client-side, feeding the same wasm core you see everywhere else. Edit a component and you are re-running the actual PocketJS toolchain — in a tab.
+
+## Why a PSP?
+
+Because it is an honest referee. A 480×272 screen, an 8 MB budget, an interpreter with no JIT, a GPU that wants aligned vertex buffers and power-of-two textures: nothing on that machine will quietly absorb a lazy architecture. If component-driven, utility-styled, spring-animated UI holds 60 FPS *there*, the architecture is what's carrying it — and everything roomier is downhill.
+
+And the PSP is the proof, not the point. The core is platform-blind; a new device is a backend to write, not a rewrite. Two additional hosts — browser WASM and headless Bun — already share it.
+
+## What v1 leaves out — on purpose
+
+PocketJS v1 has a pinned scope and loud errors at its edges: no `hover:` (there is no pointer), no `classList` or interpolated class strings (they defeat the compiler), no kinetic scroll views yet, no runtime-sized `rounded-full`. We would rather ship a small surface that is exactly right on hardware than a large one that is approximately right.
+
+## Try it
+
+- **[Playground](/playground/)** — the full toolchain and core, in your browser.
+- **[Getting started](/docs/getting-started/)** — build and run your first app.
+- **[Architecture](/docs/architecture/)** — the deep dive this post summarizes.
+- **[GitHub](https://github.com/pocket-stack/pocketjs)** — MIT, contributions welcome.
+
+Follow [@pocket_js](https://x.com/pocket_js) for what's next — there is more in the pocket than a framework.

--- a/site/home.html
+++ b/site/home.html
@@ -18,6 +18,7 @@
       <nav class="lp-nav__links" aria-label="Primary">
         <a class="lp-nav__link" href="/docs/overview/">Docs</a>
         <a class="lp-nav__link" href="/playground/">Playground</a>
+        <a class="lp-nav__link" href="/blog/">Blog</a>
         <a class="lp-nav__link lp-nav__3d" href="/3d/">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 21 7v10l-9 5-9-5V7z"/><path d="M12 12 21 7M12 12v10M12 12 3 7"/></svg>
           <span>3D</span>
@@ -414,6 +415,7 @@
         <div>
           <h4>Project</h4>
           <ul>
+            <li><a href="/blog/">Blog</a></li>
             <li><a href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">GitHub</a></li>
             <li><a href="https://x.com/pocket_js" target="_blank" rel="noreferrer">X (Twitter)</a></li>
             <li><a href="/docs/native-contract/">Native contract</a></li>

--- a/site/nav.ts
+++ b/site/nav.ts
@@ -41,6 +41,25 @@ export const DOC_NAV: DocSection[] = [
   },
 ];
 
+// The blog registry. build.ts renders one page per post from
+// site/content/blog/<slug>.md plus the /blog/ index (newest first).
+export interface BlogPost {
+  slug: string;
+  title: string;
+  date: string; // ISO yyyy-mm-dd
+  description: string;
+}
+
+export const BLOG_POSTS: BlogPost[] = [
+  {
+    slug: "introducing-pocketjs",
+    title: "Introducing PocketJS",
+    date: "2026-07-06",
+    description:
+      "Real Solid and Vue Vapor components, a compile-time Tailwind design system, and 60 FPS native animation on a 2004 handheld — inside 8 MB. What PocketJS is, and what's actually new in it.",
+  },
+];
+
 export const AOT_DOC_NAV: DocSection[] = [
   {
     title: "Product line",

--- a/site/nav.ts
+++ b/site/nav.ts
@@ -48,6 +48,7 @@ export interface BlogPost {
   title: string;
   date: string; // ISO yyyy-mm-dd
   description: string;
+  author: { name: string; url: string };
 }
 
 export const BLOG_POSTS: BlogPost[] = [
@@ -57,6 +58,7 @@ export const BLOG_POSTS: BlogPost[] = [
     date: "2026-07-06",
     description:
       "Real Solid and Vue Vapor components, a compile-time Tailwind design system, and 60 FPS native animation on a 2004 handheld — inside 8 MB. What PocketJS is, and what's actually new in it.",
+    author: { name: 'Yifeng "Evan" Wang', url: "https://github.com/doodlewind" },
   },
 ];
 

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -13,7 +13,7 @@ export const OG_IMAGE_URL = `${SITE_URL}/og-image.png`;
 
 export interface PageOpts {
   title: string | null; // null uses the bare wordmark (homepage)
-  active: string; // "home" | "docs" | "aot" | "playground"
+  active: string; // "home" | "docs" | "aot" | "playground" | "blog"
   body: string;
   bodyClass?: string;
   head?: string;
@@ -51,6 +51,7 @@ function header(active: string): string {
     <nav class="site-nav__links" aria-label="Primary">
       ${link("/docs/overview/", "Docs", "docs")}
       ${link("/playground/", "Playground", "playground")}
+      ${link("/blog/", "Blog", "blog")}
       <a href="/3d/" class="site-nav__link site-nav__3d ${active === "3d" ? "on" : ""}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 21 7v10l-9 5-9-5V7z"/><path d="M12 12 21 7M12 12v10M12 12 3 7"/></svg><span>3D</span></a>
       <a href="${GH}" target="_blank" rel="noreferrer" class="site-nav__link site-nav__gh">${ghIcon}<span class="site-nav__ghlabel">GitHub</span></a>
       <a href="${X_URL}" target="_blank" rel="noreferrer" class="site-nav__link site-nav__x" aria-label="PocketJS on X">${xIcon}</a>
@@ -87,6 +88,7 @@ const footer = `<footer class="mt-24 border-t border-line/70 bg-ink-2/60">
       <div class="text-sm">
         <h4 class="mb-3 font-semibold text-slate-200">Project</h4>
         <ul class="space-y-2 text-slate-400">
+          <li><a class="hover:text-brand-2" href="/blog/">Blog</a></li>
           <li><a class="hover:text-brand-2" href="${GH}" target="_blank" rel="noreferrer">GitHub</a></li>
           <li><a class="hover:text-brand-2" href="${X_URL}" target="_blank" rel="noreferrer">X (Twitter)</a></li>
           <li><a class="hover:text-brand-2" href="/docs/native-contract/">Native contract</a></li>


### PR DESCRIPTION
## Summary

- Adds a **Blog** section to pocketjs.dev: `BLOG_POSTS` registry in `site/nav.ts`, a `/blog/` index page, and per-post pages rendered from `site/content/blog/<slug>.md`.
- Extracts the docs' marked/shiki setup into `setupMarkdown()` so docs and blog share one markdown pipeline.
- Adds Blog links to the shared header/footer (`templates.ts`) and the landing page's own chrome (`home.html` nav + footer).
- First post: **Introducing PocketJS** — the launch announcement, walking through the stack's technical innovations (real Solid/Vue Vapor on bare metal, the twice-compiled `no_std` core, the one-crossing-per-frame native contract, compile-time Tailwind, byte-exact frame testing, baked fonts, the 8 MB arena, and the in-browser toolchain). Embeds the hardware demo video.
- Tailwind `@source` now also scans `.md` so raw HTML embedded in posts gets its utility classes compiled.

## Validation

- `bun site/build.ts` → `blog (1 posts)`, clean build.
- `bunx tsc --noEmit` clean.
- Headless-Chrome verification (`site/verify.ts`): `/`, `/blog/`, `/blog/introducing-pocketjs/` all render with no page/console errors; nav shows Blog on both the shared shell and landing chrome; post page has video, diagram, and highlighted code blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)