### PR TITLE
feat(devtools): DevTools on the desktop host — file mailbox in pocket-ui-wgpu

### DIFF
--- a/DEVTOOLS.md
+++ b/DEVTOOLS.md
@@ -104,6 +104,15 @@ The shim needs only `{ send(line), recv() -> line | null }`:
   every 10 frames on PSP (~166 ms hover latency; each poll is a few USB
   round-trips). `scripts/devtools-psp.ts` bridges the mailbox to the WS hub.
   The same mailbox works under the PPSSPP GUI via the `ms0:` fallback path.
+- **Native desktop (macOS et al., `pocket-ui-wgpu`):** the same file mailbox,
+  minus the USB cable — `pocket3d/crates/pocket-ui-wgpu/src/dbg.rs` is the
+  std twin of the PSP transport. Probed once at `UiSurface::mount`: root =
+  `$POCKETJS_DBG_DIR`, else the process cwd; active only if
+  `pocketjs-dbg/enable` exists. Arm it with `bun run devtools --dir <root>`
+  (an explicit `--dir` always beats a detected PSPLINK session), then launch
+  the host from that cwd. Tree, highlight, pause/step, eval, and tapes work
+  identically; `__dbgShot` is PSP-only for now (the panel's 📷 degrades to a
+  warning).
 - **Headless (tests, `scripts/tape.ts`):** an in-process queue pair. The CLI
   and the test suite are just DevTools clients — the whole protocol is
   drivable without a screen.

