### PR TITLE
docs(site): cover 0.2 animation + 0.3 DevTools across the docs

### DIFF
--- a/site/build.ts
+++ b/site/build.ts
@@ -600,6 +600,20 @@ async function setupMarkdown(): Promise<Highlight> {
         const text = token.text ?? "";
         return highlight(text, token.lang ?? "");
       },
+      // GitHub-style heading slugs so in-page anchors (#3d-transforms) and
+      // deep links into docs sections work.
+      heading(token: { tokens?: unknown[]; depth?: number; text?: string }) {
+        const depth = token.depth ?? 1;
+        const html = this.parser!.parseInline(token.tokens as never);
+        const slug = (token.text ?? "")
+          .toLowerCase()
+          .replace(/<[^>]+>/g, "")
+          .replace(/[`*_]/g, "")
+          .replace(/[^a-z0-9\s-]/g, "")
+          .trim()
+          .replace(/\s+/g, "-");
+        return `<h${depth} id="${slug}">${html}</h${depth}>\n`;
+      },
     },
   });
   return highlight;

--- a/site/content/docs/animation.md
+++ b/site/content/docs/animation.md
@@ -1,14 +1,17 @@
 # Animation
 
-PocketJS has two ways to move things:
+PocketJS has three ways to move things:
 
-- **Declarative motion utilities** — Tailwind-subset classes (`transition`, `duration-N`,
+- **Baked keyframe timelines** — CSS-grade `keyframes` / `animation` choreography
+  authored in `pocket.config.ts` and applied with `animate-<name>` classes. Compiled
+  into binary timelines at build time; the richest option.
+- **Transition utilities** — Tailwind-subset classes (`transition`, `duration-N`,
   `ease-*`, `delay-N`) that tween a node whenever its style is swapped.
 - **The imperative API** — `animate()`, `spring()` and `cancelAnim()` from
   [`@pocketjs/framework/animation`](/docs/api/), for one-off tweens you kick off from code.
 
-Both compile down to the same native machinery. **You declare motion once in JS; the
-Rust core owns the tween from there.**
+All three compile down to the same native machinery. **You declare motion once; the
+Rust core owns every frame from there.**
 
 ## How native animation works
 
@@ -100,7 +103,10 @@ For non-color props you pass the raw native value:
 | ------------------------------------------------------------------ | ----------------------- |
 | `translateX`, `translateY`, `width`, `height`, padding/margin/inset | pixels                 |
 | `scale`, `scaleX`, `scaleY`                                        | multiplier (`1` = 100%) |
-| `rotate`                                                           | degrees                 |
+| `rotate`, `rotateX`, `rotateY`                                     | degrees                 |
+| `translateZ`                                                       | pixels                  |
+| `arcStart`, `arcSweep`                                             | degrees                 |
+| `arcWidth`                                                         | pixels                  |
 | `opacity`                                                          | `0`–`1`                 |
 | `bgColor`, `gradFrom`, `gradTo`, `borderColor`, `textColor`        | `u32` ABGR or hex string|
 
@@ -168,7 +174,7 @@ style.
 | Utility                | Animates                                                     |
 | ---------------------- | ------------------------------------------------------------ |
 | `transition`           | transforms + colors + opacity (the default property set)     |
-| `transition-transform` | `translateX/Y`, `scale`, `scaleX/Y`, `rotate`               |
+| `transition-transform` | `translateX/Y`, `scale`, `scaleX/Y`, `rotate` (2D only — see [below](#which-props-animate-where)) |
 | `transition-colors`    | `bgColor`, `gradFrom`, `gradTo`, `borderColor`, `textColor` |
 | `transition-opacity`   | `opacity`                                                    |
 | `transition-all`       | every animatable prop (including layout — can relayout)      |
@@ -212,6 +218,160 @@ change, both tweened by one `transition-all`:
 
 See [Styling](/docs/styling/) for the full utility set and [Input & focus](/docs/input-focus/)
 for how focus moves between nodes.
+
+## Baked keyframe timelines
+
+For anything richer than a single tween — multi-stop choreography, staggered
+sequences, loops — author `keyframes` and `animation` in `pocket.config.ts`, in the
+exact shape of a `tailwind.config.js` theme:
+
+```ts
+// pocket.config.ts
+export default {
+  framework: "solid",
+  theme: {
+    keyframes: {
+      "menu-open":  { from: { width: 38 }, "60%": { width: 144 }, to: { width: 141 } },
+      "menu-close": { from: { width: 141 }, "60%": { width: 31 }, to: { width: 38 } },
+    },
+    animation: {
+      "menu-pill": {
+        value: "menu-open 0.6s ease-in-out 0.2s both, menu-close 0.6s ease-in-out 1.2s forwards",
+        loop: "4000ms",
+      },
+    },
+  },
+};
+```
+
+```tsx
+<View class="w-[38] h-[38] rounded-[19px] bg-white overflow-hidden animate-menu-pill" />
+```
+
+The compiler bakes every referenced animation into frame-precise, per-property
+segment timelines inside `styles.bin`. At runtime the core never parses a string —
+a timeline is pure data, sampled once per tick. Zero per-frame JS, byte-exact
+across every host.
+
+### CSS shorthand semantics
+
+The `animation` value is the standard CSS shorthand, and its semantics survive the
+bake:
+
+- **Comma lists** with independent durations and delays.
+- **Fill modes** — `forwards`, `backwards`, `both`; list precedence works the CSS
+  way (the last animation currently *applying* a property wins, so an intro that
+  fills forwards hands off to a later outro with no JS sequencing).
+- **`reverse`** (baked as flipped segments) and **`infinite`**.
+- **`cubic-bezier(x1, y1, x2, y2)`** plus the named easings (`linear`, `ease`,
+  `ease-in`, `ease-out`, `ease-in-out`), which bake to their canonical browser
+  curves.
+
+### Keyframe properties
+
+Keyframe declarations are CSS-in-JS (camelCase or kebab-case). Bakeable
+properties: `opacity`, `width`/`height`, `top`/`right`/`bottom`/`left`/`inset`,
+`padding`, `margin`, `gap`, `borderRadius`, `borderWidth`, `backgroundColor`,
+`color`, `borderColor`, `letterSpacing`, `lineHeight`, the arc props
+(`arcStart`/`arcSweep`/`arcWidth`) — and `transform` strings, which decompose
+into per-property tracks:
+
+```ts
+"card-flip": {
+  from: { transform: "rotateY(0deg) translateZ(0px)" },
+  to:   { transform: "rotateY(180deg) translateZ(24px)" },
+},
+```
+
+Supported transform functions: `translate()`, `translateX/Y/Z()`, `rotate()`,
+`rotateX/Y()`, `scale()`, `scaleX/Y()`. Mixed `scale()`/`scaleX()` keyframes
+share one prop space (uniform scale decomposes to X + Y).
+
+**Values must be build-time absolute.** A `translateX(-50%)`, `calc()` or
+`var()` is a compile error, not a silent guess — the core has no reference box
+at runtime. Write the resolved pixel value.
+
+### The loop CSS cannot write: `animate-loop-[N]`
+
+Plain CSS cannot say *replay this whole comma list — delays included — every
+N milliseconds*. PocketJS adds a style-level loop period, either as the `loop`
+key in the config (above) or inline:
+
+```tsx
+<View class="… animate-dpad-up animate-loop-[4000ms]" />
+```
+
+Every node's animation clock wraps modulo the period, so a whole page of tiles
+restarts in sync — no remounts, no timers, no drift. `animate-loop-[…]` accepts
+`ms` or `s` and must appear in the same literal as an `animate-<name>` (compile
+error otherwise).
+
+### Tailwind built-ins
+
+`animate-spin`, `animate-ping`, `animate-pulse` and `animate-bounce` ship with
+their standard Tailwind definitions (bounce's `-25%` translate is pinned to the
+default `-6px`, since percentages don't bake).
+
+## 3D transforms
+
+A node with `perspective-[N]` becomes a **3D context root**: its subtree composes
+3D transforms, projects through the root's perspective distance about the root
+center, and painter-sorts into clipped triangles the GPU rasterizes.
+
+| Utility | Effect |
+|---|---|
+| `perspective-[800]` | 3D context root; perspective distance in px |
+| `rotate-x-[deg]` | rotation about the X axis |
+| `rotate-y-[deg]` | rotation about the Y axis |
+| `translate-z-[px]` | depth translation (positive = toward the viewer) |
+
+```tsx
+<View class="perspective-[800]">
+  <View class="w-24 h-24 bg-blue-600 rotate-y-[35] translate-z-[-40]" />
+</View>
+```
+
+All four take bracketed arbitrary values (negatives allowed). `rotate-N` without
+an axis stays the 2D Z rotation. Transforms compose in a fixed canonical order —
+scale, then rotate Y, rotate X, rotate Z, then translate — the common CSS idiom,
+though not an arbitrary `transform:` function list: there is no `matrix3d()`,
+`rotate3d()`, `scaleZ()`, or custom function ordering. `perspective` itself is a
+static context property, not animatable.
+
+`rotateX`, `rotateY` and `translateZ` animate through **baked timelines** and
+**`animate()`** — the card-flip example above is the canonical use. See
+[which props animate where](#which-props-animate-where) for why `transition-*`
+can't drive them.
+
+## Arcs
+
+`arc-start-[deg]`, `arc-sweep-[deg]` and `arc-width-[px]` turn a node's
+background into a round-capped annular sector — a stroke arc as a native
+primitive, no SVG path renderer required:
+
+```tsx
+{/* a reload spinner: 315° of stroke, drawn from the background color */}
+<View class="w-10 h-10 bg-blue-600 arc-start-[45] arc-sweep-[315] arc-width-[5]" />
+```
+
+All three are animatable (timelines and `animate()`), which is how the Motion
+Lab reload study reproduces SVG `stroke-dasharray` drawing: the compiler samples
+the dash motion into `arcStart`/`arcSweep` keyframe stops.
+
+## Which props animate where
+
+Every animation path gates on the same native animatable-prop set, with one
+boundary worth knowing:
+
+| Props | `animate()` / `spring()` | Baked timelines | `transition-*` classes |
+|---|---|---|---|
+| 2D transforms, colors, opacity, layout props | ✓ | ✓ | ✓ |
+| `rotateX`, `rotateY`, `translateZ` | ✓ | ✓ | — |
+| `arcStart`, `arcSweep`, `arcWidth` | ✓ | ✓ | — |
+
+The transition mask is a u32 and the 3D/arc props live beyond bit 32, so a
+`transition-transform` on a `focus:rotate-y-[…]` swap will not tween — it snaps.
+Drive 3D and arc motion with a timeline or `animate()`.
 
 ## Prefer transforms over layout props
 

--- a/site/content/docs/api.md
+++ b/site/content/docs/api.md
@@ -5,7 +5,7 @@ Every public export of `@pocketjs/framework`, grouped by import path. Signatures
 | Import path | Exports |
 | --- | --- |
 | `@pocketjs/framework` | `mount`, `render`, host/runtime helpers, types |
-| `@pocketjs/framework/components` | `View`, `Text`, `Image`, `Sprite`, `Screen`, `Focusable`, `FocusScope`, `FocusGrid`, `ActionHandler`, `Portal`, `Modal`, `ActionBar`, `Grid`, `Lazy`, `Gallery` |
+| `@pocketjs/framework/components` | `View`, `Text`, `Image`, `Sprite`, `Screen`, `Focusable`, `FocusScope`, `FocusGrid`, `ActionHandler`, `Portal`, `Modal`, `ActionBar`, `Named`, `Grid`, `Lazy`, `Gallery` |
 | `solid-js` | `createSignal`, `createEffect`, `createMemo`, `onMount`, `onCleanup`, `batch`, `untrack`, `Show`, `For`, `Index`, `Switch`, `Match` |
 | `vue` | `defineComponent`, `ref`, `computed`, `watchEffect`, `onMounted`, `onScopeDispose` |
 | `@pocketjs/framework/animation` | `animate`, `spring`, `cancelAnim` |
@@ -179,10 +179,11 @@ The host primitives, wrapped React Native-style. `View` is the flex container/bo
 | `focusable` | `boolean` | Joins d-pad focus traversal. |
 | `ref` | `(node: NodeMirror) => void \| NodeMirror` | Node handle. |
 | `children` | `JSX.Element` | Child nodes. |
+| `debugName` | `string` | Semantic name in the [DevTools](/docs/devtools/) tree (mirror-only, zero native cost). |
 
-**`TextProps`** — `class`, `style`, `ref`, `children`.
-**`ImageProps`** — `class`, `src` (`string`), `style`, `ref`.
-**`SpriteProps`** — `class`, `sprite` (`string` — a `ui:sprite.<name>` atlas key), `style`, `ref`.
+**`TextProps`** — `class`, `style`, `ref`, `children`, `debugName`.
+**`ImageProps`** — `class`, `src` (`string`), `style`, `ref`, `debugName`.
+**`SpriteProps`** — `class`, `sprite` (`string` — a `ui:sprite.<name>` atlas key), `style`, `ref`, `debugName`.
 
 `Sprite` is a native animated primitive: its atlas (a pow2 texture holding a grid of frames) is baked into the pak, and the Rust core cycles the frame cells per vblank — deterministic and with **zero per-frame JS**. It auto-plays from the first frame the moment it is displayed, so a sprite revealed by paging or a `Show`/`Lazy` starts animating on its own. Bake atlases by listing them in a demo's `sprites.json` (`{ "<atlas>.png": { cols, rows, frames, step } }`); `step` is vblanks per frame (fps = 60/step). See `demos/gallery` (its covers are shader-baked animated sprites).
 
@@ -260,6 +261,16 @@ function Modal(props: ModalProps): JSX.Element
 ```
 
 A portalled backdrop + focus-scoped panel. While `open`, it blocks background button handlers (`pushButtonHandlerBlock`) and fades/scales the panel in. `class` styles the centering frame; `panelClass` styles the panel.
+
+### `Named`
+
+```ts
+function Named(props: { name: string; children?: JSX.Element }): JSX.Element
+```
+
+Tags the host nodes it renders with a semantic name for the
+[DevTools](/docs/devtools/) component tree (`<Named name="MessageCard"><Card/></Named>`).
+Renders no node of its own; a child's explicit `debugName` prop wins.
 
 ### `ActionBar`
 

--- a/site/content/docs/build-pipeline.md
+++ b/site/content/docs/build-pipeline.md
@@ -156,7 +156,10 @@ Two literals that produce byte‑identical records share a single styleId, so
 compiler emits:
 
 - **`styles.bin`** — the encoded style table, packed into the pak as
-  `ui:styles`.
+  `ui:styles`. Any `theme.keyframes` / `theme.animation` entries referenced by
+  an `animate-<name>` class are baked into it too, as frame-precise
+  per-property segment timelines (the ANIM TABLE) — see
+  [Animation → baked keyframe timelines](/docs/animation/#baked-keyframe-timelines).
 - **`src/styles.generated.ts`** — a TypeScript module the renderer imports,
   mapping each source class literal to its styleId, plus the font‑slot metadata
   and record count:

--- a/site/content/docs/components.md
+++ b/site/content/docs/components.md
@@ -203,6 +203,7 @@ own wrapper components.
 | `onPress`   |   ✓    |        |         | `() => void`                               | Fires when focused and confirmed. |
 | `ref`       |   ✓    |   ✓    |   ✓     | `(node: NodeMirror) => void \| NodeMirror` | Handle to the mirror node. |
 | `src`       |        |        |   ✓     | `string`                                   | Baked texture name. |
+| `debugName` |   ✓    |   ✓    |   ✓     | `string`                                   | Semantic name in the [DevTools](/docs/devtools/) component tree. Mirror-only: zero pixel/native cost. |
 
 ### `style` vs `class`
 
@@ -398,6 +399,7 @@ compose `View` with focus and overlay behavior:
 | `Portal`         | Renders children into the overlay root.                  |
 | `Modal`          | Backdrop + focus-trapped panel over the overlay.         |
 | `ActionBar`      | Docked bottom bar in the overlay layer.                  |
+| `Named`          | Tags its subtree with a [DevTools](/docs/devtools/) name (`<Named name="MessageCard">…`); renders no node. |
 
 These are documented in full — with focus semantics and examples — on the
 [App shell](/docs/app-shell/) and [Input & focus](/docs/input-focus/) pages.

--- a/site/content/docs/devtools.md
+++ b/site/content/docs/devtools.md
@@ -1,0 +1,103 @@
+# DevTools
+
+Pocket DevTools is built into every bundle: a component inspector that
+highlights nodes **on the device screen** (real PSP included), pause and
+single-step for the whole world, a REPL and `console.log` from hardware, an
+always-on input-tape flight recorder, and on-demand screenshots. The design
+rests on one property: PocketJS is fixed-dt deterministic and its entire
+per-frame input is one button bitmask — so a recorded input tape replays any
+session byte-for-byte. Architecture deep-dive:
+[the blog post](/blog/time-travel-devtools/) and
+[`DEVTOOLS.md`](https://github.com/pocket-stack/pocketjs/blob/main/DEVTOOLS.md).
+
+## One command
+
+```sh
+bun run devtools            # panel + hub + USB bridge, one process
+bun run devtools cards      # + build, USB-link and launch cards on a real PSP
+```
+
+The panel serves at `http://127.0.0.1:8130/devtools`. With an app argument it
+builds the EBOOT, serves it to the PSP over usbhostfs and launches it through
+PSPLINK; if a `bun psplink` / `bun run hw` session already owns the cable it is
+detected and bridged into instead. Shortcuts: `o` open panel, `r` rebuild +
+relaunch, `q` quit. Also available from the CLI as `pocket devtools`.
+
+Browser-host debugging needs nothing extra — any demo loaded from the dev
+server connects to the panel automatically.
+
+## The component tree
+
+The left panel is the live component tree. Hover a node and the region lights
+up on the device screen — the highlight is drawn by the renderer itself (four
+rectangles appended to the DrawList), so it works identically on PSP hardware,
+in the browser, and headless, and it glides between nodes as you move. Click
+pins a node and shows its details: type, classes, text, and the world-space
+rect.
+
+Name your components so the tree reads like your source:
+
+```tsx
+// a) the debugName prop on any primitive
+<View debugName="Header" class="flex-row items-center justify-between">…</View>
+
+// b) the <Named> wrapper around a component subtree (renders no node)
+<Named name="MessageCard"><Card {...props} /></Named>
+```
+
+Both are mirror-only — provably zero pixel and zero native cost (goldens are
+byte-identical with and without them).
+
+## Time travel
+
+Every bundle runs a flight recorder unconditionally: one `u16` button mask per
+frame in a 36 000-frame ring (10 minutes ≈ 72 KB). Because the runtime is
+deterministic, that tape **is** the session.
+
+In the panel: **⏸ pause** freezes the entire world in the core — every
+animation, timeline and sprite clock holds, and stepping advances everything by
+exactly 1/60 s. **Load tape** renders the input activity per frame; clicking a
+frame seeks there (the browser host reloads and deterministically
+fast-forwards). **Export** downloads the tape as JSON; **Replay file…** plays
+one back from boot.
+
+Headless, the same tape answers debugging questions from the terminal:
+
+```sh
+bun run tape replay <app> session.tape.json --hashes h.json   # per-frame hashes
+bun run tape replay <app> session.tape.json --assert h.json   # first divergent frame
+bun run tape replay <app> session.tape.json --png 4120        # render any frame
+bun run tape tree   <app> session.tape.json --at 4120         # tree JSON at a frame
+```
+
+`--assert` turns a recorded session into a regression test: replay it against a
+new build and it names the exact frame where behavior changed. The repo ships
+one as a *session golden* (`bun run tape:check`).
+
+## REPL, console, errors
+
+The console panel evals JavaScript in the app's global scope between frames —
+the world is quiescent there, so what you inspect is real state. `console.log`
+/ `warn` / `error` mirror to the panel from every host, including QuickJS on
+the PSP (which has no console of its own — the shim installs one). Exceptions
+thrown during a frame are reported with their frame index; the frame number
+plus the tape is a reproduction.
+
+## Screenshots
+
+The 📷 button captures the device framebuffer on demand and downloads it as a
+PNG (plus a thumbnail strip of recent captures). On real hardware the raw VRAM
+rides the usbhostfs mount and the desktop bridge encodes the PNG — pixels never
+cross the debug channel.
+
+## Real PSP setup
+
+The debug channel to hardware is a file mailbox on the PSPLINK usbhostfs share
+(`host0:/pocketjs-dbg/`). The app probes for it **once at boot** — so start
+`bun run devtools` first, then (re)launch the app; without PSPLINK the probe is
+two failed file-opens and the app never touches IO again. On PSP the shim polls
+every 10 frames (~166 ms hover latency); other hosts poll every frame.
+
+The same mailbox works under the PPSSPP emulator: PPSSPP maps the EBOOT's own
+directory as `host0:`, which is exactly where `bun run devtools <app>` puts the
+mailbox.

--- a/site/content/docs/getting-started.md
+++ b/site/content/docs/getting-started.md
@@ -41,8 +41,9 @@ pocket setup    # installs whatever doctor flagged as missing
 ```
 
 It also wraps the day-to-day commands — `pocket create <name>` scaffolds a
-demo app, and `pocket dev|build|psp|hw|psplink` run the build scripts from
-anywhere inside the checkout.
+demo app, `pocket dev|build|psp|hw|psplink` run the build scripts from
+anywhere inside the checkout, and `pocket devtools [app]` opens the
+[DevTools](/docs/devtools/) panel with the USB debug bridge.
 
 That pulls `solid-js`, Vue Vapor dependencies, and the build-time tooling (the
 Babel + Tailwind-subset compiler, the font baker, and the dev host). There is no

--- a/site/content/docs/styling.md
+++ b/site/content/docs/styling.md
@@ -64,7 +64,9 @@ Utilities use Tailwind's default value scales.
 | Box | `w-12`, `h-full`, `min-w-4`, `max-h-40`, `p-2`, `px-4`, `mt-2`, `absolute`, `inset-0`, `hidden`, `overflow-hidden`, `z-10` |
 | Visual | `bg-blue-600`, `bg-gradient-to-b`, `from-slate-800`, `to-slate-950`, `rounded-md`, `opacity-50`, `shadow-lg`, `border`, `border-slate-700` |
 | Text | `text-slate-50`, `text-xl`, `font-bold`, `text-center`, `leading-6`, `tracking-wide` |
-| Transform | `translate-x-2`, `scale-95`, `rotate-45` |
+| Transform | `translate-x-2`, `scale-95`, `rotate-45`, `rotate-y-[35]`, `translate-z-[-40]`, `perspective-[800]` |
+| Arc | `arc-start-[45]`, `arc-sweep-[315]`, `arc-width-[5]` |
+| Motion | `transition-colors`, `duration-150`, `ease-out`, `animate-spin`, `animate-menu-pill`, `animate-loop-[4s]` |
 
 **Spacing scale.** Numeric spacing follows Tailwind: `N` means `N * 4` px, so
 `p-2` is 8px and `gap-4` is 16px.

--- a/site/content/docs/tailwind.md
+++ b/site/content/docs/tailwind.md
@@ -224,9 +224,27 @@ motion.
 | `scale-x-N` | X scale, `N/100` |
 | `scale-y-N` | Y scale, `N/100` |
 | `rotate-N` | rotation in degrees (e.g. `rotate-45`) |
+| `rotate-x-[N]` | 3D rotation about X, degrees (bracket-only, negatives ok) |
+| `rotate-y-[N]` | 3D rotation about Y, degrees (bracket-only, negatives ok) |
+| `translate-z-[N]` | 3D depth translation, px (bracket-only, negatives ok) |
+| `perspective-[N]` | makes the node a 3D context root; distance in px |
 
 `scale-*` and `rotate-*` take plain numbers only (no bracket syntax, no
-negatives).
+negatives); the 3D utilities are bracket-only. A `perspective-[N]` root
+projects its subtree through that distance and painter-sorts the result —
+see [Animation → 3D transforms](/docs/animation/#3d-transforms).
+
+## Arc
+
+`arc-*` strokes a round-capped annular sector from the node's background
+color — a native stroke-arc primitive (all three animatable via timelines
+and `animate()`):
+
+| Utility | Effect |
+|---|---|
+| `arc-start-[N]` | start angle, degrees |
+| `arc-sweep-[N]` | sweep angle, degrees |
+| `arc-width-[N]` | stroke width, px |
 
 ## Motion / transition
 
@@ -240,7 +258,9 @@ and interpolate the animatable properties in the mask.
 | `transition-all` | animate all animatable properties |
 | `transition-colors` | animate bg / text / border / gradient colors |
 | `transition-opacity` | animate opacity |
-| `transition-transform` | animate translate / scale / rotate |
+| `transition-transform` | animate translate / scale / rotate (2D only — 3D/arc props exceed the u32 transition mask; use timelines or `animate()`) |
+| `animate-<name>` | apply a baked keyframe timeline from `theme.animation` (built-ins: `spin`, `ping`, `pulse`, `bounce`) |
+| `animate-loop-[Nms]` \| `[Ns]` | whole-choreography loop period (needs `animate-<name>` in the same literal) |
 | `duration-N` | duration in ms (0–65535) |
 | `delay-N` | delay in ms (0–65535) |
 | `ease-linear` \| `-in` \| `-out` \| `-in-out` \| `-spring` \| `-out-back` | easing curve |

--- a/site/nav.ts
+++ b/site/nav.ts
@@ -28,6 +28,7 @@ export const DOC_NAV: DocSection[] = [
       { slug: "animation", title: "Animation" },
       { slug: "input-focus", title: "Input & focus" },
       { slug: "app-shell", title: "App shell & overlays" },
+      { slug: "devtools", title: "DevTools" },
     ],
   },
   {


### PR DESCRIPTION
Audit finding: the reference docs had **zero coverage** of the 0.2 animation release (baked keyframes, `animate-loop-[N]`, the 3D pipeline, arcs) and the 0.3 DevTools — greps across all 14 doc pages came back empty; the only writing lived in the blog posts.

## What's covered now

- **animation.md** — three new sections: *Baked keyframe timelines* (`pocket.config.ts` → `animate-<name>`, full CSS shorthand semantics, the keyframe property table incl. `transform` string decomposition, hard bake-ability rules, `animate-loop-[N]`, the Tailwind built-ins), *3D transforms* (`perspective-[N]` context roots, utility grammar, fixed compose order, subset limits), and *Arcs*. Plus a **"Which props animate where"** boundary table documenting that 3D/arc props animate via timelines and `animate()` but sit beyond the u32 transition mask (`transition-*` snaps) — previously undocumented, silently surprising behavior.
- **tailwind.md / styling.md** — 3D, perspective, arc and `animate-*` utilities in the reference tables, with the bracket-only grammar and the `transition-transform` 2D-only caveat.
- **NEW docs page: DevTools** (Guides nav) — one command, component tree + `debugName`/`<Named>`, time travel + the headless tape CLI, REPL/console, screenshots, real-PSP setup.
- **components.md / api.md** — `debugName` prop rows + the `Named` component signature.
- **build-pipeline.md** — `styles.bin` notes the baked ANIM TABLE; getting-started mentions `pocket devtools`.
- **Bonus fix:** markdown headings now render GitHub-style slug ids — every in-page `#anchor` on the site (including a pre-existing dead one in animation.md) was a no-op until now; deep links into doc sections work.

All utility grammar was extracted from `compiler/tailwind.ts` / `compiler/animation.ts` (not from memory): bracket-only 3D/arc values, `animate-loop-[Nms|Ns]` requiring an `animate-<name>` in the same literal, the keyframe prop table, supported transform functions, and the calc()/%/var() hard errors.

Verified: site builds (15 docs pages), heading anchors resolve, the animation page visually checked via headless Chrome, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)