### PR TITLE
feat(devtools): bundle-hash handshake + device diagnostic counters

### DIFF
--- a/DEVTOOLS.md
+++ b/DEVTOOLS.md
@@ -122,6 +122,7 @@ The shim needs only `{ send(line), recv() -> line | null }`:
 Panel → device:
 `{t:"inspect", id}` · `{t:"pause"}` · `{t:"resume"}` · `{t:"step"}` ·
 `{t:"getTree"}` · `{t:"eval", id, code}` · `{t:"dumpTape"}` ·
+`{t:"devStats"}` (device diagnostic counters + build identity, OP.debugStats) ·
 `{t:"seek", frame}` / `{t:"replay", tape}` (handled by the *host*, not the
 shim: the browser host reloads the demo and fast-forwards tick-only — no
 render — to the target frame, then pauses).
@@ -131,6 +132,12 @@ Device → panel:
 `{t:"tree", frame, root:{i,t,n?,c?,x?,k:[…]}}` (id/type/name/class/text/kids) ·
 `{t:"inspect", id, rect:[x,y,w,h]|null}` ·
 `{t:"stats", frame, nodes, tapeLen, paused}` ·
+`{t:"devStats", frame, data}` (data: `{app, bundle, audio:{starved, reserveGiveups,
+lastReserveErr, releaseTimeouts, pushedFrames}, vid:{presented, torn, lapped,
+epochs, hdrFails, bytes}, svc:{truncResets}}` from native/src/stats.rs, or
+null when the host lacks the op; `bundle` is the FNV-1a64 of the embedded
+js+pak — the PSPLINK bridge requests this on every hello and compares it
+against `dist/` via scripts/bundle-hash.ts, flagging a stale embed loudly) ·
 `{t:"log", level, args}` · `{t:"error", frame, message, stack?}` ·
 `{t:"evalResult", id, ok, value}` ·
 `{t:"tape", tape:{v:1, app, frames, masks:[[mask,count],…]}}` (RLE).

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pocketjs/cli",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "The PocketJS CLI — manifest-first PSP and PS Vita builds, app scaffolding, and pinned PSP toolchain setup.",
   "license": "MIT",
   "type": "module",

--- a/core/src/spec.rs
+++ b/core/src/spec.rs
@@ -90,6 +90,7 @@ pub mod op {
     pub const VIDEO_TICK: u8 = 35;
     pub const VIDEO_TEXTURE: u8 = 36;
     pub const VIDEO_CLOSE: u8 = 37;
+    pub const DEBUG_STATS: u8 = 38;
 }
 
 /// Property ids (u8, stable, append-only). Groups:

--- a/native/build.rs
+++ b/native/build.rs
@@ -88,8 +88,6 @@ fn main() {
             )
         })
     };
-    code.push('\0');
-    fs::write(Path::new(&out_dir).join("game.js"), code).unwrap();
 
     // Asset pack (styles.bin + font atlases + images; .pak container) ->
     // $OUT_DIR/app.pak. Empty when absent; main.rs skips an empty pack.
@@ -100,6 +98,21 @@ fn main() {
         println!("cargo:rerun-if-changed={}", path.display());
         fs::read(&path).unwrap_or_default()
     };
+
+    // Build identity: FNV-1a64 over exactly the bytes embedded (js before
+    // its NUL, then pak). scripts/bundle-hash.ts is the host-side twin; the
+    // device reports this through OP.debugStats and the PSPLINK bridge
+    // compares it against local dist/ — a stale embed announces itself
+    // instead of silently invalidating a round of on-device verification.
+    let bundle_hash = if embed_app {
+        fnv1a64(&[code.as_bytes(), &pak])
+    } else {
+        String::from("none")
+    };
+    println!("cargo:rustc-env=POCKETJS_BUNDLE_HASH={bundle_hash}");
+
+    code.push('\0');
+    fs::write(Path::new(&out_dir).join("game.js"), code).unwrap();
     fs::write(Path::new(&out_dir).join("app.pak"), pak).unwrap();
 
     // Scripted input for deterministic capture builds (test/e2e-ppsspp.ts):
@@ -153,4 +166,17 @@ fn main() {
             println!("cargo:rerun-if-changed={}", e.path().display());
         }
     }
