### PR TITLE
docs(site): remove homepage footer tagline

### DIFF
--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -893,7 +893,8 @@ a.lp-btn--primary:hover {
   color: var(--muted);
   font-size: 0.8rem;
 }
-.lp-footer__bar span:first-child { font-family: var(--mono); letter-spacing: 0.02em; }
+.lp-footer__bar--end { justify-content: flex-end; }
+.lp-footer__bar:not(.lp-footer__bar--end) span:first-child { font-family: var(--mono); letter-spacing: 0.02em; }
 
 /* ---- Scroll-reveal (progressive enhancement; visible by default) ---------- */
 @supports (animation-timeline: view()) {

--- a/site/home.html
+++ b/site/home.html
@@ -420,8 +420,7 @@
           </ul>
         </div>
       </div>
-      <div class="lp-footer__bar">
-        <span>Solid/Vue Vapor UI, native pixels</span>
+      <div class="lp-footer__bar lp-footer__bar--end">
         <span>&copy; 2026 PocketJS &middot; MIT</span>
       </div>
     </div>

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -96,8 +96,7 @@ const footer = `<footer class="mt-24 border-t border-line/70 bg-ink-2/60">
         </ul>
       </div>
     </div>
-    <div class="mt-10 flex flex-col gap-2 border-t border-line/60 pt-6 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-between">
-      <span>Solid/Vue Vapor UI, native pixels</span>
+    <div class="mt-10 flex flex-col gap-2 border-t border-line/60 pt-6 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-end">
       <span>© ${YEAR} PocketJS · MIT</span>
     </div>
   </div>


### PR DESCRIPTION
## Summary

- Remove the `Solid/Vue Vapor UI, native pixels` tagline from the homepage footer.
- Remove the same tagline from the shared site footer template so regenerated pages stay aligned.
- Keep the standalone homepage copyright row right-aligned without applying the tagline monospace styling to the copyright text.

## Validation

- `bun install --frozen-lockfile`
- `bun scripts/build.ts hero >/dev/null`
- `bun scripts/wasm.ts`
- `bun site/build.ts`
- `git diff --check`
- `bunx tsc --noEmit`