--- a/pocket3d/crates/pocket-ui-wgpu/src/dbg.rs
+++ b/pocket3d/crates/pocket-ui-wgpu/src/dbg.rs
@@ -1,0 +1,115 @@
+//! DevTools mailbox transport for desktop hosts — the std twin of the PSP's
+//! `native/src/dbg.rs` (DEVTOOLS.md §3). The bridge (`bun run devtools
+//! --dir <root>`) owns `<root>/pocketjs-dbg/{enable,in,out}.jsonl`; we read
+//! panel commands from `in.jsonl` at a running offset and append replies to
+//! `out.jsonl`. The file is the wire, exactly as on hardware — the same
+//! bridge and panel drive both without knowing which one they got.
+//!
+//! Probed ONCE at mount: the root is `$POCKETJS_DBG_DIR` if set, else the
+//! process working directory. Active only if `pocketjs-dbg/enable` exists —
+//! a plain run costs one metadata stat and never touches IO again.
+
+use std::fs::{File, OpenOptions};
+use std::io::{Read, Seek, SeekFrom, Write};
+use std::path::PathBuf;
+
+/// Max bytes consumed per poll; longer backlogs drain over several polls
+/// (same cap as the PSP transport).
+const POLL_BUF: usize = 4096;
+
+pub struct DbgMailbox {
+    /// `<root>/pocketjs-dbg`.
+    dir: PathBuf,
+    /// Byte offset into `in.jsonl` of the first unconsumed byte.
+    read_off: u64,
+}
+
+impl DbgMailbox {
+    /// Probe for an armed mailbox. Skips any commands already in `in.jsonl`
+    /// from a previous session (starts reading at the current EOF), matching
+    /// the PSP boot behavior.
+    pub fn probe() -> Option<DbgMailbox> {
+        let root = std::env::var_os("POCKETJS_DBG_DIR")
+            .map(PathBuf::from)
+            .or_else(|| std::env::current_dir().ok())?;
+        let dir = root.join("pocketjs-dbg");
+        if !dir.join("enable").exists() {
+            return None;
+        }
+        let read_off = std::fs::metadata(dir.join("in.jsonl"))
+            .map(|m| m.len())
+            .unwrap_or(0);
+        log::info!("pocket-ui: DevTools mailbox attached at {}", dir.display());
+        Some(DbgMailbox { dir, read_off })
+    }
+
+    /// New bytes from `in.jsonl` since the last poll, cut at the last
+    /// complete line (a line the bridge is mid-writing stays for the next
+    /// poll).
+    pub fn poll(&mut self) -> Option<String> {
+        let mut f = File::open(self.dir.join("in.jsonl")).ok()?;
+        f.seek(SeekFrom::Start(self.read_off)).ok()?;
+        let mut buf = vec![0u8; POLL_BUF];
+        let n = f.read(&mut buf).ok()?;
+        if n == 0 {
+            return None;
+        }
+        let complete = buf[..n].iter().rposition(|&b| b == b'\n')? + 1;
+        self.read_off += complete as u64;
+        String::from_utf8(buf[..complete].to_vec()).ok()
+    }
+
+    /// Append one JSON line to `out.jsonl`.
+    pub fn send(&self, line: &str) {
+        let Ok(mut f) = OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(self.dir.join("out.jsonl"))
+        else {
+            return;
+        };
+        let _ = f.write_all(line.as_bytes());
+        let _ = f.write_all(b"\n");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn armed_box(tmp: &std::path::Path) -> DbgMailbox {
+        std::fs::create_dir_all(tmp.join("pocketjs-dbg")).unwrap();
+        std::fs::write(tmp.join("pocketjs-dbg/enable"), "").unwrap();
+        std::fs::write(tmp.join("pocketjs-dbg/in.jsonl"), "").unwrap();
+        DbgMailbox {
+            dir: tmp.join("pocketjs-dbg"),
+            read_off: 0,
+        }
+    }
+
+    #[test]
+    fn poll_cuts_at_last_complete_line() {
+        let tmp = std::env::temp_dir().join(format!("pjs-dbg-{}", std::process::id()));
+        let mut b = armed_box(&tmp);
+        std::fs::write(b.dir.join("in.jsonl"), "{\"t\":\"a\"}\n{\"t\":\"b\"}\n{\"t\":").unwrap();
+        assert_eq!(b.poll().unwrap(), "{\"t\":\"a\"}\n{\"t\":\"b\"}\n");
+        // The partial third line stays for the next poll…
+        assert!(b.poll().is_none());
+        // …and arrives once the writer finishes it.
+        let mut f = OpenOptions::new().append(true).open(b.dir.join("in.jsonl")).unwrap();
+        f.write_all(b"\"c\"}\n").unwrap();
+        assert_eq!(b.poll().unwrap(), "{\"t\":\"c\"}\n");
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+
+    #[test]
+    fn send_appends_lines() {
+        let tmp = std::env::temp_dir().join(format!("pjs-dbg-send-{}", std::process::id()));
+        let b = armed_box(&tmp);
+        b.send("{\"t\":\"hello\"}");
+        b.send("{\"t\":\"stats\"}");
+        let out = std::fs::read_to_string(b.dir.join("out.jsonl")).unwrap();
+        assert_eq!(out, "{\"t\":\"hello\"}\n{\"t\":\"stats\"}\n");
+        std::fs::remove_dir_all(&tmp).ok();
+    }
+}

--- a/pocket3d/crates/pocket-ui-wgpu/src/lib.rs
+++ b/pocket3d/crates/pocket-ui-wgpu/src/lib.rs
@@ -14,6 +14,7 @@
 //! 2D and 3D share one base: the same `pocket3d::Gpu` device drives both.
 
 mod blit;
+mod dbg;
 mod pak;
 mod render;
 mod surface;

--- a/pocket3d/crates/pocket-ui-wgpu/src/surface.rs
+++ b/pocket3d/crates/pocket-ui-wgpu/src/surface.rs
@@ -18,6 +18,7 @@ use pocket_mod::Guest;
 use pocket_mod::qjs::{Coerced, Function, Object, TypedArray};
 use pocketjs_core::Ui;
 
+use crate::dbg::DbgMailbox;
 use crate::pak::walk_pak;
 
 /// One sprite-atlas registration from the pak (`ui.__sprites[name]`).
@@ -271,6 +272,47 @@ impl UiSurface {
                 ui.borrow_mut().ui.measure_text(&s.0, slot as u8) as f64
             });
 
+            // ---- DevTools ops (spec ops 18..22) + mailbox transport ------
+            // Same names and semantics as the PSP FFI (native/src/ffi.rs +
+            // native/src/dbg.rs): the shim's transport resolution and the
+            // devtools bridge work against this host unchanged.
+            let ui = self.inner.clone();
+            op!("debugInspect", move |id: i32| ui
+                .borrow_mut()
+                .ui
+                .debug_inspect(id));
+
+            let ui = self.inner.clone();
+            op!("debugRectXY", move || ui.borrow().ui.debug_rect_xy());
+
+            let ui = self.inner.clone();
+            op!("debugRectWH", move || ui.borrow().ui.debug_rect_wh());
+
+            let ui = self.inner.clone();
+            op!("debugPause", move |on: bool| ui
+                .borrow_mut()
+                .ui
+                .debug_pause(on));
+
+            let ui = self.inner.clone();
+            op!("debugStep", move || ui.borrow_mut().ui.debug_step());
+
+            let mbox = Rc::new(RefCell::new(DbgMailbox::probe()));
+            let m = mbox.clone();
+            op!("__dbgActive", move || m.borrow().is_some());
+
+            let m = mbox.clone();
+            op!("__dbgPoll", move || -> Option<String> {
+                m.borrow_mut().as_mut().and_then(|b| b.poll())
+            });
+
+            let m = mbox;
+            op!("__dbgSend", move |line: Coerced<String>| {
+                if let Some(b) = m.borrow().as_ref() {
+                    b.send(&line.0);
+                }
+            });
+
             // ---- boot tables (PSP contract) + desktop viewport ----------
             let inner = self.inner.borrow();
             let textures = Object::new(ctx.clone())?;
@@ -295,6 +337,11 @@ impl UiSurface {
             viewport.set("w", vw as f64)?;
             viewport.set("h", vh as f64)?;
             ns.set("__viewport", viewport)?;
+
+            // Honest host label for DevTools' hello (the shim would
+            // otherwise report "psp" — this namespace passes its PSP-shaped
+            // host detection on purpose).
+            ns.set("__host", "desktop")?;
 
             Ok(())
         })

