### PR TITLE
chore(release): v0.2.1 — npm badges, install docs, changelog entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 <h1><img src="./site/assets/favicon.svg" width="40" height="40" alt="" align="absmiddle" /> PocketJS</h1>
 
+[![@pocketjs/framework](https://img.shields.io/npm/v/%40pocketjs%2Fframework?label=%40pocketjs%2Fframework)](https://www.npmjs.com/package/@pocketjs/framework)
+[![@pocketjs/cli](https://img.shields.io/npm/v/%40pocketjs%2Fcli?label=%40pocketjs%2Fcli)](https://www.npmjs.com/package/@pocketjs/cli)
+[![license: MIT](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
+
 High-performance JSX UI outside the browser, with native rendering, standard
 Vue Vapor and Solid support, a Tailwind design system, and 60 FPS animation
 under an 8 MB memory budget. Write Solid or Vue Vapor components, run them on
@@ -34,6 +38,12 @@ bun install
 bun scripts/build.ts hero             # -> dist/hero.js + dist/hero.pak
 bun scripts/build.ts hero-vue-vapor-main --framework=vue-vapor
 ```
+
+Or drive everything through the [`pocketjs` CLI](https://www.npmjs.com/package/@pocketjs/cli):
+`npm i -g @pocketjs/cli`, then `pocketjs doctor` checks the bun / Rust / PSP
+toolchain (`pocketjs setup` installs what's missing), `pocketjs create <name>`
+scaffolds an app, and `pocketjs dev|build|psp|hw|psplink` wrap the scripts
+below.
 
 The build is two-pass: pass 1 babel-transforms every module reachable from the
 entry (framework-specific JSX + TypeScript, content-hash cached in

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pocketjs/cli",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "The PocketJS toolchain CLI — doctor/setup for the bun + Rust + PSP toolchain, app scaffolding, and build/run passthrough.",
   "license": "MIT",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pocketjs/framework",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -3,6 +3,19 @@
 Engine and site milestones, newest first. Versions track the
 `@pocketjs/framework` npm package.
 
+## 0.2.1 — July 7, 2026
+
+**On npm.** PocketJS is now installable.
+
+- [`@pocketjs/framework`](https://www.npmjs.com/package/@pocketjs/framework)
+  and [`@pocketjs/cli`](https://www.npmjs.com/package/@pocketjs/cli) published
+  under the MIT license.
+- New `pocketjs` CLI — flutter-style `doctor` / `setup` for the bun + Rust +
+  PSP toolchain, `create` app scaffolding, and `dev` / `build` / `psp` / `hw` /
+  `psplink` passthrough.
+- Releases are automated: pushing a version tag publishes both packages from
+  GitHub Actions via npm trusted publishing (OIDC), with provenance.
+
 ## 0.2.0 — July 7, 2026
 
 **The animation engine.** The Tailwind style table learned motion —

--- a/site/content/docs/getting-started.md
+++ b/site/content/docs/getting-started.md
@@ -31,6 +31,19 @@ cd pocketjs
 bun install
 ```
 
+The [`@pocketjs/cli`](https://www.npmjs.com/package/@pocketjs/cli) package can
+check (and mostly install) the toolchain for you, flutter-doctor style:
+
+```sh
+npm install -g @pocketjs/cli
+pocketjs doctor   # diagnoses bun, the Rust targets, and the PSP toolchain
+pocketjs setup    # installs whatever doctor flagged as missing
+```
+
+It also wraps the day-to-day commands — `pocketjs create <name>` scaffolds a
+demo app, and `pocketjs dev|build|psp|hw|psplink` run the build scripts from
+anywhere inside the checkout.
+
 That pulls `solid-js`, Vue Vapor dependencies, and the build-time tooling (the
 Babel + Tailwind-subset compiler, the font baker, and the dev host). There is no
 separate runtime to install — the framework is the `@pocketjs/framework` package


### PR DESCRIPTION
## What

Follow-up now that `@pocketjs/framework` and `@pocketjs/cli` 0.2.0 are live on npm:

- **README** — npm version badges for both packages + a CLI quickstart paragraph (`npm i -g @pocketjs/cli`, `doctor`/`setup`/`create` and the passthrough commands).
- **Getting started** — documents the CLI as the flutter-doctor-style way to provision the toolchain.
- **Changelog** — 0.2.1 entry: packages on npm, the CLI, tokenless release automation.
- **Version bumps** — framework + cli 0.2.0 → 0.2.1.

Tagging `v0.2.1` after merge doubles as the first end-to-end verification of the trusted-publishing (OIDC) pipeline — 0.2.0 was bootstrap-published locally with an OTP, so the automated path hasn't proven itself yet.

## Verification

- Site rebuilt: `/changelog/` shows the 0.2.1 entry, getting-started renders the CLI section.
- Registry install smoke-tested: `npm i @pocketjs/framework @pocketjs/cli` from a clean dir, `pocketjs --version`/`doctor` run, wasm + LICENSE present in the framework tarball.

🤖 Generated with [Claude Code](https://claude.com/claude-code)