### PR TITLE
feat(release): npm publish pipeline, pocketjs CLI, changelog page

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release to npm
+
+# Publish @pocketjs/framework and @pocketjs/cli when a v* tag is pushed
+# (e.g. `git tag v0.2.0 && git push origin v0.2.0`). Requires the NPM_TOKEN
+# repo secret (an npm automation token with publish rights on @pocketjs).
+# Publishing is idempotent: versions already on the registry are skipped, so
+# re-running a tag or bumping only one package is safe.
+on:
+  push:
+    tags: ["v*"]
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  id-token: write # npm --provenance
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      # npm (not bun) does the publishing — provenance support + registry auth.
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      # host-web/pocketjs.wasm is a gitignored build artifact shipped in the
+      # framework tarball, so build it from core/wasm. Stable Rust suffices.
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo + wasm target
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            wasm/target
+          key: ${{ runner.os }}-wasm-${{ hashFiles('wasm/Cargo.toml', 'core/Cargo.toml', 'wasm/src/**', 'core/src/**') }}
+          restore-keys: ${{ runner.os }}-wasm-
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build wasm (core + software rasterizer)
+        run: bun scripts/wasm.ts
+
+      - name: Test
+        run: bun run test
+
+      - name: Publish @pocketjs/framework
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version already published — skipping"
+          else
+            npm publish --access public --provenance
+          fi
+
+      - name: Publish @pocketjs/cli
+        working-directory: cli
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          name=$(node -p "require('./package.json').name")
+          version=$(node -p "require('./package.json').version")
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "$name@$version already published — skipping"
+          else
+            npm publish --access public --provenance
+          fi

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Yifeng Wang
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,31 @@
+# @pocketjs/cli
+
+The [PocketJS](https://pocketjs.dev) toolchain CLI — `doctor`/`setup` for the
+bun + Rust + PSP toolchain (flutter-doctor style), app scaffolding, and
+build/run passthrough.
+
+```sh
+npm install -g @pocketjs/cli
+
+pocketjs doctor            # diagnose bun / Rust / PSP toolchain / PSPLINK
+pocketjs setup             # install what doctor found missing
+pocketjs create my-app     # scaffold demos/my-app in a PocketJS checkout
+pocketjs dev my-app-main   # build + serve in the browser
+pocketjs psp my-app        # build the PSP EBOOT
+pocketjs hw my-app         # build + run on a real PSP over PSPLINK
+pocketjs psplink           # interactive multi-app switcher on a real PSP
+```
+
+`create`, `dev`, `build`, `psp`, `hw` and `psplink` run inside a PocketJS
+checkout (the CLI finds it by walking up from the current directory):
+
+```sh
+git clone https://github.com/pocket-stack/pocketjs
+cd pocketjs && bun install
+pocketjs doctor
+```
+
+Only Node ≥ 18 is required for the CLI itself; everything it diagnoses or
+installs is for building PocketJS apps. See the
+[repository](https://github.com/pocket-stack/pocketjs) and
+[pocketjs.dev](https://pocketjs.dev) for the framework docs.

--- a/cli/bin.mjs
+++ b/cli/bin.mjs
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+// @pocketjs/cli — the PocketJS toolchain CLI (flutter/react-native doctor
+// style). Zero dependencies; plain Node >= 18.
+//
+//   pocketjs doctor          diagnose the local toolchain
+//   pocketjs setup [--yes]   install what doctor found missing (best effort)
+//   pocketjs create <name>   scaffold a demo app inside a PocketJS checkout
+//   pocketjs dev|build|psp|hw|psplink [...args]
+//                            passthrough to the checkout's bun scripts
+//
+// The PSP toolchain pin below MUST match scripts/psp.ts in the framework
+// checkout — the CLI only diagnoses/installs, the build scripts consume.
+
+import { execFileSync, spawnSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir, platform } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { createInterface } from "node:readline";
+
+const NIGHTLY = "nightly-2026-05-28";
+const C = {
+  ok: (s) => `\x1b[32m✓\x1b[0m ${s}`,
+  bad: (s) => `\x1b[31m✗\x1b[0m ${s}`,
+  warn: (s) => `\x1b[33m!\x1b[0m ${s}`,
+  dim: (s) => `\x1b[2m${s}\x1b[0m`,
+  bold: (s) => `\x1b[1m${s}\x1b[0m`,
+};
+
+const which = (bin) => {
+  const r = spawnSync(platform() === "win32" ? "where" : "which", [bin], { encoding: "utf8" });
+  return r.status === 0 ? r.stdout.trim().split("\n")[0] : null;
+};
+const run = (cmd, args) => {
+  const r = spawnSync(cmd, args, { encoding: "utf8" });
+  return r.status === 0 ? r.stdout.trim() : null;
+};
+
+// ---------------------------------------------------------------------------
+// Checkout discovery
+// ---------------------------------------------------------------------------
+
+function findCheckout(from = process.cwd()) {
+  let dir = resolve(from);
+  for (;;) {
+    const pkg = join(dir, "package.json");
+    if (existsSync(pkg)) {
+      try {
+        if (JSON.parse(readFileSync(pkg, "utf8")).name === "@pocketjs/framework") return dir;
+      } catch {}
+    }
+    const parent = dirname(dir);
+    if (parent === dir) return null;
+    dir = parent;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// doctor
+// ---------------------------------------------------------------------------
+
+function sdkCandidates(root) {
+  const home = homedir();
+  const out = [process.env.PSP_SDK].filter(Boolean);
+  if (root) {
+    // Mirrors the candidate order in scripts/psp.ts.
+    out.push(join(root, "mipsel-sony-psp"));
+    out.push(join(root, "dreamcart", "mipsel-sony-psp"));
+  }
+  out.push(join(home, "code", "dreamcart", "mipsel-sony-psp"));
+  return out;
+}
+
+function checks() {
+  const root = findCheckout();
+  const isMac = platform() === "darwin";
+  const llvm = isMac
+    ? ["/opt/homebrew/opt/llvm/bin/clang", "/usr/local/opt/llvm/bin/clang"].find(existsSync) ?? null
+    : which("clang");
+  const toolchains = run("rustup", ["toolchain", "list"]) ?? "";
+  const targets = run("rustup", ["target", "list", "--installed"]) ?? "";
+  const sdk = sdkCandidates(root).find((p) => existsSync(join(p, "psp", "lib", "libc.a"))) ?? null;
+  return {
+    root,
+    isMac,
+    core: [
+      { name: "bun", ok: !!which("bun"), hint: "curl -fsSL https://bun.sh/install | bash" },
+      { name: "rustup", ok: !!which("rustup"), hint: "curl https://sh.rustup.rs -sSf | sh" },
+      {
+        name: "Rust stable + wasm32-unknown-unknown (web host)",
+        ok: targets.includes("wasm32-unknown-unknown"),
+        fix: ["rustup", ["target", "add", "wasm32-unknown-unknown"]],
+      },
+      {
+        name: "PocketJS checkout",
+        ok: !!root,
+        hint: "git clone https://github.com/pocket-stack/pocketjs && cd pocketjs",
+        detail: root ?? undefined,
+      },
+    ],
+    psp: [
+      {
+        name: `Rust ${NIGHTLY} (PSP builds)`,
+        ok: toolchains.includes(NIGHTLY),
+        fix: ["rustup", ["toolchain", "install", NIGHTLY, "--component", "rust-src"]],
+      },
+      { name: "cargo-psp", ok: !!which("cargo-psp"), fix: ["cargo", ["install", "cargo-psp"]] },
+      {
+        name: "Homebrew LLVM (TARGET_CFLAGS clang)",
+        ok: !!llvm,
+        fix: isMac ? ["brew", ["install", "llvm"]] : null,
+        hint: isMac ? undefined : "install clang/llvm via your distro's package manager",
+        detail: llvm ?? undefined,
+      },
+      {
+        name: "rust-psp SDK (mipsel-sony-psp)",
+        ok: !!sdk,
+        hint: "set PSP_SDK=/path/to/mipsel-sony-psp (contains psp/lib/libc.a)",
+        detail: sdk ?? undefined,
+      },
+      {
+        name: "PSPLINK host tools (usbhostfs_pc + pspsh)",
+        ok: !!which("usbhostfs_pc") && !!which("pspsh"),
+        hint: "build from https://github.com/pspdev/psplinkusb (or the pspdev toolchain)",
+      },
+    ],
+    optional: [
+      {
+        name: "PPSSPPHeadless (emulator E2E)",
+        ok: existsSync(join(homedir(), "ppsspp-src", "build", "PPSSPPHeadless")) || !!process.env.PPSSPP_HEADLESS,
+        hint: "source-build PPSSPP with headless, or set PPSSPP_HEADLESS",
+      },
+      { name: "ImageMagick (frame decoding)", ok: !!which("magick"), fix: isMac ? ["brew", ["install", "imagemagick"]] : null },
+    ],
+  };
+}
+
+function doctor() {
+  const c = checks();
+  const section = (title, items) => {
+    console.log("\n" + C.bold(title));
+    for (const it of items) {
+      const line = it.ok ? C.ok(it.name) : title === "Optional" ? C.warn(it.name) : C.bad(it.name);
+      console.log("  " + line + (it.detail ? C.dim(`  (${it.detail})`) : ""));
+      if (!it.ok && (it.hint || it.fix)) {
+        console.log("      " + C.dim(it.fix ? `fix: ${it.fix[0]} ${it.fix[1].join(" ")}` : it.hint));
+      }
+    }
+  };
+  console.log(C.bold("PocketJS doctor"));
+  section("Core (web/desktop development)", c.core);
+  section("PSP hardware builds", c.psp);
+  section("Optional", c.optional);
+  const missing = [...c.core, ...c.psp].filter((i) => !i.ok).length;
+  console.log(
+    "\n" +
+      (missing === 0
+        ? C.ok("Everything looks good.")
+        : C.warn(`${missing} issue(s) found — run ${C.bold("pocketjs setup")} to fix the installable ones.`)),
+  );
+  process.exitCode = 0;
+}
+
+// ---------------------------------------------------------------------------
+// setup
+// ---------------------------------------------------------------------------
+
+async function confirm(question) {
+  if (process.argv.includes("--yes") || process.argv.includes("-y")) return true;
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const answer = await new Promise((res) => rl.question(`${question} [y/N] `, res));
+  rl.close();
+  return /^y(es)?$/i.test(answer.trim());
+}
+
+async function setup() {
+  const c = checks();
+  const fixable = [...c.core, ...c.psp, ...c.optional].filter((i) => !i.ok && i.fix);
+  const manual = [...c.core, ...c.psp].filter((i) => !i.ok && !i.fix);
+  if (fixable.length === 0 && manual.length === 0) {
+    console.log(C.ok("Nothing to do — the toolchain is complete."));
+    return;
+  }
+  for (const it of fixable) {
+    const [cmd, args] = it.fix;
+    if (!(await confirm(`Install ${C.bold(it.name)} via \`${cmd} ${args.join(" ")}\`?`))) continue;
+    console.log(C.dim(`$ ${cmd} ${args.join(" ")}`));
+    const r = spawnSync(cmd, args, { stdio: "inherit" });
+    console.log(r.status === 0 ? C.ok(it.name) : C.bad(`${it.name} (exit ${r.status})`));
+  }
+  if (manual.length > 0) {
+    console.log("\n" + C.bold("Manual steps remaining:"));
+    for (const it of manual) console.log("  " + C.warn(it.name) + "\n      " + C.dim(it.hint ?? ""));
+  }
+  console.log("\nRe-run " + C.bold("pocketjs doctor") + " to verify.");
+}
+
+// ---------------------------------------------------------------------------
+// create
+// ---------------------------------------------------------------------------
+
+const APP_TSX = (title) => `// ${title} — scaffolded by \`pocketjs create\`.
+import { createSignal } from "solid-js";
+import { Text, View } from "@pocketjs/framework/components";
+import { onButtonPress } from "@pocketjs/framework/lifecycle";
+import { BTN } from "@pocketjs/framework/input";
+
+export default function App() {
+  const [count, setCount] = createSignal(0);
+  onButtonPress(BTN.CROSS, () => setCount((n) => n + 1));
+  return (
+    <View class="w-full h-full flex-col items-center justify-center gap-4 bg-slate-950">
+      <View class="w-[48] h-[48] rounded-[12px] bg-indigo-500 animate-spin" />
+      <Text class="text-xl text-white font-bold">{\`Count: \${count()}\`}</Text>
+      <Text class="text-sm text-slate-400">Press CROSS (Z / Enter) to count</Text>
+    </View>
+  );
+}
+`;
+
+const MAIN_TSX = (title) => `// @title PocketJS: ${title}
+import App from "./app.tsx";
+import { mount } from "@pocketjs/framework";
+
+mount(() => <App />);
+`;
+
+const CONFIG_TS = `import { definePocketConfig } from "@pocketjs/framework/config";
+
+export default definePocketConfig({
+  framework: "solid",
+  // theme: { keyframes: { … }, animation: { … } }  — see /docs and the
+  // "Baking Motion" post for the animation surface.
+});
+`;
+
+function create(name) {
+  if (!name || !/^[a-z][a-z0-9-]*$/.test(name)) {
+    console.error(C.bad("usage: pocketjs create <kebab-case-name>"));
+    process.exit(1);
+  }
+  const root = findCheckout();
+  if (!root) {
+    console.error(C.bad("not inside a PocketJS checkout — clone https://github.com/pocket-stack/pocketjs first"));
+    process.exit(1);
+  }
+  const dir = join(root, "demos", name);
+  if (existsSync(dir)) {
+    console.error(C.bad(`demos/${name} already exists`));
+    process.exit(1);
+  }
+  const title = name.replace(/-/g, " ").replace(/\b\w/g, (ch) => ch.toUpperCase());
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "app.tsx"), APP_TSX(title));
+  writeFileSync(join(dir, "main.tsx"), MAIN_TSX(title));
+  writeFileSync(join(dir, "pocket.config.ts"), CONFIG_TS);
+  console.log(C.ok(`demos/${name} scaffolded`));
+  console.log(C.dim(`  pocketjs dev ${name}-main     # browser at http://127.0.0.1:8130/`));
+  console.log(C.dim(`  pocketjs psp ${name} --release  # PSP EBOOT`));
+}
+
+// ---------------------------------------------------------------------------
+// passthrough
+// ---------------------------------------------------------------------------
+
+const SCRIPTS = { dev: "scripts/dev.ts", build: "scripts/build.ts", psp: "scripts/psp.ts", hw: "scripts/hw.ts", psplink: "scripts/psplink.ts" };
+
+function passthrough(cmd, args) {
+  const root = findCheckout();
+  if (!root) {
+    console.error(C.bad(`\`pocketjs ${cmd}\` must run inside a PocketJS checkout`));
+    process.exit(1);
+  }
+  if (!which("bun")) {
+    console.error(C.bad("bun not found — run `pocketjs setup`"));
+    process.exit(1);
+  }
+  const r = spawnSync("bun", [join(root, SCRIPTS[cmd]), ...args], { stdio: "inherit", cwd: root });
+  process.exit(r.status ?? 1);
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+
+const [, , cmd, ...rest] = process.argv;
+const HELP = `${C.bold("pocketjs")} — the PocketJS toolchain CLI
+
+  pocketjs doctor            diagnose bun / Rust / PSP toolchain / PSPLINK
+  pocketjs setup [--yes]     install what doctor found missing
+  pocketjs create <name>     scaffold demos/<name> in a PocketJS checkout
+  pocketjs dev <app>-main    build + serve an app in the browser
+  pocketjs build <app>       build an app bundle + pak
+  pocketjs psp <app>         build the PSP EBOOT
+  pocketjs hw <app>          build + run on a real PSP over PSPLINK
+  pocketjs psplink           interactive multi-app switcher on a real PSP
+`;
+
+switch (cmd) {
+  case "doctor":
+    doctor();
+    break;
+  case "setup":
+    await setup();
+    break;
+  case "create":
+    create(rest[0]);
+    break;
+  case "dev":
+  case "build":
+  case "psp":
+  case "hw":
+  case "psplink":
+    passthrough(cmd, rest);
+    break;
+  case "--version":
+  case "-v":
+    console.log(JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")).version);
+    break;
+  default:
+    console.log(HELP);
+    process.exitCode = cmd && cmd !== "--help" && cmd !== "help" ? 1 : 0;
+}

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@pocketjs/cli",
+  "version": "0.2.0",
+  "description": "The PocketJS toolchain CLI — doctor/setup for the bun + Rust + PSP toolchain, app scaffolding, and build/run passthrough.",
+  "license": "MIT",
+  "type": "module",
+  "bin": {
+    "pocketjs": "./bin.mjs"
+  },
+  "files": [
+    "bin.mjs",
+    "README.md"
+  ],
+  "engines": {
+    "node": ">=18"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pocket-stack/pocketjs.git",
+    "directory": "cli"
+  },
+  "homepage": "https://pocketjs.dev",
+  "keywords": [
+    "pocketjs",
+    "psp",
+    "cli",
+    "toolchain",
+    "doctor"
+  ],
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,8 +1,44 @@
 {
   "name": "@pocketjs/framework",
   "version": "0.2.0",
-  "private": true,
+  "license": "MIT",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pocket-stack/pocketjs.git"
+  },
+  "homepage": "https://pocketjs.dev",
+  "keywords": [
+    "pocketjs",
+    "psp",
+    "solid",
+    "vue-vapor",
+    "tailwind",
+    "jsx",
+    "embedded-ui",
+    "wasm"
+  ],
+  "files": [
+    "src",
+    "compiler",
+    "spec",
+    "scripts",
+    "host-web",
+    "assets/fonts",
+    "core/src",
+    "core/Cargo.toml",
+    "wasm/src",
+    "wasm/Cargo.toml",
+    "native/src",
+    "native/targets",
+    "native/build.rs",
+    "native/Cargo.toml",
+    "pocket.config.ts",
+    "tsconfig.json"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": "./src/index.ts",
     "./animation": "./src/animation.ts",

--- a/site/build.ts
+++ b/site/build.ts
@@ -395,6 +395,7 @@ async function main() {
   const highlight = await setupMarkdown();
   await buildDocs(highlight);
   await buildBlog();
+  buildChangelog();
 
   // 9b. 404
   write("404.html", renderPage({
@@ -737,6 +738,23 @@ function formatPostDate(iso: string): string {
 }
 
 const BLOG_DESC = "Announcements and engineering notes from the PocketJS team.";
+function buildChangelog() {
+  const md = SITE + "content/changelog.md";
+  if (!existsSync(md)) return;
+  const html = marked.parse(readFileSync(md, "utf8")) as string;
+  write("changelog/index.html", renderPage({
+    title: "Changelog",
+    active: "changelog",
+    desc: "Engine and site milestones — what shipped in each PocketJS release.",
+    path: "/changelog/",
+    body:
+      `<main class="mx-auto w-full max-w-3xl px-6 py-14">` +
+      `<article class="prose prose-invert max-w-none doc-content">${html}</article>` +
+      `</main>`,
+  }));
+  console.log("  changelog  (1 page)");
+}
+
 async function buildBlog() {
   const dir = SITE + "content/blog/";
   const posts = [...BLOG_POSTS].sort((a, b) => (a.date < b.date ? 1 : -1));

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -1,0 +1,52 @@
+# Changelog
+
+Engine and site milestones, newest first. Versions track the
+`@pocketjs/framework` npm package.
+
+## 0.2.0 — July 7, 2026
+
+**The animation engine.** The Tailwind style table learned motion —
+[read the deep-dive](/blog/baking-motion/).
+
+- **Baked keyframe timelines** — `theme.keyframes` / `theme.animation` in
+  `pocket.config.ts` (tailwind.config shape) compile into frame-precise,
+  per-property segment timelines inside `styles.bin`; `animate-<name>`
+  utilities apply them. Full CSS shorthand semantics: comma lists, fills,
+  delays, `reverse`, `infinite`, `cubic-bezier(…)` with named easings baked
+  to their canonical curves.
+- **`animate-loop-[Nms]`** — a style-level loop period that replays a node's
+  whole choreography (delays included), the loop plain CSS can't express
+  without a remount.
+- **3D transform pipeline** — `perspective-[N]` context roots,
+  `rotate-x/-y-[deg]`, `translate-z-[px]`; subtrees compose 3×4 matrices,
+  project about the root center and painter-sort into clipped triangles.
+- **Arc primitive** — `arc-start/-sweep/-width` stroke a round-capped
+  annular sector from the background color; all three animatable.
+- **`TEX_TRI` DrawList op** — textured triangles in all three backends;
+  2D-rotated images un-culled, textures ride 3D surfaces.
+- **SVG path baking** — `compiler/bake-svg.ts` rasterizes `<path>` data
+  (beziers, winding rules, transforms, `fill="hole"` masks) into pak
+  textures.
+- **Real-hardware performance** (measured on a PSP over PSPLINK): baked-disc
+  rounded corners, incremental taffy layout, a radius-capped disc cache and
+  a pipelined CPU/GPU frame loop took the busiest demo page from 17.4 ms
+  and dropped frames to a locked 60 FPS.
+- **Motion Lab demo** — four pages of yui540's motion studies ported
+  one-to-one; now the homepage hero and the playground default.
+- Tooling: `bun psplink` rebuilds stale cached PRXs by input mtime.
+
+## 0.1.0 — July 6, 2026
+
+**Initial public release** — [Introducing PocketJS](/blog/introducing-pocketjs/).
+
+- `#![no_std]` Rust core: retained tree, taffy flexbox, compiled Tailwind
+  styles, baked font atlases, tween/spring animation, deterministic
+  fixed-dt DrawList rendering.
+- Real Solid and Vue Vapor components through their official custom
+  renderers; React Native-style `<View>` / `<Text>` / `<Image>` primitives.
+- Hosts: Sony PSP (QuickJS + sceGu), browser WebAssembly (software
+  rasterizer), desktop wgpu window, headless Bun for byte-exact golden
+  tests, PPSSPP end-to-end capture harness.
+- Two-pass build: class literals and codepoints collected from the AST,
+  styles/fonts/images baked into a `.pak`.
+- pocketjs.dev: docs, blog, and the in-browser live-recompile playground.

--- a/site/home.html
+++ b/site/home.html
@@ -19,10 +19,7 @@
         <a class="lp-nav__link" href="/docs/overview/">Docs</a>
         <a class="lp-nav__link" href="/playground/">Playground</a>
         <a class="lp-nav__link" href="/blog/">Blog</a>
-        <a class="lp-nav__link lp-nav__3d" href="/3d/">
-          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 21 7v10l-9 5-9-5V7z"/><path d="M12 12 21 7M12 12v10M12 12 3 7"/></svg>
-          <span>3D</span>
-        </a>
+        <a class="lp-nav__link" href="/changelog/">Changelog</a>
         <a class="lp-nav__link lp-nav__gh" href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 4.7 18 5 18 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
           <span class="lp-nav__ghlabel">GitHub</span>

--- a/site/nav.ts
+++ b/site/nav.ts
@@ -54,7 +54,7 @@ export interface BlogPost {
 export const BLOG_POSTS: BlogPost[] = [
   {
     slug: "baking-motion",
-    title: "Baking Motion: Keyframes, Arcs, and 3D in the Style Engine",
+    title: "Baking Motion into PocketJS: Keyframes, Arcs, and a 3D Pipeline",
     date: "2026-07-07",
     description:
       "The style table learns motion: compile-time keyframe timelines, an animatable stroke-arc primitive, and a painter-sorted 3D pipeline — plus the four hardware performance lessons a one-to-one port of yui540's motion studies forced out of the engine.",

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -52,7 +52,7 @@ function header(active: string): string {
       ${link("/docs/overview/", "Docs", "docs")}
       ${link("/playground/", "Playground", "playground")}
       ${link("/blog/", "Blog", "blog")}
-      <a href="/3d/" class="site-nav__link site-nav__3d ${active === "3d" ? "on" : ""}"><svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2 21 7v10l-9 5-9-5V7z"/><path d="M12 12 21 7M12 12v10M12 12 3 7"/></svg><span>3D</span></a>
+      ${link("/changelog/", "Changelog", "changelog")}
       <a href="${GH}" target="_blank" rel="noreferrer" class="site-nav__link site-nav__gh">${ghIcon}<span class="site-nav__ghlabel">GitHub</span></a>
       <a href="${X_URL}" target="_blank" rel="noreferrer" class="site-nav__link site-nav__x" aria-label="PocketJS on X">${xIcon}</a>
     </nav>


### PR DESCRIPTION
## What

Everything needed to ship PocketJS as installable packages, plus the site follow-ups from this round of feedback.

### npm publish pipeline
- **`@pocketjs/framework` publish prep** — removed `private`, added MIT `LICENSE`, `files` whitelist (TS sources, compiler, spec, scripts, web host including the built `pocketjs.wasm`, font assets, and the three Rust crate sources so `psp`/`hw` builds work from the tarball), `repository`/`homepage`/`keywords`, `publishConfig.access: public`. Dry-run tarball: 1.1 MB / 86 files.
- **`.github/workflows/release.yml`** — pushing a `v*` tag runs tests, builds the wasm artifact, and `npm publish --provenance`es both packages. Versions already on the registry are skipped, so re-running a tag or bumping one package at a time is safe. Auth via the `NPM_TOKEN` repo secret (already set).

### `@pocketjs/cli` — `pocketjs` on your PATH
A zero-dependency Node ESM CLI in `cli/`, in the spirit of `flutter doctor` / `react-native doctor`:
- `pocketjs doctor` — diagnoses bun, rustup, the wasm target, the pinned PSP nightly (`nightly-2026-05-28`), `cargo-psp`, Homebrew LLVM, the rust-psp SDK (mirroring `scripts/psp.ts` candidate paths + `PSP_SDK`), PSPLINK host tools, and optional PPSSPP/ImageMagick — with a concrete fix line per miss.
- `pocketjs setup [--yes]` — executes the installable fixes (rustup toolchain/target, `cargo install cargo-psp`, brew LLVM/ImageMagick), lists the manual ones.
- `pocketjs create <name>` — scaffolds `demos/<name>` (app + main + `pocket.config.ts`) inside a checkout.
- `pocketjs dev|build|psp|hw|psplink` — passthrough to the checkout's bun scripts, found by walking up to `@pocketjs/framework`.

### Site
- Blog title now carries the keyword: **"Baking Motion into PocketJS: Keyframes, Arcs, and a 3D Pipeline"**.
- Landing + docs nav: the 3D entry is hidden (page still exists at `/3d/`), replaced by **Changelog**.
- New `/changelog/` page generated from `site/content/changelog.md` (0.2.0 animation engine, 0.1.0 initial release).

## Verification
- `bun run test` — 96 pass; `bunx tsc --noEmit` clean.
- `npm pack --dry-run` inspected for both packages (wasm/LICENSE/Cargo.toml present in framework tarball; CLI is 3 files).
- `node cli/bin.mjs doctor` all green on a fully provisioned machine; `--version`, help, and scaffold paths exercised.
- Site rebuilt: homepage nav shows Docs/Playground/Blog/Changelog (no `/3d/`), `/changelog/` renders, blog index shows the new title.

After merge: tag `v0.2.0` to trigger the first automated publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)