+}
+
+/// FNV-1a 64 as 16 hex digits — keep in lockstep with scripts/bundle-hash.ts
+/// (test vectors asserted there: "" = cbf29ce484222325, "a" = af63dc4c8601ec8c).
+fn fnv1a64(chunks: &[&[u8]]) -> String {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for chunk in chunks {
+        for &b in *chunk {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    format!("{h:016x}")
 }

--- a/native/src/audio.rs
+++ b/native/src/audio.rs
@@ -77,6 +77,7 @@ unsafe extern "C" fn audio_thread(_argc: usize, _argv: *mut c_void) -> i32 {
         if avail < need {
             // Starved (paused stream, USB stall): sleep instead of pushing
             // silence, so resume latency is one block, not a queue of hush.
+            crate::stats::AUDIO_STARVED.fetch_add(1, Ordering::Relaxed);
             sys::sceKernelDelayThread(4_000);
             continue;
         }
@@ -150,6 +151,7 @@ unsafe fn release_channel() {
         }
         sys::sceKernelDelayThread(2_000);
     }
+    crate::stats::AUDIO_RELEASE_TIMEOUTS.fetch_add(1, Ordering::Relaxed);
 }
 
 /// Reserve a normal 44.1 kHz channel and start the output thread. Rates
@@ -172,9 +174,11 @@ pub unsafe fn start(sample_rate: u32) -> bool {
         if ch >= 0 {
             break;
         }
+        crate::stats::AUDIO_LAST_RESERVE_ERR.store(ch, Ordering::Relaxed);
         sys::sceKernelDelayThread(4_000);
     }
     if ch < 0 {
+        crate::stats::AUDIO_RESERVE_GIVEUPS.fetch_add(1, Ordering::Relaxed);
         return false;
     }
     CHANNEL.store(ch, Ordering::Relaxed);
@@ -248,6 +252,7 @@ pub unsafe fn push(pcm: &[i16], channels: u32) {
         }
     }
     WRITE_POS.store(write.wrapping_add(n), Ordering::Release);
+    crate::stats::AUDIO_PUSHED_FRAMES.fetch_add(n as u32, Ordering::Relaxed);
 }
 
 /// Drop everything queued (seek/epoch discontinuity): jump the read cursor

--- a/native/src/ffi.rs
+++ b/native/src/ffi.rs
@@ -548,6 +548,18 @@ unsafe extern "C" fn js_dbg_poll(
     }
 }
 
