### PR TITLE
docs(site): retitle the pocket-character post as a product introduction

### DIFF
--- a/site/home.html
+++ b/site/home.html
@@ -46,7 +46,7 @@
       <div class="lp-container lp-hero__in">
         <a class="lp-eyebrow" href="/blog/pocket-character/">
           <span class="lp-eyebrow__tag">New</span>
-          One process, whole character: airi's digital human at 4% of a core
+          Pocket Character: a desktop digital human at 4% of one core
           <span class="lp-eyebrow__arw" aria-hidden="true">&rarr;</span>
         </a>
         <h1 class="lp-h1">Bare Metal<span class="lp-grad">Modern Web</span></h1>

--- a/site/nav.ts
+++ b/site/nav.ts
@@ -56,7 +56,7 @@ export interface BlogPost {
 export const BLOG_POSTS: BlogPost[] = [
   {
     slug: "pocket-character",
-    title: "One Process, Whole Character",
+    title: "Pocket Character: a Desktop Digital Human in One Native Process",
     date: "2026-07-19",
     description:
       "airi's 3D digital human — same VRM model, same idle loop, same blink math, same spring-bone physics, same transparent always-on-top window — rebuilt as a single native process on the Pocket runtime: 118 MB and 4 % of one core instead of an Electron tree's 2.2 GB and 44 %. Inside: morph targets that cost nothing between blinks, a VRM crate that learned the difference between +Z and −Z the hard way, a QuickJS bundle as the hot-swappable personality, and a measurement section with receipts — same machine, same ruler, screenshots included.",


### PR DESCRIPTION
Title now leads with the project name and says what it is — matching the Pocket YouTube naming pattern: **"Pocket Character: a Desktop Digital Human in One Native Process"**. Landing eyebrow aligned. Slug/URL unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)