--- a/scripts/devtools.ts
+++ b/scripts/devtools.ts
@@ -221,8 +221,15 @@ const server = startDevServer({ port: wantedPort, portRetries: 10 });
 let bridge: Bridge;
 let pspLine: string;
 
-const external = await detectUsbhostfs();
-if (external) {
+const dirFlag = argValue("--dir");
+const external = dirFlag ? null : await detectUsbhostfs();
+if (dirFlag) {
+  // An explicit --dir always wins: it targets a desktop-host mailbox
+  // (pocket-ui-wgpu) and must not be hijacked by a running PSP session.
+  bridge = startBridge({ dir: dirFlag, port: server.port, onEvent });
+  const rel = dirFlag.startsWith(ROOT) ? dirFlag.slice(ROOT.length) : dirFlag;
+  pspLine = `mailbox armed at ${rel} — launch the desktop host with this cwd (or POCKETJS_DBG_DIR) to attach`;
+} else if (external) {
   bridge = startBridge({ dir: external.dir, port: server.port, onEvent });
   const rel = external.dir.startsWith(ROOT) ? external.dir.slice(ROOT.length) : external.dir;
   pspLine = `external PSPLINK session (pid ${external.pid}, ${rel}) — relaunch the app there to attach`;
@@ -236,7 +243,7 @@ if (external) {
   bridge = startBridge({ dir: targetDir, port: server.port, onEvent });
   pspLine = `waiting for the PSP on USB… launch PSPLINK on it (XMB → Game)`;
 } else {
-  const dir = argValue("--dir") ?? join(ROOT, "dist", "psplink");
+  const dir = join(ROOT, "dist", "psplink");
   bridge = startBridge({ dir, port: server.port, onEvent });
   const rel = dir.startsWith(ROOT) ? dir.slice(ROOT.length) : dir;
   pspLine = `no device — mailbox armed at ${rel} (bun psplink / bun run devtools <app> to launch)`;

--- a/skills/pocketjs-devtools/SKILL.md
+++ b/skills/pocketjs-devtools/SKILL.md
@@ -58,6 +58,20 @@ fast-forwards); REPL evals in the app global scope between frames; 📷
 screenshot button downloads a PNG (browser: canvas; PSP: raw VRAM dump over
 usbhostfs, converted by the bridge — pixels never cross the JSON channel).
 
+## Native desktop (macOS) specifics
+
+- `pocket-ui-wgpu` hosts (OpenStrike desktop, `pocket3d/examples/uihost`)
+  carry the same file-mailbox transport as the PSP, pointed at
+  `$POCKETJS_DBG_DIR` (else the process cwd). Workflow: `bun run devtools
+  --dir <root> --port 8131` FIRST (explicit `--dir` wins over a running
+  PSPLINK session, so a PSP panel and a desktop panel can run side by
+  side), then launch the app with that cwd — e.g. `cargo run -p openstrike`
+  from the open-strike repo root. The app probes `pocketjs-dbg/enable`
+  once at mount, like the PSP boot probe.
+- Everything except 📷 screenshots works identically (desktop `__dbgShot`
+  is unimplemented; the panel button logs a warning). `hello` reports
+  `host:"desktop"` via `ui.__host`.
+
 ## Real-PSP specifics
 
 - Transport = `pocketjs-dbg/{enable,in,out}.jsonl` on the usbhostfs share

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -480,6 +480,9 @@ function clip(s: string): string {
 
 function hostKind(): string {
   const ops = state.ops as (HostOps & { __textures?: unknown }) | null;
+  // Native hosts may self-identify (pocket-ui-wgpu sets "desktop"); the
+  // PSP host predates the field and falls through to the tables check.
+  if (typeof ops?.__host === "string") return ops.__host;
   if (ops?.__textures !== undefined) return "psp";
   if (typeof (globalThis as { document?: unknown }).document !== "undefined") return "web";
   return "headless";

--- a/src/host.ts
+++ b/src/host.ts
@@ -88,6 +88,9 @@ export interface HostOps {
   /** PSP on-demand screenshot: dump the displayed framebuffer to
    *  pocketjs-dbg/shot.raw (bridge converts to PNG). → success. */
   __dbgShot?(): boolean;
+  /** Host self-identification for DevTools' hello (e.g. "desktop"); hosts
+   *  without it are inferred from the boot tables. */
+  __host?: string;
 }
 
 export interface Host {


### PR DESCRIPTION
DevTools now reaches native desktop hosts (macOS): the component tree, on-screen highlight, pause/step, REPL, and tapes all work against `pocket-ui-wgpu` apps — OpenStrike desktop and `examples/uihost` — through the existing panel and bridge, unchanged.

## What

- **`pocket-ui-wgpu/src/dbg.rs` (new):** the std twin of `native/src/dbg.rs` — a `pocketjs-dbg/{enable,in,out}.jsonl` file mailbox probed once at `UiSurface::mount` (`$POCKETJS_DBG_DIR`, else cwd). Same read-offset/complete-line/append semantics, same 4 KB poll cap; unit-tested (partial-line cut + append).
- **`surface.rs`:** mounts spec ops 18..22 (`debugInspect/RectXY/RectWH/Pause/Step` → the same `pocketjs_core::Ui` methods the PSP FFI forwards to) + `__dbgActive/__dbgPoll/__dbgSend`, and labels itself `ui.__host = "desktop"`.
- **shim:** `hostKind()` prefers `ops.__host`, so hello says `desktop` instead of inferring `psp` from the boot tables.
- **`bun run devtools --dir <root>`** now always targets that mailbox — an explicit `--dir` no longer loses to a detected PSPLINK session, so a PSP panel (8130) and a desktop panel (8131) run side by side.
- Docs: DEVTOOLS.md §3 transport entry + a desktop section in the devtools skill.

## Verified on macOS (real run, not tests)

OpenStrike desktop (vendor pinned to this branch, bundle rebuilt) + `bun run devtools --dir ~/code/open-strike`:

- `hello` → `{"t":"hello","host":"desktop","frame":9}`; tree streamed from frame 1; stats every 30 frames
- `inspect{id:13}` → `rect:[24,24,1552,33]` and the blue core-drawn highlight visibly framed the top HUD row in the 1600×900 game window (screenshot-verified)
- `pause` froze the HUD world (`paused:true` in stats), `resume` released it
- screenshot button degrades to the documented warning (`__dbgShot` PSP-only)
- meanwhile the REAL PSP session on 8130 kept streaming its own tree — both panels live simultaneously

Tests: `cargo test -p pocket-ui-wgpu` (2 new mailbox tests), `bun test test/devtools.test.ts` (11 pass), `test/contract.ts` green, `tape:check` byte-stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)