### PR TITLE
fix(release): unblock v0.4.0 gates on CI

### DIFF
--- a/test/npm-package.test.ts
+++ b/test/npm-package.test.ts
@@ -10,10 +10,13 @@ function packedFiles(cwd: string): string[] {
     stderr: "pipe",
   });
   expect(result.exitCode, result.stderr.toString()).toBe(0);
-  const report = JSON.parse(result.stdout.toString()) as Array<{
-    files: Array<{ path: string }>;
-  }>;
-  return report[0]!.files.map((file) => file.path);
+  // npm <= 11 reports an array of packs; npm >= 12 keys packs by package name.
+  const parsed = JSON.parse(result.stdout.toString()) as unknown;
+  const report = (
+    Array.isArray(parsed) ? parsed[0] : Object.values(parsed as object)[0]
+  ) as { files: Array<{ path: string }> } | undefined;
+  expect(report?.files, result.stdout.toString().slice(0, 200)).toBeDefined();
+  return report!.files.map((file) => file.path);
 }
 
 describe("published npm artifacts", () => {

--- a/test/psp-toolchain.test.ts
+++ b/test/psp-toolchain.test.ts
@@ -232,7 +232,8 @@ describe("canonical PSP toolchain", () => {
     expect(result.exitCode).toBe(1);
     expect(result.stdout.toString()).toContain("LLVM override (POCKETJS_LLVM_BIN)");
     expect(result.stdout.toString()).toContain(missing);
-  });
+    // Spawning the CLI cold takes >5 s on CI runners; the default timeout flakes.
+  }, 30_000);
 
   test("production entrypoints have no personal, DreamCart, or sibling toolchain fallback", async () => {
     const productionFiles = [


### PR DESCRIPTION
## Summary

- the v0.4.0 release run [29261713418](https://github.com/pocket-stack/pocketjs/actions/runs/29261713418) failed in the pre-publish test gate, before any npm publish happened
- `npm pack --dry-run --json` changed shape in npm 12 (which the workflow installs as `npm@latest` before running tests): npm ≤ 11 prints an array of pack reports, npm 12 keys them by package name — `packedFiles` now accepts both and asserts the shape with the raw output in the failure message
- the `doctor` CLI-spawn test took 8.3 s on the CI runner against bun's 5 s default timeout — it now carries an explicit 30 s timeout

## Validation

- `bun test test/npm-package.test.ts` under system npm 11.12.1 (array shape) — 2/2
- `bun test test/npm-package.test.ts` with npm 12.0.1 first on PATH (object shape) — 2/2
- `bun test test/psp-toolchain.test.ts` — 13/13

After merge, v0.4.0 will be re-tagged onto the new main head so the tag-triggered workflow picks up the fixed gates (no package was published by the failed run; the publish steps' `npm view` guards make re-runs safe).

🤖 Generated with [Claude Code](https://claude.com/claude-code)