+/// ui.debugStats() -> string: one JSON snapshot of the diagnostic counters
+/// plus build identity (spec OP.debugStats; see native/src/stats.rs).
+unsafe extern "C" fn js_debug_stats(
+    ctx: *mut JSContext,
+    _this: JSValue,
+    _argc: i32,
+    _argv: *mut JSValue,
+) -> JSValue {
+    let s = crate::stats::json();
+    JS_NewStringLen(ctx, s.as_ptr(), s.len())
+}
+
 /// ui.__dbgShot() -> bool: dump the displayed framebuffer to
 /// pocketjs-dbg/shot.raw (the bridge converts it to PNG panel-side).
 unsafe extern "C" fn js_dbg_shot(
@@ -779,6 +791,7 @@ pub unsafe fn register(
     add_fn(ctx, ui_obj, b"__dbgActive\0", js_dbg_active, 0);
     add_fn(ctx, ui_obj, b"__dbgPoll\0", js_dbg_poll, 0);
     add_fn(ctx, ui_obj, b"__dbgSend\0", js_dbg_send, 1);
+    add_fn(ctx, ui_obj, b"debugStats\0", js_debug_stats, 0);
     add_fn(ctx, ui_obj, b"__dbgShot\0", js_dbg_shot, 0);
     // Host service channel + video plane (spec ops 30..37; svc.rs / vid.rs).
     add_fn(ctx, ui_obj, b"svcOpen\0", js_svc_open, 1);

--- a/native/src/lib.rs
+++ b/native/src/lib.rs
@@ -30,5 +30,6 @@ pub mod ge;
 pub mod host;
 pub mod pak;
 pub mod qjs_alloc;
+pub mod stats;
 pub mod svc;
 pub mod vid;

--- a/native/src/stats.rs
+++ b/native/src/stats.rs
@@ -1,0 +1,79 @@
+//! Device diagnostic counters (spec OP.debugStats).
+//!
+//! One atomic per signal, incremented at the point of truth and snapshotted
+//! into a JSON line on demand — turning the questions that used to take a
+//! pspsh autopsy ("is audio underrunning?", "are frames being presented or
+//! torn?", "did the svc offset defense fire?") into a single devtools
+//! query. Also carries the build identity (app output name + FNV-1a64 of
+//! the embedded js+pak, computed by build.rs) so the PSPLINK bridge can
+//! detect a stale embed the moment the device says hello.
+//!
+//! Counters are u32 and free-running; readers diff two snapshots over a
+//! known window rather than resetting (writers stay wait-free, and two
+//! independent readers can't clobber each other).
+
+use alloc::format;
+use alloc::string::String;
+use core::sync::atomic::{AtomicI32, AtomicU32, Ordering};
+
+/// Starved 4 ms waits in the audio output thread. Grows freely while the
+/// stream is PAUSED (that is starvation by design) — meaningful only as a
+/// delta across a window that was supposed to be playing.
+pub static AUDIO_STARVED: AtomicU32 = AtomicU32::new(0);
+/// start() gave up reserving the hardware channel (the mute-forever class).
+pub static AUDIO_RESERVE_GIVEUPS: AtomicU32 = AtomicU32::new(0);
+/// Most recent negative sceAudioChReserve result (0 = never failed).
+pub static AUDIO_LAST_RESERVE_ERR: AtomicI32 = AtomicI32::new(0);
+/// release_channel() exhausted its drain retries (channel left held).
+pub static AUDIO_RELEASE_TIMEOUTS: AtomicU32 = AtomicU32::new(0);
+/// Source sample frames accepted into the RAM ring.
+pub static AUDIO_PUSHED_FRAMES: AtomicU32 = AtomicU32::new(0);
+
+/// Frames committed to the plane texture (the on-screen fps numerator).
+pub static VID_PRESENTED: AtomicU32 = AtomicU32::new(0);
+/// Completed slot reads discarded because the writer touched the slot
+/// mid-read (torn) — a few per seek are normal, a stream of them is not.
+pub static VID_TORN: AtomicU32 = AtomicU32::new(0);
+/// In-flight slot reads abandoned because the writer lapped the ring
+/// (sustained USB stall or an underpowered IO budget).
+pub static VID_LAPPED: AtomicU32 = AtomicU32::new(0);
+/// Epoch resyncs observed (seek/resume discontinuities).
+pub static VID_EPOCHS: AtomicU32 = AtomicU32::new(0);
+/// Header-block reads that failed outright (transport errors).
+pub static VID_HDR_FAILS: AtomicU32 = AtomicU32::new(0);
+/// Total stream-file bytes read (wraps at 4 GiB; diff across a window for
+/// effective throughput vs. IO_BUDGET).
+pub static VID_BYTES: AtomicU32 = AtomicU32::new(0);
+
+/// svc poll truncation defenses fired (host restarted / file recreated).
+pub static SVC_TRUNC_RESETS: AtomicU32 = AtomicU32::new(0);
+
+/// One JSON snapshot. Field names are the wire contract for the devtools
+/// "stats" message — extend, never rename.
+pub fn json() -> String {
+    let r = |c: &AtomicU32| c.load(Ordering::Relaxed);
+    format!(
+        concat!(
+            "{{\"app\":\"{}\",\"bundle\":\"{}\",",
+            "\"audio\":{{\"starved\":{},\"reserveGiveups\":{},\"lastReserveErr\":{},",
+            "\"releaseTimeouts\":{},\"pushedFrames\":{}}},",
+            "\"vid\":{{\"presented\":{},\"torn\":{},\"lapped\":{},\"epochs\":{},",
+            "\"hdrFails\":{},\"bytes\":{}}},",
+            "\"svc\":{{\"truncResets\":{}}}}}"
+        ),
+        env!("POCKETJS_APP"),
+        env!("POCKETJS_BUNDLE_HASH"),
+        r(&AUDIO_STARVED),
+        r(&AUDIO_RESERVE_GIVEUPS),
+        AUDIO_LAST_RESERVE_ERR.load(Ordering::Relaxed),
+        r(&AUDIO_RELEASE_TIMEOUTS),
+        r(&AUDIO_PUSHED_FRAMES),
+        r(&VID_PRESENTED),
+        r(&VID_TORN),
+        r(&VID_LAPPED),
+        r(&VID_EPOCHS),
+        r(&VID_HDR_FAILS),
+        r(&VID_BYTES),
+        r(&SVC_TRUNC_RESETS),
+    )
+}

--- a/native/src/svc.rs
+++ b/native/src/svc.rs
@@ -100,6 +100,7 @@ pub unsafe fn poll() -> Option<String> {
     let end = sys::sceIoLseek(fd, 0, IoWhence::End);
     if end < READ_OFF {
         READ_OFF = 0;
+        crate::stats::SVC_TRUNC_RESETS.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     }
     sys::sceIoLseek(fd, READ_OFF, IoWhence::Set);
     let mut buf: Vec<u8> = alloc::vec![0u8; pocketjs_core::spec::svc::POLL_BUF];

--- a/native/src/vid.rs
+++ b/native/src/vid.rs
@@ -92,6 +92,7 @@ unsafe fn pread(fd: SceUid, off: u32, buf: &mut [u8]) -> bool {
         }
         got += n as usize;
     }
+    crate::stats::VID_BYTES.fetch_add(buf.len() as u32, core::sync::atomic::Ordering::Relaxed);
     true
 }
 
@@ -166,9 +167,12 @@ pub unsafe fn tick(ui: &mut Ui) -> i32 {
     let Some(s) = SESSION.as_mut() else { return -1 };
     let mut budget = IO_BUDGET;
 
+    use core::sync::atomic::Ordering::Relaxed;
+
     // 1. Writer cursors.
     let mut hdr = [0u8; st::HEADER_BLOCK_SIZE];
     if !pread(s.fd, 0, &mut hdr) {
+        crate::stats::VID_HDR_FAILS.fetch_add(1, Relaxed);
         return s.presented_frame;
     }
     budget -= st::HEADER_BLOCK_SIZE;
@@ -187,6 +191,7 @@ pub unsafe fn tick(ui: &mut Ui) -> i32 {
         s.pending = false; // a staged pre-seek frame must not present
         s.audio_next = 0;
         audio::flush();
+        crate::stats::VID_EPOCHS.fetch_add(1, Relaxed);
     }
 
     // 3. Audio top-up (whole chunks; the RAM ring absorbs jitter).
@@ -242,6 +247,7 @@ pub unsafe fn tick(ui: &mut Ui) -> i32 {
         // The writer lapped the slot mid-read; its bytes are torn. Restart.
         s.target_seq = 0;
         s.staged = 0;
+        crate::stats::VID_LAPPED.fetch_add(1, Relaxed);
     }
     if !s.pending && s.target_seq == 0 && v.latest_seq > s.presented_seq {
         s.target_seq = v.latest_seq;
@@ -275,6 +281,8 @@ pub unsafe fn tick(ui: &mut Ui) -> i32 {
                     s.staged_seq = s.target_seq;
                     s.staged_frame = sh.frame_index as i32;
                     s.pending = true;
+                } else {
+                    crate::stats::VID_TORN.fetch_add(1, Relaxed);
                 }
                 s.target_seq = 0;
                 s.staged = 0;
@@ -303,6 +311,7 @@ pub unsafe fn present(ui: &mut Ui) {
         ge::writeback_texture(ui, s.tex);
         s.presented_seq = s.staged_seq;
         s.presented_frame = s.staged_frame;
+        crate::stats::VID_PRESENTED.fetch_add(1, core::sync::atomic::Ordering::Relaxed);
     }
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pocketjs/framework",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/pocket.json
+++ b/pocket.json
@@ -4,7 +4,7 @@
   "id": "dev.pocket-stack.hero",
   "name": "pocketjs-hero",
   "title": "PocketJS Hero",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "engine": {
     "capabilities": {
       "requires": [

--- a/scripts/bundle-hash.ts
+++ b/scripts/bundle-hash.ts
@@ -1,0 +1,41 @@
+// scripts/bundle-hash.ts — the build-identity hash, host side.
+//
+// FNV-1a 64 over the app JS bundle bytes followed by the pak bytes. The
+// SAME algorithm runs in native/build.rs over the bytes it embeds into the
+// PRX (spec OP.debugStats reports it back), so "which code is the device
+// actually running" becomes a comparison instead of an act of faith — a
+// stale embed once shipped two rounds of "verified" fixes that never ran.
+//
+// Keep both implementations in lockstep; the published FNV-1a test vectors
+// below are asserted in test/devtools.test.ts.
+
+import { readFileSync } from "node:fs";
+
+const OFFSET = 0xcbf29ce484222325n;
+const PRIME = 0x100000001b3n;
+const MASK = 0xffffffffffffffffn;
+
+/** FNV-1a 64 over the concatenation of `chunks`, as 16 hex digits. */
+export function fnv1a64(...chunks: Uint8Array[]): string {
+  let h = OFFSET;
+  for (const chunk of chunks) {
+    for (let i = 0; i < chunk.length; i++) {
+      h ^= BigInt(chunk[i]);
+      h = (h * PRIME) & MASK;
+    }
+  }
+  return h.toString(16).padStart(16, "0");
+}
+
+/** Hash of the exact bytes native/build.rs embeds: js file, then pak file.
+ *  A missing pak hashes as empty — build.rs embeds an empty pak then too. */
+export function bundleHash(jsPath: string, pakPath: string): string {
+  const js = readFileSync(jsPath);
+  let pak: Uint8Array;
+  try {
+    pak = readFileSync(pakPath);
+  } catch {
+    pak = new Uint8Array(0);
+  }
+  return fnv1a64(js, pak);
+}

--- a/scripts/devtools-bridge.ts
+++ b/scripts/devtools-bridge.ts
@@ -20,10 +20,18 @@ import {
   writeFileSync,
 } from "node:fs";
 import { join } from "node:path";
+import { bundleHash } from "./bundle-hash.ts";
 import { encodePNG } from "../test/png.ts";
 
 export interface BridgeEvent {
-  type: "hub-connected" | "hub-lost" | "device-talking" | "hello" | "screenshot";
+  type:
+    | "hub-connected"
+    | "hub-lost"
+    | "device-talking"
+    | "hello"
+    | "screenshot"
+    | "bundle-ok"
+    | "bundle-mismatch";
   detail?: string;
 }
 
@@ -32,6 +40,9 @@ export interface BridgeOptions {
   dir: string;
   /** dev-server (WS hub) port */
   port: number;
+  /** dist dir holding <app>.js/.pak for the bundle-hash check (default:
+   *  the repo's dist/ next to this script). */
+  dist?: string;
   onEvent?: (e: BridgeEvent) => void;
 }
 
@@ -102,6 +113,30 @@ export function startBridge(opts: BridgeOptions): Bridge {
     return "data:image/png;base64," + encodePNG(rgba, w, h).toString("base64");
   }
 
+  const distDir = opts.dist ?? new URL("../dist", import.meta.url).pathname;
+
+  /** Stale-embed tripwire: the device's stats reply carries the FNV-1a64 of
+   *  the js+pak baked into the PRX (native/build.rs); compare it with the
+   *  hash of what dist/ holds NOW. A mismatch means the running EBOOT does
+   *  not contain the code being edited — every on-device observation would
+   *  be evidence about the wrong build. */
+  function checkBundle(data: Record<string, unknown>): void {
+    const app = String(data.app ?? "");
+    const device = String(data.bundle ?? "");
+    if (!app || !device || device === "none") return;
+    let local: string;
+    try {
+      local = bundleHash(join(distDir, `${app}.js`), join(distDir, `${app}.pak`));
+    } catch {
+      return; // no local build of this app — nothing to compare against
+    }
+    if (local === device) {
+      emit({ type: "bundle-ok", detail: `${app} @ ${device}` });
+    } else {
+      emit({ type: "bundle-mismatch", detail: `${app}: device ${device} != dist ${local}` });
+    }
+  }
+
   function handleDeviceLine(line: string): void {
     let msg: Record<string, unknown> | null = null;
     try {
@@ -109,7 +144,19 @@ export function startBridge(opts: BridgeOptions): Bridge {
     } catch {
       msg = null;
     }
-    if (msg?.t === "hello") emit({ type: "hello", detail: String(msg.app ?? "?") });
+    if (msg?.t === "hello") {
+      emit({ type: "hello", detail: String(msg.app ?? "?") });
+      // Fresh boot: ask for device stats — the reply carries the bundle hash.
+      try {
+        appendFileSync(inPath, JSON.stringify({ t: "devStats" }) + "\n");
+      } catch {
+        // usbhostfs hiccup — the next hello retries
+      }
+    }
+    if (msg?.t === "devStats" && msg.data && typeof msg.data === "object") {
+      checkBundle(msg.data as Record<string, unknown>);
+      // fall through: panels get the stats reply too
+    }
     if (msg?.t === "screenshotRaw") {
       try {
         const data = convertShot(

--- a/scripts/devtools-bridge.ts
+++ b/scripts/devtools-bridge.ts
@@ -31,7 +31,8 @@ export interface BridgeEvent {
     | "hello"
     | "screenshot"
     | "bundle-ok"
-    | "bundle-mismatch";
+    | "bundle-mismatch"
+    | "bundle-silent";
   detail?: string;
 }
 
@@ -146,14 +147,30 @@ export function startBridge(opts: BridgeOptions): Bridge {
     }
     if (msg?.t === "hello") {
       emit({ type: "hello", detail: String(msg.app ?? "?") });
-      // Fresh boot: ask for device stats — the reply carries the bundle hash.
+      // Fresh boot: ask for device stats — the reply carries the bundle
+      // hash. A build too old to know devStats never replies, which would
+      // fail SILENT — the one thing this tripwire must not do — so a
+      // watchdog turns silence into a verdict too (first caught live: an
+      // EBOOT embedding the pre-rename shim during this feature's own
+      // hardware pass).
       try {
         appendFileSync(inPath, JSON.stringify({ t: "devStats" }) + "\n");
+        if (statsWatchdog) clearTimeout(statsWatchdog);
+        statsWatchdog = setTimeout(() => {
+          emit({
+            type: "bundle-silent",
+            detail: "no devStats reply in 3 s — the embedded bundle predates the handshake (stale or pre-#118)",
+          });
+        }, 3000);
       } catch {
         // usbhostfs hiccup — the next hello retries
       }
     }
     if (msg?.t === "devStats" && msg.data && typeof msg.data === "object") {
+      if (statsWatchdog) {
+        clearTimeout(statsWatchdog);
+        statsWatchdog = null;
+      }
       checkBundle(msg.data as Record<string, unknown>);
       // fall through: panels get the stats reply too
     }
@@ -177,6 +194,7 @@ export function startBridge(opts: BridgeOptions): Bridge {
     if (ws && ws.readyState === 1) ws.send(line);
   }
 
+  let statsWatchdog: ReturnType<typeof setTimeout> | null = null;
   let offset = 0;
   let sawDevice = false;
   const tail = setInterval(() => {
@@ -208,6 +226,7 @@ export function startBridge(opts: BridgeOptions): Bridge {
     stop() {
       stopped = true;
       clearInterval(tail);
+      if (statsWatchdog) clearTimeout(statsWatchdog);
       ws?.close();
       try {
         if (existsSync(enablePath)) rmSync(enablePath);

--- a/scripts/devtools-psp.ts
+++ b/scripts/devtools-psp.ts
@@ -38,6 +38,12 @@ const bridge = startBridge({
       console.log(`devtools-psp: device is talking — open the panel at http://127.0.0.1:${port}/devtools`);
     if (e.type === "hello") console.log(`devtools-psp: app "${e.detail}" said hello`);
     if (e.type === "screenshot") console.log(`devtools-psp: screenshot served (${e.detail})`);
+    if (e.type === "bundle-ok") console.log(`devtools-psp: bundle verified — ${e.detail}`);
+    if (e.type === "bundle-mismatch")
+      console.error(
+        `devtools-psp: *** STALE EMBED *** ${e.detail}\n` +
+          "devtools-psp: the device is NOT running the code in dist/ — rebuild the EBOOT and reload before trusting anything you observe.",
+      );
   },
 });
 

--- a/scripts/devtools-psp.ts
+++ b/scripts/devtools-psp.ts
@@ -39,6 +39,7 @@ const bridge = startBridge({
     if (e.type === "hello") console.log(`devtools-psp: app "${e.detail}" said hello`);
     if (e.type === "screenshot") console.log(`devtools-psp: screenshot served (${e.detail})`);
     if (e.type === "bundle-ok") console.log(`devtools-psp: bundle verified — ${e.detail}`);
+    if (e.type === "bundle-silent") console.error(`devtools-psp: *** BUNDLE UNVERIFIED *** ${e.detail}`);
     if (e.type === "bundle-mismatch")
       console.error(
         `devtools-psp: *** STALE EMBED *** ${e.detail}\n` +

--- a/scripts/devtools.ts
+++ b/scripts/devtools.ts
@@ -264,6 +264,13 @@ function onEvent(e: { type: string; detail?: string }): void {
   if (e.type === "device-talking") status(green("device is talking — open the panel"));
   if (e.type === "hello") status(green(`app "${e.detail}" attached`));
   if (e.type === "screenshot") status(`screenshot served (${e.detail})`);
+  if (e.type === "bundle-ok") status(green(`bundle verified — ${e.detail}`));
+  if (e.type === "bundle-mismatch")
+    status(
+      yellow(
+        `*** STALE EMBED *** ${e.detail} — the device is NOT running dist/; rebuild + reload before trusting observations`,
+      ),
+    );
 }
 
 if (managed) {

--- a/scripts/devtools.ts
+++ b/scripts/devtools.ts
@@ -265,6 +265,7 @@ function onEvent(e: { type: string; detail?: string }): void {
   if (e.type === "hello") status(green(`app "${e.detail}" attached`));
   if (e.type === "screenshot") status(`screenshot served (${e.detail})`);
   if (e.type === "bundle-ok") status(green(`bundle verified — ${e.detail}`));
+  if (e.type === "bundle-silent") status(yellow(`bundle unverified — ${e.detail}`));
   if (e.type === "bundle-mismatch")
     status(
       yellow(

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -3,6 +3,49 @@
 Engine and site milestones, newest first. Versions track the
 `@pocketjs/framework` npm package.
 
+## 0.5.0 — July 17, 2026
+
+**The console grows system software.** Streaming media, a system keyboard, a
+virtual pointer, and self-diagnosing devices — capabilities every handheld
+app needs, now owned by the framework instead of copy-pasted per demo —
+proven by [streaming YouTube to a PSP over USB](/blog/pocket-youtube/).
+
+- **App services over USB** — the `pocket-svc` mailbox gives any app a JSON
+  command channel to a companion desktop service (request/reply with side
+  files for bulk bytes), the same file-transport model DevTools proved,
+  hardened against host restarts. Pocket YouTube — search, host-rendered CJK
+  result rows, and full-motion playback on real hardware — ships as its own
+  app repo (`pocket-stack/pocket-youtube`) built entirely on these APIs.
+- **A streaming video plane** — `.pkst` ring files carry palettized frames
+  and PCM audio from the host; the native side pumps them under a per-frame
+  IO budget, commits texture updates only in the GE-idle window (tear-free
+  by construction), and plays audio on a dedicated hardware channel with a
+  software resampler. Seek, pause, and epoch resync are part of the
+  contract, not the app.
+- **A system on-screen keyboard** — `@pocketjs/framework/osk`: an LVGL-style
+  variable-width key grid with letters/caps/symbols layers, dark and light
+  themes, and a caret-editing session (`createOsk`). While open it owns
+  input outright (modal focus scope + button block), retiring the
+  gate-every-handler pattern. One component, per-platform input: d-pad
+  spatial navigation and the classic PSP chords, front-touch on Vita, and
+  the virtual cursor for free.
+- **A virtual cursor capability** (`input.cursor`) — the analog nub steers a
+  core-drawn pointer; hover *is* focus, so every `focus:` style doubles as
+  the hover style, presses arm and fire like real buttons, and d-pad
+  traversal stays available as a fallback. Opt-in via `enableCursor()`.
+- **Devices that vouch for themselves** — every build embeds an FNV-1a64
+  hash of its app bundle; the PSPLINK bridge verifies it against `dist/` on
+  every boot and calls out a stale embed (or a silent, pre-handshake build)
+  before you trust a single observation. `OP.debugStats` exposes live
+  audio/video/transport counters through the new DevTools `devStats` query —
+  underruns, torn frames, and truncation resets become one request instead
+  of a thread autopsy.
+- **Compatibility:** existing apps build unchanged. New host ops (30–38) are
+  optional capabilities — hosts that lack them simply omit the op, and the
+  framework degrades gracefully (the OSK falls back to bottom-dock geometry
+  without hit testing; `devStats` replies `data: null`). PS Vita builds now
+  ship complete default LiveArea artwork.
+
 ## 0.4.0 — July 13, 2026
 
 **One app, two PlayStations.** PocketJS now treats PSP and PS Vita as two

--- a/skills/pocketjs-release/SKILL.md
+++ b/skills/pocketjs-release/SKILL.md
@@ -16,9 +16,11 @@ on every `main` push (`deploy.yml`). `@pocketjs/aot` stays private.
 ## Standard workflow
 
 1. **Version bumps (in the feature PR, before merge).** Set the same version
-   in `package.json` and `cli/package.json`. Semver within 0.x: breaking
-   changes (e.g. a bin rename) and feature sets bump the minor; docs-only
-   fixes ride the next release rather than getting their own.
+   in `package.json`, `cli/package.json`, AND `pocket.json` — the release
+   gate (`scripts/release-check.ts`) verifies all three authorities agree
+   with the tag. Semver within 0.x: breaking changes (e.g. a bin rename)
+   and feature sets bump the minor; docs-only fixes ride the next release
+   rather than getting their own.
 2. **Changelog (same PR).** Add the `## X.Y.Z — <Month D, YYYY>` entry at the
    top of `site/content/changelog.md`: one bold thesis line, then bullets
    grouped by capability, linking the blog deep-dive when one exists. Mark

--- a/spec/spec.ts
+++ b/spec/spec.ts
@@ -193,6 +193,17 @@ export const OP = {
   videoTexture: 36, //    () -> handle | -1. The plane texture (stable for the
   //                      whole session; -1 when no stream is open).
   videoClose: 37, //      () — stop audio, close the stream, free the plane.
+  debugStats: 38, //      () -> string. One JSON snapshot of the device's
+  //                      diagnostic counters (native/src/stats.rs: audio
+  //                      underruns/reserve failures, video frames presented/
+  //                      torn/lapped, svc truncation resets) plus build
+  //                      identity: the app output name and the FNV-1a64 hash
+  //                      of the embedded js+pak (scripts/bundle-hash.ts is
+  //                      the host-side twin). The devtools "devStats"
+  //                      message rides this; the bridge compares the hash
+  //                      against local dist/ on every hello and calls out a
+  //                      stale-embed loudly. Hosts without counters simply
+  //                      omit the op.
 } as const;
 
 // ---------------------------------------------------------------------------

--- a/src/devtools.ts
+++ b/src/devtools.ts
@@ -358,6 +358,25 @@ function handleMessage(line: string): void {
     case "dumpTape":
       send({ t: "tape", tape: exportTape() });
       break;
+    case "devStats": {
+      // Device diagnostic counters + build identity (OP.debugStats). The
+      // PSPLINK bridge sends this on every hello to verify the embedded
+      // bundle hash against local dist/; panels can poll it for underrun/
+      // presented/torn counters. Hosts without the op reply data: null so
+      // the round trip still completes. (Distinct from the periodic
+      // {t:"stats"} shim push — that one is JS-side frame/node/tape state.)
+      let data: unknown = null;
+      const raw = ops?.debugStats?.();
+      if (raw) {
+        try {
+          data = JSON.parse(raw);
+        } catch {
+          data = null;
+        }
+      }
+      send({ t: "devStats", frame: state.frame, data });
+      break;
+    }
     case "screenshot": {
       // PSP path only — the browser host intercepts this message itself
       // (canvas.toDataURL) and it never reaches the shim there. The native

--- a/src/host.ts
+++ b/src/host.ts
@@ -156,6 +156,11 @@ export interface HostOps {
   __dbgSend?(line: string): void;
   /** PSP on-demand screenshot: dump the displayed framebuffer to
    *  pocketjs-dbg/shot.raw (bridge converts to PNG). → success. */
+  /** OP.debugStats — one JSON snapshot of device diagnostic counters
+   *  (audio/vid/svc) plus build identity (app output name + FNV-1a64 of the
+   *  embedded js+pak). Hosts without counters omit the op; the devtools
+   *  "stats" message replies with data: null then. */
+  debugStats?(): string;
   __dbgShot?(): boolean;
   /** Framework target/profile identity (for example "psp" or "vita"). */
   __host?: string;

--- a/test/devtools.test.ts
+++ b/test/devtools.test.ts
@@ -328,3 +328,43 @@ describe("errors + formatting", () => {
     expect(fmt(undefined)).toBe("undefined");
   });
 });
+
+// ---------------------------------------------------------------------------
+// stats (OP.debugStats) + the bundle-hash twin
+// ---------------------------------------------------------------------------
+
+describe("stats", () => {
+  test("stats replies with the host's parsed counter snapshot", () => {
+    host.ops.debugStats = () =>
+      '{"app":"devtools-test","bundle":"cafe00cafe00cafe","vid":{"presented":42}}';
+    mountApp(() => View({}));
+    push({ t: "devStats" });
+    frame();
+    const s = sent("devStats");
+    expect(s.length).toBe(1);
+    const data = s[0].data as Record<string, unknown>;
+    expect(data.bundle).toBe("cafe00cafe00cafe");
+    expect((data.vid as Record<string, unknown>).presented).toBe(42);
+  });
+
+  test("a host without the op still completes the round trip (data: null)", () => {
+    mountApp(() => View({}));
+    push({ t: "devStats" });
+    frame();
+    const s = sent("devStats");
+    expect(s.length).toBe(1);
+    expect(s[0].data).toBeNull();
+  });
+});
+
+describe("bundle hash", () => {
+  test("fnv1a64 matches the published FNV-1a 64 test vectors", async () => {
+    const { fnv1a64 } = await import("../scripts/bundle-hash.ts");
+    const bytes = (s: string) => new TextEncoder().encode(s);
+    expect(fnv1a64(new Uint8Array(0))).toBe("cbf29ce484222325"); // offset basis
+    expect(fnv1a64(bytes("a"))).toBe("af63dc4c8601ec8c");
+    expect(fnv1a64(bytes("hello"))).toBe("a430d84680aabd0b");
+    // Chunk boundaries must not matter (js+pak concatenation).
+    expect(fnv1a64(bytes("he"), bytes("llo"))).toBe(fnv1a64(bytes("hello")));
+  });
+});


### PR DESCRIPTION
Two DX upgrades from the pocket-youtube hardware sessions, sharing one wire (spec OP.debugStats, 38):

## Build identity — the stale-embed tripwire

`native/build.rs` bakes an FNV-1a64 of exactly the bytes it embeds (js + pak) into the PRX; `scripts/bundle-hash.ts` is the byte-for-byte host twin (published FNV-1a test vectors asserted in CI). The PSPLINK bridge requests device stats on every `hello` and compares the reported hash against `dist/`:

- match → `bundle verified — im-main @ 4a4aebb252ddc9a9`
- mismatch → `*** STALE EMBED *** … the device is NOT running the code in dist/ — rebuild the EBOOT and reload before trusting anything you observe.`

Why: a missing `rerun-if-changed` once shipped two rounds of hardware-"verified" fixes inside a fresh PRX wrapping the *previous* bundle — and masked a compile error behind them. That failure class is now self-announcing.

## Device diagnostic counters

`native/src/stats.rs`: one free-running atomic per signal, incremented at the point of truth —

- **audio**: starved waits · reserve giveups (+ last sce error code) · release timeouts · pushed frames
- **vid**: frames presented / torn / lapped · epoch resyncs · header-read failures · bytes read
- **svc**: truncation-defense resets

`OP.debugStats` snapshots them as one JSON line (with app name + bundle hash); the new devtools `{t:"devStats"}` message (distinct from the periodic JS-side `{t:"stats"}` push) carries it to panels and the bridge. The pspsh-autopsy questions from the youtube sessions — *is audio underrunning? are frames presenting or tearing? did the svc offset defense fire?* — become a single query.

## Verified

- `bun run test` green (devtools suite covers the devStats round trip with and without the op, plus FNV vectors); `cargo test` 76/76; contract regenerated + green.
- Offline bridge integration: fake mailbox drove `hello` → auto `devStats` request → `bundle-ok` with the real dist hash → `bundle-mismatch` with a corrupted one.
- PSP release EBOOT builds; `strings` confirms the exact expected hash and the stats template embedded.
- **Pending**: one live hardware pass (device currently unplugged) — hello handshake verdict + counters moving during playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Hardware pass — complete ✓

Live on a real PSP over PSPLINK (im EBOOT):

1. **Verified**: boot → hello → `bundle verified — im-main @ dfffebd897d43065` (device hash == dist hash, automatic).
2. **`{t:"devStats"}` round trip**: full counter JSON returned from the device (all zeros for im, correctly — no audio/video/svc in that app), bundle identity included.
3. **Tripwire drill**: appended one comment line to `dist/im-main.js`, reloaded the *same* PRX → `*** STALE EMBED *** im-main: device dfffebd897d43065 != dist fc1b63f315c47670`. Restored the file, reloaded → verified again.
4. **Watchdog** (second commit): the pass itself caught the one silent failure mode — the first EBOOT loaded predated the message rename, ignored the request, and the bridge printed *nothing*. A 3 s watchdog per hello now emits `*** BUNDLE UNVERIFIED ***` for handshake-oblivious builds (offline-tested: hello with no reply → `bundle-silent`).

The tripwire's first real catch was a genuine stale embed inside its own verification session.
