### PR TITLE
docs(site): add Discord community links

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![@pocketjs/framework](https://img.shields.io/npm/v/%40pocketjs%2Fframework?label=%40pocketjs%2Fframework)](https://www.npmjs.com/package/@pocketjs/framework)
 [![@pocketjs/cli](https://img.shields.io/npm/v/%40pocketjs%2Fcli?label=%40pocketjs%2Fcli)](https://www.npmjs.com/package/@pocketjs/cli)
 [![license: MIT](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
+[![Discord](https://img.shields.io/badge/Discord-Join-5865F2?logo=discord&logoColor=white)](https://discord.gg/cTce4eXzSK)
 
 High-performance JSX UI outside the browser, with native rendering, standard
 Vue Vapor and Solid support, a Tailwind design system, and 60 FPS animation

--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -178,6 +178,29 @@ html, body { margin: 0; background: #05070d; }
   border-color: rgba(96, 165, 250, 0.44);
   background: rgba(20, 29, 49, 0.78);
 }
+.lp-btn--discord,
+.lp-btn--discord:visited {
+  color: #f8fafc;
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.09), rgba(255, 255, 255, 0) 48%),
+    rgba(88, 101, 242, 0.16);
+  border-color: rgba(88, 101, 242, 0.55);
+  box-shadow:
+    0 14px 30px -22px rgba(3, 9, 20, 0.82),
+    inset 0 1px 0 rgba(255, 255, 255, 0.07);
+}
+.lp-btn--discord svg {
+  width: 18px;
+  height: 18px;
+  color: #cfd3ff;
+}
+.lp-btn--discord:hover {
+  transform: translateY(-2px);
+  border-color: rgba(138, 149, 255, 0.74);
+  background:
+    linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(255, 255, 255, 0) 48%),
+    rgba(88, 101, 242, 0.24);
+}
 .lp-hero__cta .lp-btn--ghost,
 .lp-hero__cta .lp-btn--ghost:visited {
   color: var(--ink);
@@ -192,6 +215,10 @@ html, body { margin: 0; background: #05070d; }
   color: #fff;
   border-color: rgba(96, 165, 250, 0.52);
   background: rgba(20, 29, 49, 0.72);
+}
+.lp-hero__cta .lp-btn--discord,
+.lp-hero__cta .lp-btn--discord:visited {
+  color: #f8fafc;
 }
 a.lp-btn--primary,
 a.lp-btn--primary:link,
@@ -230,7 +257,13 @@ a.lp-btn--primary:hover {
   color: var(--ink);
 }
 .lp-brand svg { width: 26px; height: 26px; }
-.lp-nav__links { display: flex; align-items: center; gap: 0.25rem; }
+.lp-nav__links {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.25rem;
+  min-width: 0;
+}
 .lp-nav__link {
   color: var(--ink-2);
   text-decoration: none;
@@ -263,7 +296,8 @@ a.lp-btn--primary:hover {
 }
 @media (max-width: 480px) {
   .lp-nav__ghlabel { display: none; }
-  .lp-nav__link { padding: 0.5rem 0.5rem; font-size: 13px; }
+  .lp-nav__optional { display: none; }
+  .lp-nav__link { padding: 0.5rem 0.38rem; font-size: 12px; }
 }
 
 /* ---- Hero ----------------------------------------------------------------- */

--- a/site/assets/tailwind.css
+++ b/site/assets/tailwind.css
@@ -182,9 +182,12 @@
     .site-nav__ghlabel {
       display: none;
     }
+    .site-nav__optional {
+      display: none;
+    }
     .site-nav__link {
-      padding: 0.5rem;
-      font-size: 13px;
+      padding: 0.5rem 0.38rem;
+      font-size: 12px;
     }
   }
 
@@ -253,16 +256,27 @@
     border: 1px solid var(--color-line);
     border-radius: 0.7rem;
     padding: 0.95rem 1.1rem;
+    max-width: 100%;
     overflow-x: auto;
     font-size: 12.5px;
     line-height: 1.65;
   }
   .prose pre.shiki code {
+    display: block;
+    min-width: max-content;
     font-family: var(--font-mono);
     background: transparent;
     padding: 0;
     border: 0;
     color: inherit;
+  }
+  .prose :where(table) {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+  }
+  .prose :where(th, td) {
+    white-space: nowrap;
   }
 
   /* ---- handheld device frame (hero + playground) ------------------------- */
@@ -465,7 +479,7 @@
   .pg-hint code { font-family: var(--font-mono); color: var(--color-brand-2); }
 
   /* ---- docs layout ------------------------------------------------------- */
-  .doc-shell { display: grid; grid-template-columns: 1fr; gap: 0; max-width: 80rem; margin: 0 auto; }
+  .doc-shell { display: grid; grid-template-columns: minmax(0, 1fr); gap: 0; width: 100%; max-width: 80rem; min-width: 0; margin: 0 auto; }
   @media (min-width: 1000px) { .doc-shell { grid-template-columns: 250px minmax(0, 1fr); } }
   .doc-nav {
     display: none; padding: 2rem 1.25rem; border-right: 1px solid var(--color-line);
@@ -477,8 +491,9 @@
   .doc-nav a { display: block; padding: 0.3rem 0.6rem; border-radius: 0.4rem; font-size: 0.88rem; color: var(--color-slate-400); }
   .doc-nav a:hover { color: var(--color-slate-100); background: var(--color-surface); }
   .doc-nav a.on { color: var(--color-brand-2); background: color-mix(in oklab, var(--color-brand) 12%, transparent); font-weight: 600; }
-  .doc-body { padding: 2.5rem 1.5rem 4rem; max-width: 52rem; }
+  .doc-body { width: 100%; min-width: 0; padding: 2.5rem 1.5rem 4rem; max-width: 52rem; }
   @media (min-width: 1000px) { .doc-body { padding: 2.5rem 3rem 5rem; } }
+  .doc-content { min-width: 0; overflow-wrap: anywhere; }
   .doc-pager { display: flex; justify-content: space-between; gap: 1rem; margin-top: 3rem; padding-top: 1.5rem; border-top: 1px solid var(--color-line); }
   .doc-pager a { display: flex; flex-direction: column; padding: 0.75rem 1rem; border: 1px solid var(--color-line); border-radius: 0.6rem; font-size: 0.9rem; color: var(--color-slate-200); max-width: 48%; }
   .doc-pager a:hover { border-color: var(--color-brand); }
@@ -486,6 +501,8 @@
   .doc-pager span { font-size: 0.72rem; font-weight: 600; color: var(--color-slate-500); }
   .doc-fw-code {
     margin: 1.25rem 0;
+    max-width: 100%;
+    min-width: 0;
   }
   .doc-fw-radio {
     position: absolute;
@@ -515,6 +532,7 @@
   }
   .doc-fw-panel {
     display: none;
+    min-width: 0;
   }
   .doc-fw-panel pre {
     margin-top: 0;

--- a/site/home.html
+++ b/site/home.html
@@ -19,10 +19,9 @@
         <a class="lp-nav__link" href="/docs/overview/">Docs</a>
         <a class="lp-nav__link" href="/playground/">Playground</a>
         <a class="lp-nav__link" href="/blog/">Blog</a>
-        <a class="lp-nav__link" href="/changelog/">Changelog</a>
-        <a class="lp-nav__link lp-nav__gh" href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">
+        <a class="lp-nav__link lp-nav__optional" href="/changelog/">Changelog</a>
+        <a class="lp-nav__link lp-nav__gh" href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer" aria-label="PocketJS on GitHub">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 4.7 18 5 18 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
-          <span class="lp-nav__ghlabel">GitHub</span>
         </a>
         <a class="lp-nav__link lp-nav__x" href="https://x.com/pocket_js" target="_blank" rel="noreferrer" aria-label="PocketJS on X">
           <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
@@ -58,6 +57,10 @@
           <a class="lp-btn lp-btn--ghost" href="/playground/">
             Open playground
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
+          </a>
+          <a class="lp-btn lp-btn--discord" href="https://discord.gg/cTce4eXzSK" target="_blank" rel="noreferrer">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.54 5.34A17.75 17.75 0 0 0 15.07 4c-.19.35-.41.82-.56 1.19a16.5 16.5 0 0 0-5.02 0A12.1 12.1 0 0 0 8.92 4c-1.55.27-3.06.73-4.47 1.34C1.62 9.54.86 13.64 1.24 17.68A17.9 17.9 0 0 0 6.72 20.4c.44-.59.83-1.22 1.16-1.89-.64-.24-1.25-.54-1.83-.89.15-.11.3-.23.44-.35a12.68 12.68 0 0 0 11.02 0c.15.12.29.24.44.35-.58.35-1.2.65-1.84.89.34.67.72 1.3 1.16 1.89a17.85 17.85 0 0 0 5.49-2.72c.45-4.69-.75-8.75-3.22-12.34ZM8.7 15.19c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Zm6.6 0c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Z"/></svg>
+            Join Discord
           </a>
         </div>
 
@@ -365,6 +368,10 @@
         <div class="lp-cta__btns">
           <a class="lp-btn lp-btn--primary" href="/docs/getting-started/">Get started</a>
           <a class="lp-btn lp-btn--ghost" href="/docs/overview/">Read the docs</a>
+          <a class="lp-btn lp-btn--discord" href="https://discord.gg/cTce4eXzSK" target="_blank" rel="noreferrer">
+            <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.54 5.34A17.75 17.75 0 0 0 15.07 4c-.19.35-.41.82-.56 1.19a16.5 16.5 0 0 0-5.02 0A12.1 12.1 0 0 0 8.92 4c-1.55.27-3.06.73-4.47 1.34C1.62 9.54.86 13.64 1.24 17.68A17.9 17.9 0 0 0 6.72 20.4c.44-.59.83-1.22 1.16-1.89-.64-.24-1.25-.54-1.83-.89.15-.11.3-.23.44-.35a12.68 12.68 0 0 0 11.02 0c.15.12.29.24.44.35-.58.35-1.2.65-1.84.89.34.67.72 1.3 1.16 1.89a17.85 17.85 0 0 0 5.49-2.72c.45-4.69-.75-8.75-3.22-12.34ZM8.7 15.19c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Zm6.6 0c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Z"/></svg>
+            Join Discord
+          </a>
         </div>
       </div>
     </section>
@@ -414,6 +421,7 @@
           <ul>
             <li><a href="/blog/">Blog</a></li>
             <li><a href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">GitHub</a></li>
+            <li><a href="https://discord.gg/cTce4eXzSK" target="_blank" rel="noreferrer">Discord</a></li>
             <li><a href="https://x.com/pocket_js" target="_blank" rel="noreferrer">X (Twitter)</a></li>
             <li><a href="/docs/native-contract/">Native contract</a></li>
             <li><a href="/docs/build-pipeline/">Build pipeline</a></li>

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -4,6 +4,7 @@
 
 const YEAR = 2026;
 const GH = "https://github.com/pocket-stack/pocketjs";
+const DISCORD = "https://discord.gg/cTce4eXzSK";
 const X_URL = "https://x.com/pocket_js";
 export const SITE_URL = "https://pocketjs.dev";
 export const SITE_TITLE = "PocketJS — Bare Metal Modern Web";
@@ -40,9 +41,9 @@ function header(active: string): string {
     '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 4.7 18 5 18 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>';
   const xIcon =
     '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>';
-  const link = (href: string, label: string, key: string, ext = false) =>
+  const link = (href: string, label: string, key: string, ext = false, className = "") =>
     `<a href="${href}"${ext ? ' target="_blank" rel="noreferrer"' : ""} ` +
-    `class="site-nav__link ${active === key ? "on" : ""}">${label}</a>`;
+    `class="site-nav__link ${className} ${active === key ? "on" : ""}">${label}</a>`;
   return `<header class="site-nav">
   <div class="site-nav__in">
     <a href="/" class="site-brand" aria-label="PocketJS home">
@@ -52,7 +53,7 @@ function header(active: string): string {
       ${link("/docs/overview/", "Docs", "docs")}
       ${link("/playground/", "Playground", "playground")}
       ${link("/blog/", "Blog", "blog")}
-      ${link("/changelog/", "Changelog", "changelog")}
+      ${link("/changelog/", "Changelog", "changelog", false, "site-nav__optional")}
       <a href="${GH}" target="_blank" rel="noreferrer" class="site-nav__link site-nav__gh">${ghIcon}<span class="site-nav__ghlabel">GitHub</span></a>
       <a href="${X_URL}" target="_blank" rel="noreferrer" class="site-nav__link site-nav__x" aria-label="PocketJS on X">${xIcon}</a>
     </nav>
@@ -90,6 +91,7 @@ const footer = `<footer class="mt-24 border-t border-line/70 bg-ink-2/60">
         <ul class="space-y-2 text-slate-400">
           <li><a class="hover:text-brand-2" href="/blog/">Blog</a></li>
           <li><a class="hover:text-brand-2" href="${GH}" target="_blank" rel="noreferrer">GitHub</a></li>
+          <li><a class="hover:text-brand-2" href="${DISCORD}" target="_blank" rel="noreferrer">Discord</a></li>
           <li><a class="hover:text-brand-2" href="${X_URL}" target="_blank" rel="noreferrer">X (Twitter)</a></li>
           <li><a class="hover:text-brand-2" href="/docs/native-contract/">Native contract</a></li>
           <li><a class="hover:text-brand-2" href="/docs/build-pipeline/">Build pipeline</a></li>


### PR DESCRIPTION
## Summary

- Add a Discord badge link to the root README.
- Add Discord CTAs with inline SVG icons to the homepage hero and closing CTA, plus footer links on homepage and docs pages.
- Make the homepage GitHub nav item icon-only with an accessible label.
- Fix mobile `/docs` and `/aot/docs` horizontal page overflow by constraining the docs grid/content and keeping tables/code blocks internally scrollable.

## Validation

- `bun site/build.ts`
- `bunx tsc --noEmit`
- `bun run test`
- Local homepage browser checks with `bun site/serve.ts` + `bun site/verify.ts` at desktop and 390px mobile viewports.
- Local mobile checks for every `/docs/*` and `/aot/docs/*` page: `visualViewport=390`, `scrollWidth=390`, `wideCount=0`, no page or console errors.
