### PR TITLE
fix(site): seat the L/R shoulders on the shell's silhouette

### DIFF
--- a/site/assets/screen.css
+++ b/site/assets/screen.css
@@ -50,8 +50,12 @@
     0 0 0 1px rgba(38, 46, 66, 0.9);
 }
 
-/* ---- shoulder bumpers — flush in the top corners, outer corner radius EXACTLY
-   matching the body's so the two curves coincide (no double curve). --------- */
+/* ---- shoulder bumpers — tabs on the FLAT stretch of the top edge. The pill
+   body's corner arc spans exactly --emu-radius horizontally, so insetting by
+   that much guarantees the shoulder sits fully on the silhouette at ANY
+   radius (pinning them at the corners left them floating outside the curve —
+   observed on the deployed page). Bottom corners stay square so the tab
+   welds onto the edge. ------------------------------------------------------ */
 .emu-shoulder {
   position: absolute;
   top: 0cqw;
@@ -65,12 +69,12 @@
   color: var(--emu-label);
   background: linear-gradient(180deg, #232837, #12151f);
   border: 1px solid rgba(255, 255, 255, 0.08);
-  border-radius: 1cqw; /* inner corners */
+  border-radius: 1.2cqw 1.2cqw 0 0;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.12), 0 2px 4px rgba(0, 0, 0, 0.4);
   transition: color 0.1s ease, background 0.1s ease, transform 0.06s ease, box-shadow 0.1s ease, border-color 0.1s ease;
 }
-.emu-shoulder.l { left: 0cqw; border-top-left-radius: var(--emu-radius); border-bottom-left-radius: 0.4cqw; }
-.emu-shoulder.r { right: 0cqw; border-top-right-radius: var(--emu-radius); border-bottom-right-radius: 0.4cqw; }
+.emu-shoulder.l { left: var(--emu-radius); }
+.emu-shoulder.r { right: var(--emu-radius); }
 .emu-shoulder:hover { background: linear-gradient(180deg, #2a3042, #171b26); color: #c6cddc; }
 .emu-shoulder.is-down,
 .emu-shoulder:active {


### PR DESCRIPTION
The hero shell's shoulder tabs floated outside the pill body's corner arc (user-reported on the live page). Inset by --emu-radius so they sit on the flat top edge at any radius. Screenshot-verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)