### PR TITLE
feat(pocket-widget): widget capability crate + 3D PSP handheld runtime

### DIFF
--- a/RUNTIMES.md
+++ b/RUNTIMES.md
@@ -147,6 +147,7 @@ The grammar is implemented once, as infrastructure every runtime reuses:
 | --- | --- |
 | `pocket-mod` | Guest hosting: QuickJS realm lifecycle, surface mounting (`mount("ui", ops)`), per-tick pump (frame call + job drain + timers), console, hot reload. The "mod runtime" capability, as a library. |
 | `pocket-ui-wgpu` | The `ui` surface, desktop edition: feeds paks to `pocketjs-core`, exposes the 17 `HostOps` ops to the guest, renders the DrawList through wgpu into any render target — a window (standalone app host) or an overlay pass over a 3D scene (game HUD). |
+| `pocket-widget` | The desktop-widget capability (WIDGET.md): a widget window shell whose guest ticks at a fixed rate while GPU frames render on demand, embedded `ui` surfaces bound onto meshes, and cursor-ray part picking mapped to spec BTN bits. The handheld example (a 3D PSP running unmodified bundles) is the first runtime on it. |
 | `pocketjs-core` | The 2D UI core (unchanged; now viewport-parameterized). |
 | `pocket3d` | Native substrate, desktop edition: wgpu bootstrap, forward renderer, glTF models, headless capture. |
 | `pocket3d-bsp` | The portable half of the 3D substrate (no_std + alloc): GoldSrc maps, hull collision, the character controller, PVS visibility, and the cooked `.p3d` world format. Runs identically under wgpu and on the PSP. |

--- a/WIDGET.md
+++ b/WIDGET.md
@@ -1,0 +1,226 @@
+# Pocket Widget — desktop widgets as a runtime-family capability
+
+*How the Pocket runtime family puts small, always-on, guest-programmable
+presences on the desktop — and the first runtime built on it: a borderless
+3D PSP on your Mac that actually runs Pocket apps.*
+
+This document names and generalizes what
+[pocket-character](https://github.com/pocket-stack/pocket-character) proved,
+and specifies the next runtime that needs the generalization. It follows the
+[RUNTIMES.md](RUNTIMES.md) ontology: a widget runtime is still
+⟨Cores, Surfaces, Guest⟩; **pocket-widget** is the mechanism layer that makes
+the desktop-widget *form factor* a reusable capability instead of a per-app
+reinvention.
+
+## 1. The capability
+
+A desktop widget is the smallest unit of ambient software: one always-on-top,
+transparent, undecorated window that lives on the desktop for hours. The form
+factor puts two hard constraints on the architecture:
+
+1. **Idle must cost almost nothing.** A widget is judged by what it burns at
+   rest, not at peak. pocket-character measured the gap: the same character
+   stage costs 8 processes / 2184 MB / 44% CPU on Electron and
+   1 process / 118 MB / 3.9% CPU on the Pocket stack — *while rendering 60
+   fps of skinned, spring-boned 3D continuously*. A widget whose content is
+   mostly static should land far below even that.
+2. **Behavior must be a bundle, not a build.** Which app the widget hosts,
+   how it reacts, what its personality is — guest program, hot-swappable,
+   sandboxed by construction (capability = surface).
+
+pocket-character satisfied both, but its host is product-specific code. The
+generic halves it left upstream (`AppConfig` widget-window mode, transparent
+clear, `max_fps` pacing, morph/pose machinery — pocketjs #125) are window
+plumbing, not the full capability. **pocket-widget** is the missing middle: a
+`pocket3d`-workspace mechanism crate, sitting beside `pocket-mod` and
+`pocket-ui-wgpu` in the RUNTIMES.md table:
+
+| Piece | Role |
+| --- | --- |
+| `WidgetShell` | The window contract: transparent / undecorated / always-on-top / drag-to-move (all from #125), plus occlusion suspend, focus loss, cursor hit-test toggling for click-through, and headless offscreen capture of the whole composite (alpha = real window transparency). |
+| `EmbeddedUi` | A full PocketJS `ui` surface rendered off-window: `pocket-ui-wgpu` draws the core's DrawList into an `OffscreenTarget`, and the resulting texture view is bound as a named material on any `pocket3d` model. A screen inside a widget is a *real app*, not a video. |
+| `PartMap` | The interaction vocabulary: glTF node names → semantic parts (`btn_cross`, `dpad_up`, `nub`, `screen`, `led_power`). Cursor-ray picking against named nodes (event-driven, CPU, cold path), pressed parts → host input bits, drag on analog parts → analog axes. |
+| `PowerGovernor` | The idle contract, §4: fixed-rate guest ticks, demand-driven GPU frames. |
+
+What stays out of pocket-widget: any specific model, part map, or behavior —
+those are the product. (pocket-character retrofits onto `WidgetShell` +
+`PowerGovernor` naturally; that refactor is desirable but not a blocker.)
+
+## 2. The first runtime: pocket-handheld
+
+The motivating product — and the proof that `EmbeddedUi` + `PartMap` carry
+real weight — is a **3D PSP model on the desktop that works**:
+
+- Borderless, transparent, always-on-top window framing a 3D PSP.
+- The PSP's screen is a live 480×272 PocketJS `ui` surface — the same
+  DrawList renderer that drives PSP hardware, **not** an emulator. PPSSPP
+  renders a machine; we render the *app*, because the app was never
+  PSP-binary-shaped to begin with.
+- The PSP's buttons are pickable meshes. Click CROSS and the guest's next
+  `frame(buttons, analog)` carries `BTN_CROSS` — the identical bit the real
+  hardware's pad register produces. Drag the analog nub and the guest sees
+  the same packed axes a real nub produces.
+- Therefore: **any existing PocketJS app boots inside the widget unmodified.**
+  The bundle that runs on a real PSP, in uihost, and on the Vita runs here,
+  and cannot tell the difference. That is the whole demo.
+
+Proposed name: `pocket-handheld` (per the `pocket-<product>` convention;
+"handheld" rather than "psp" because the runtime is shell-agnostic — §6 — and
+to avoid colliding with the `pocketjs-psp` host library). Own repo under
+pocket-stack with the engine as a submodule, like pocket-character.
+
+In RUNTIMES.md notation:
+
+```
+pocket-handheld (Rust bin, macOS)
+  = widget shell        (pocket-widget: window, picking, part input, power)
+  + PSP shell asset     (glTF: body, named button nodes, screen material, nub)
+  + mounts `ui`         (pocket-ui-wgpu → OffscreenTarget → screen material)
+  + mounts `widget`     (optional, §7: hover/led/framing facts and intents)
+  + pocket-mod guest    (one unmodified PocketJS app bundle + pak)
+```
+
+There is no new domain vocabulary to invent for v1: the guest-facing surface
+is the existing `ui` surface, byte-for-byte. The runtime's novelty is
+entirely host-side composition.
+
+## 3. Input: from meshes to BTN bits
+
+The bridge is deliberately dumb — a static table, no gameplay logic:
+
+- **Buttons.** `btn_cross/circle/square/triangle`, `dpad_up/down/left/right`,
+  `btn_start/select`, `trig_l/r` map 1:1 to the spec BTN bits. Mouse-down on
+  a part sets the bit until mouse-up; multiple parts can be held (chords work,
+  the OSK needs them). Pressed parts get a procedural press: a small
+  translation along the button's local axis injected via `ModelInstance::pose`
+  (the #125 pose-injection split) — no baked animations required.
+- **Analog nub.** Drag within the nub's radius maps to the packed axes
+  (`(x << 8) | y`, 0–255, 128 center); release springs back to center.
+  Extremes are raw 255/1 — never 0 — matching the input-tape convention.
+- **Keyboard, always.** The uihost key map (arrows, Z/Enter = CROSS, …) is
+  mounted unconditionally. Mouse-on-model is the magic; keys are the daily
+  driver. Both funnel into one `buttons` word per tick — Law 3 is untouched.
+- **Picking is event-shaped.** A cursor ray against named-node AABBs (then a
+  triangle test for the hit node) runs only on mouse events, never per frame.
+  Buttons are rigid; node global transform × static local bounds is exact
+  enough.
+- **Click-through.** Clicks on fully transparent pixels should reach the
+  desktop behind. Mechanism: toggle the window's cursor hit-test off when the
+  cursor leaves the model silhouette (open question §9 on re-entry
+  detection). Dragging the body moves the window (`drag_window`).
+
+## 4. Power: two rates, one clock
+
+The determinism laws stay intact — and they are what make low power *cheap*
+to implement:
+
+- **The guest ticks at a fixed 60 Hz, always.** One guest turn per host tick
+  (Law 3); tapes, goldens, and replays hold inside the widget. An idle
+  QuickJS tick over a settled app is microseconds — the PSP does it at
+  333 MHz.
+- **GPU frames are demand-driven.** A frame renders only when something is
+  dirty: the `ui` core produced a different DrawList (cheap content hash per
+  tick — DrawLists are small), a pose/morph changed (button press), the
+  camera or window moved, or hover state changed. No dirt → no render pass,
+  no present; the compositor retains the last frame. A PSP showing a settled
+  menu costs **zero GPU frames**.
+- Native baked animations (the styles.bin timelines) run in the core, so
+  "app is animating" is a core-side fact, not a guess.
+- `max_fps` pacing (sleep, not spin) bounds the active case; macOS occlusion
+  events suspend rendering entirely while ticks continue, so the app stays
+  live behind other windows.
+- **Targets, measured not vibed** (pocket-character's methodology: ≥60 s
+  steady-state over the process tree): idle < 1% CPU and 0 GPU frames;
+  actively animating comparable to pocket-character's 3.9%; RSS in the same
+  ~100 MB class. The measurement harness is Bun TS in-repo, and the numbers
+  go in the README table next to the airi baselines.
+
+## 5. Screen fidelity
+
+A 480×272 texture sampled in perspective shimmers. Levers, in order:
+
+- **Render the surface at density 2** (960×544) — the Vita host already
+  proved the same logical layout renders at density 2 with density-2 paks;
+  the widget reuses that asset path. Density 1 stays available and is what
+  byte-exact goldens verify against.
+- Mipmaps + anisotropic filtering on the screen material; default framing
+  keeps the screen near-parallel to the view.
+- **Two framings**: "desk" (whole device, ambient) and "focus" (screen fills
+  the window, near-flat — effectively uihost with a bezel). Double-click the
+  screen or scroll to toggle; the camera animates between them. Focus mode is
+  how you actually *use* the app for minutes at a time.
+
+## 6. The shell asset convention
+
+The model is data, the contract is names:
+
+- glTF with node names `btn_*`, `dpad_*`, `trig_*`, `nub`, `screen`,
+  `led_power`, body meshes free-form. The `screen` material's base color is
+  replaced by the `EmbeddedUi` texture at load; `led_power` is an emissive
+  the host (or the `widget` surface) can tint.
+- The PSP shell is an **original model authored in Blender** — a
+  PSP-1000-silhouette handheld, not a ripped or scanned asset. Sony's trade
+  dress is a real concern for anything distributed; keep the shape "generic
+  handheld, obviously PSP-adjacent" and keep the asset fetch-at-setup like
+  pocket-character's VRM (never committed).
+- The convention is shell-agnostic on purpose: a Vita shell (960×544 screen,
+  density-2 native, front-touch as cursor) is the obvious second model, and
+  the platform-contracts work means the same guest bundle is already
+  admissible on both.
+
+## 7. The `widget` surface (v2, optional)
+
+v1 mounts only `ui` — an unmodified app must be the base case (RUNTIMES.md
+rule 5). For bundles that *want* to know they're in a widget, a tiny
+string-keyed surface in the `character`/`strike` style:
+
+- **events**: `hover(part|null)`, `pressed(parts)`, `framing(desk|focus)`,
+  `occluded(bool)`.
+- **ops**: `widget.led(rgb)` (notifications on the power LED),
+  `widget.focus(bool)`, `widget.quit()`.
+
+Kept to one page of spec, append-only, or it doesn't ship.
+
+## 8. Verification
+
+- **Screen path is byte-exact.** Same core, same DrawList, same golden specs
+  as every other `ui` host — the shared golden-specs suite runs against the
+  widget's offscreen surface at density 1. If a golden drifts here, the bug
+  is real.
+- **Picking is unit-tested**: synthetic camera + the real shell asset, known
+  cursor coords → expected part names, including near-miss and overlap cases.
+- **End-to-end is a tape**: scripted cursor clicks drive a known app through
+  a menu flow headlessly; the screen texture asserts byte-exact, the full 3D
+  composite asserts by RMSE (the gameblocks precedent). Alpha in the capture
+  is the real window transparency.
+- **Power is a gate, not a hope**: the measurement script fails if idle CPU
+  or GPU-frames-at-rest regress past thresholds.
+
+## 9. Delivery plan and open questions
+
+Upstream (this repo), in order:
+
+1. `feat(pocket3d)`: bind an external texture view onto a named material
+   (rebuild that primitive's bind group), plus node-name → transform/bounds
+   lookup for picking. Small, mechanical.
+2. `feat(pocket-widget)`: the crate — `WidgetShell`, `EmbeddedUi`, `PartMap`,
+   `PowerGovernor`, headless capture. RUNTIMES.md table row added.
+3. Milestone demo in-tree: uihost app on a flat quad in a widget window (no
+   PSP model yet) — proves the screen path and the governor before any asset
+   work.
+
+Product repo (`pocket-stack/pocket-handheld`): PSP shell asset + part map,
+framings, measurement harness, README with the numbers. pocket-character
+retrofit onto pocket-widget follows when convenient.
+
+Open questions:
+
+- **Click-through re-entry**: with the window's hit-test off, mouse-move
+  events stop; re-enabling needs either a low-rate (~10 Hz) cursor poll only
+  while in pass-through, or raw device events if winit delivers them
+  unfocused on macOS. Decide by experiment in milestone 3.
+- **Dirty detection source**: DrawList content hash per tick is the simple,
+  robust default; if the core's damage tracking (or the #118 stats counters)
+  already expose an equivalent signal, prefer that.
+- **Name**: `pocket-handheld` is a proposal; only "pocket-widget" (the
+  capability) is pinned.

--- a/WIDGET.md
+++ b/WIDGET.md
@@ -37,14 +37,13 @@ plumbing, not the full capability. **pocket-widget** is the missing middle: a
 
 | Piece | Role |
 | --- | --- |
-| `WidgetShell` | The window contract: transparent / undecorated / always-on-top / drag-to-move (all from #125), plus occlusion suspend, focus loss, cursor hit-test toggling for click-through, and headless offscreen capture of the whole composite (alpha = real window transparency). |
-| `EmbeddedUi` | A full PocketJS `ui` surface rendered off-window: `pocket-ui-wgpu` draws the core's DrawList into an `OffscreenTarget`, and the resulting texture view is bound as a named material on any `pocket3d` model. A screen inside a widget is a *real app*, not a video. |
-| `PartMap` | The interaction vocabulary: glTF node names → semantic parts (`btn_cross`, `dpad_up`, `nub`, `screen`, `led_power`). Cursor-ray picking against named nodes (event-driven, CPU, cold path), pressed parts → host input bits, drag on analog parts → analog axes. |
-| `PowerGovernor` | The idle contract, §4: fixed-rate guest ticks, demand-driven GPU frames. |
+| `shell` | The window contract and its event loop: transparent / undecorated / always-on-top (from #125) plus occlusion suspend, a per-press drag-to-move policy hook, and the governor of §4 — fixed-rate guest ticks, demand-driven GPU frames, with a frames-vs-ticks receipt logged on exit. |
+| `embed` | A full PocketJS `ui` surface rendered off-window: `pocket-ui-wgpu` draws the core's DrawList into an `OffscreenTarget` whose texture view binds onto any mesh (`ModelAsset::from_geometry_textured`). A screen inside a widget is a *real app*, not a video. The per-tick DrawList content hash is the dirty signal. |
+| `parts` + `pick` | The interaction vocabulary: named part shapes (`btn_cross`, `dpad_up`, `nub`, `screen`) → spec BTN bits, analog packing (raw extremes 255/1, never 0), the shared uihost keyboard map, and cursor-ray picking against oriented part bounds (event-driven, CPU, cold path). Procedural shells register each part as its own model instance; glTF node names remain the convention for authored shells. |
 
 What stays out of pocket-widget: any specific model, part map, or behavior —
-those are the product. (pocket-character retrofits onto `WidgetShell` +
-`PowerGovernor` naturally; that refactor is desirable but not a blocker.)
+those are the product. (pocket-character retrofits onto `shell` naturally;
+that refactor is desirable but not a blocker.)
 
 ## 2. The first runtime: pocket-handheld
 
@@ -64,10 +63,13 @@ real weight — is a **3D PSP model on the desktop that works**:
   The bundle that runs on a real PSP, in uihost, and on the Vita runs here,
   and cannot tell the difference. That is the whole demo.
 
-Proposed name: `pocket-handheld` (per the `pocket-<product>` convention;
-"handheld" rather than "psp" because the runtime is shell-agnostic — §6 — and
-to avoid colliding with the `pocketjs-psp` host library). Own repo under
-pocket-stack with the engine as a submodule, like pocket-character.
+Shipped first as the in-tree example `pocket3d/examples/handheld` — the
+runtime, the procedural shell, and the scripted verification live next to
+the mechanism they prove. The standalone product (`pocket-handheld` per the
+`pocket-<product>` convention; "handheld" rather than "psp" because the
+runtime is shell-agnostic — §6 — and to avoid colliding with the
+`pocketjs-psp` host library) extracts to its own pocket-stack repo when the
+shell asset grows beyond what procedural authoring carries.
 
 In RUNTIMES.md notation:
 
@@ -90,10 +92,11 @@ The bridge is deliberately dumb — a static table, no gameplay logic:
 
 - **Buttons.** `btn_cross/circle/square/triangle`, `dpad_up/down/left/right`,
   `btn_start/select`, `trig_l/r` map 1:1 to the spec BTN bits. Mouse-down on
-  a part sets the bit until mouse-up; multiple parts can be held (chords work,
-  the OSK needs them). Pressed parts get a procedural press: a small
-  translation along the button's local axis injected via `ModelInstance::pose`
-  (the #125 pose-injection split) — no baked animations required.
+  a part sets the bit until mouse-up; keyboard chords compose into the same
+  word (the OSK needs them). Pressed parts get a procedural press — a small
+  translation on the part's instance transform (parts are their own
+  instances; skinned authored shells would use the #125 pose-injection split
+  instead) — no baked animations required.
 - **Analog nub.** Drag within the nub's radius maps to the packed axes
   (`(x << 8) | y`, 0–255, 128 center); release springs back to center.
   Extremes are raw 255/1 — never 0 — matching the input-tape convention.
@@ -105,9 +108,11 @@ The bridge is deliberately dumb — a static table, no gameplay logic:
   Buttons are rigid; node global transform × static local bounds is exact
   enough.
 - **Click-through.** Clicks on fully transparent pixels should reach the
-  desktop behind. Mechanism: toggle the window's cursor hit-test off when the
-  cursor leaves the model silhouette (open question §9 on re-entry
-  detection). Dragging the body moves the window (`drag_window`).
+  desktop behind. v1 ships without it (the window hugs the model, so dead
+  margin is small); the candidate mechanism — toggle the window's cursor
+  hit-test off when the cursor leaves the model silhouette — hangs on the
+  re-entry question in §9. Dragging anything inert moves the window (the
+  shell's per-press `drag_at` policy).
 
 ## 4. Power: two rates, one clock
 
@@ -132,8 +137,11 @@ to implement:
 - **Targets, measured not vibed** (pocket-character's methodology: ≥60 s
   steady-state over the process tree): idle < 1% CPU and 0 GPU frames;
   actively animating comparable to pocket-character's 3.9%; RSS in the same
-  ~100 MB class. The measurement harness is Bun TS in-repo, and the numbers
-  go in the README table next to the airi baselines.
+  ~100 MB class. The steady-state harness lands with the product repo; the
+  shell already logs its receipt on every exit, and the first measurements
+  agree: over a 10 s run on an M3 Max, an app that settles rendered 103
+  frames across 601 ticks (all in the first seconds; ~0 after), the
+  perpetually-spinning hero demo 365, and RSS held at ~87 MB — one process.
 
 ## 5. Screen fidelity
 
@@ -141,8 +149,9 @@ A 480×272 texture sampled in perspective shimmers. Levers, in order:
 
 - **Render the surface at density 2** (960×544) — the Vita host already
   proved the same logical layout renders at density 2 with density-2 paks;
-  the widget reuses that asset path. Density 1 stays available and is what
-  byte-exact goldens verify against.
+  the widget can reuse that asset path. v1 renders density 1 (480×272, the
+  byte-exact golden flavor) and leans on the framing instead; density 2 is
+  the next fidelity lever.
 - Mipmaps + anisotropic filtering on the screen material; default framing
   keeps the screen near-parallel to the view.
 - **Two framings**: "desk" (whole device, ambient) and "focus" (screen fills
@@ -154,15 +163,17 @@ A 480×272 texture sampled in perspective shimmers. Levers, in order:
 
 The model is data, the contract is names:
 
-- glTF with node names `btn_*`, `dpad_*`, `trig_*`, `nub`, `screen`,
-  `led_power`, body meshes free-form. The `screen` material's base color is
-  replaced by the `EmbeddedUi` texture at load; `led_power` is an emissive
-  the host (or the `widget` surface) can tint.
-- The PSP shell is an **original model authored in Blender** — a
-  PSP-1000-silhouette handheld, not a ripped or scanned asset. Sony's trade
-  dress is a real concern for anything distributed; keep the shape "generic
-  handheld, obviously PSP-adjacent" and keep the asset fetch-at-setup like
-  pocket-character's VRM (never committed).
+- The v1 PSP shell is **authored procedurally in code** (a rounded-slab
+  body, cap and cylinder parts, ~180 lines) — original by construction, no
+  committed binary, no fetched asset, and every part is born with its
+  semantic name. Sony's trade dress is a real concern for anything
+  distributed; the shape stays "generic handheld, obviously PSP-adjacent".
+- Authored shells (Blender → glTF) use node names for the same contract:
+  `btn_*`, `dpad_*`, `trig_*`, `nub`, `screen`, `led_power`, body meshes
+  free-form. The `screen` material's base color is replaced by the
+  `EmbeddedUi` texture at load; `led_power` is an emissive the host (or the
+  `widget` surface) can tint. Authored assets are fetched at setup, never
+  committed — pocket-character's posture.
 - The convention is shell-agnostic on purpose: a Vita shell (960×544 screen,
   density-2 native, front-touch as cursor) is the obvious second model, and
   the platform-contracts work means the same guest bundle is already
@@ -183,44 +194,52 @@ Kept to one page of spec, append-only, or it doesn't ship.
 
 ## 8. Verification
 
-- **Screen path is byte-exact.** Same core, same DrawList, same golden specs
-  as every other `ui` host — the shared golden-specs suite runs against the
-  widget's offscreen surface at density 1. If a golden drifts here, the bug
-  is real.
-- **Picking is unit-tested**: synthetic camera + the real shell asset, known
-  cursor coords → expected part names, including near-miss and overlap cases.
-- **End-to-end is a tape**: scripted cursor clicks drive a known app through
-  a menu flow headlessly; the screen texture asserts byte-exact, the full 3D
-  composite asserts by RMSE (the gameblocks precedent). Alpha in the capture
-  is the real window transparency.
-- **Power is a gate, not a hope**: the measurement script fails if idle CPU
-  or GPU-frames-at-rest regress past thresholds.
+- **Screen path is byte-exact.** Same core, same DrawList renderer, same
+  paks as every other `ui` host; wiring the shared golden-specs suite
+  against the widget's offscreen surface at density 1 is the standing next
+  step. If a golden drifts here, the bug is real.
+- **Picking is unit-tested**: ray/OBB slab tests incl. rotation, ties, and
+  behind-origin cases; nearest-hit part resolution; the analog packing's
+  255/1-never-0 extremes.
+- **End-to-end is a script, today**: `--click x,y` presses a window pixel
+  through pick → part → BTN → guest; `--tap circle@30` sequences buttons.
+  The proof run drives the unmodified hero demo — D-pad tap to focus, two
+  CIRCLE taps — and the screen reads `Count: 2`. Captures are composite
+  PNGs whose alpha is the real window transparency.
+- **Power is a receipt, then a gate**: the shell logs ticks vs. frames
+  rendered on every exit; the product repo's measurement harness turns the
+  thresholds into a failing check.
 
 ## 9. Delivery plan and open questions
 
-Upstream (this repo), in order:
+Landed in this repo:
 
-1. `feat(pocket3d)`: bind an external texture view onto a named material
-   (rebuild that primitive's bind group), plus node-name → transform/bounds
-   lookup for picking. Small, mechanical.
-2. `feat(pocket-widget)`: the crate — `WidgetShell`, `EmbeddedUi`, `PartMap`,
-   `PowerGovernor`, headless capture. RUNTIMES.md table row added.
-3. Milestone demo in-tree: uihost app on a flat quad in a widget window (no
-   PSP model yet) — proves the screen path and the governor before any asset
-   work.
+1. `pocket3d`: `ModelAsset::from_geometry_textured` (external texture view
+   as a material), `Camera::screen_ray`, `Input::inject_cursor`, and
+   `pick_alpha_mode` made public for alternative shells.
+2. `pocket-ui-wgpu`: `UiRenderer::render_words` — render a DrawList the
+   host already built, so the per-tick dirty hash costs one tree walk, not
+   two.
+3. `pocket-widget`: the crate — `shell` (demand-render loop), `embed`,
+   `parts`, `pick` — with the RUNTIMES.md table row.
+4. `examples/handheld`: the full first runtime — procedural PSP shell,
+   mouse/keyboard input, desk/focus framings, headless scripting
+   (`--screenshot/--click/--tap/--hold/--focus/--auto-quit`).
 
-Product repo (`pocket-stack/pocket-handheld`): PSP shell asset + part map,
-framings, measurement harness, README with the numbers. pocket-character
-retrofit onto pocket-widget follows when convenient.
+Still ahead: the golden-specs wiring (§8), density-2 screens (§5), the
+`widget` surface (§7), click-through, and the extraction into
+`pocket-stack/pocket-handheld` with the steady-state measurement harness.
+pocket-character retrofits onto pocket-widget when convenient.
 
 Open questions:
 
 - **Click-through re-entry**: with the window's hit-test off, mouse-move
   events stop; re-enabling needs either a low-rate (~10 Hz) cursor poll only
   while in pass-through, or raw device events if winit delivers them
-  unfocused on macOS. Decide by experiment in milestone 3.
-- **Dirty detection source**: DrawList content hash per tick is the simple,
-  robust default; if the core's damage tracking (or the #118 stats counters)
-  already expose an equivalent signal, prefer that.
+  unfocused on macOS. Decide by experiment.
 - **Name**: `pocket-handheld` is a proposal; only "pocket-widget" (the
   capability) is pinned.
+
+Resolved: dirty detection is an FNV-1a hash of the DrawList words — texture
+generations ride along in the handles, so re-uploaded pixels change the
+hash too.

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "pocket": "bun scripts/pocket.ts",
     "build": "bun scripts/build.ts",
     "play": "bun scripts/play.ts",
+ "widget": "bun scripts/widget.ts",
     "psp": "bun scripts/psp.ts",
     "psp:all": "bun scripts/psp-all.ts",
     "psp:switch": "bun psplink",

--- a/pocket3d/Cargo.lock
+++ b/pocket3d/Cargo.lock
@@ -801,6 +801,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "handheld"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "env_logger",
+ "glam",
+ "log",
+ "pocket-mod",
+ "pocket-ui-wgpu",
+ "pocket-widget",
+ "pocket3d",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1601,6 +1617,20 @@ dependencies = [
  "pocket3d",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "pocket-widget"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "glam",
+ "log",
+ "pocket-ui-wgpu",
+ "pocket3d",
+ "pocketjs-core",
+ "wgpu",
+ "winit",
 ]
 
 [[package]]

--- a/pocket3d/Cargo.toml
+++ b/pocket3d/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "crates/pocket-mod",
     "crates/pocket-ui-wgpu",
     "crates/pocket-vrm",
+    "crates/pocket-widget",
+    "examples/handheld",
     "examples/uihost",
 ]
 # PSP-only crates (tier-3 target, cargo-psp toolchain) — kept out of the
@@ -25,6 +27,7 @@ pocket3d-bsp = { path = "crates/pocket3d-bsp" }
 pocket-mod = { path = "crates/pocket-mod" }
 pocket-ui-wgpu = { path = "crates/pocket-ui-wgpu" }
 pocket-vrm = { path = "crates/pocket-vrm" }
+pocket-widget = { path = "crates/pocket-widget" }
 pocketjs-core = { path = "../core", features = ["std"] }
 rquickjs = "0.12"
 

--- a/pocket3d/README.md
+++ b/pocket3d/README.md
@@ -75,6 +75,14 @@ are pickable parts that feed real BTN bits — the same unmodified bundle
 uihost runs, inside a handheld you can click.
 
 ```sh
+bun run widget                   # from the repo root: build bundle + binary, launch
+bun run widget im                # any demo
+bun run widget --proof           # headless acceptance (scripted taps → Count: 2)
+```
+
+Or by hand:
+
+```sh
 bun scripts/build.ts hero-main   # from the repo root
 cd pocket3d
 cargo run -p handheld -- --app hero-main

--- a/pocket3d/README.md
+++ b/pocket3d/README.md
@@ -33,10 +33,13 @@ pocket3d/
 │   │                      # entities, clipnode hull tracing (no GPU deps)
 │   ├── pocket-mod/        # guest hosting: one QuickJS realm, mounted surfaces,
 │   │                      # one guest turn per tick (the mod-runtime mechanism)
-│   └── pocket-ui-wgpu/    # the PocketJS `ui` surface on this base: pak feeding,
-│                          # HostOps for the guest, DrawList → wgpu, Blit compositor
+│   ├── pocket-ui-wgpu/    # the PocketJS `ui` surface on this base: pak feeding,
+│   │                      # HostOps for the guest, DrawList → wgpu, Blit compositor
+│   └── pocket-widget/     # desktop widgets as a capability: demand-render shell,
+│                          # embedded `ui` surfaces on meshes, part picking (WIDGET.md)
 └── examples/
-    └── uihost/            # PocketJS UI demos in a native macOS window
+    ├── uihost/            # PocketJS UI demos in a native macOS window
+    └── handheld/          # a borderless 3D PSP that runs Pocket apps (pocket-widget)
 ```
 
 Dependency shape: `pocket3d-bsp` knows nothing about rendering; `pocket3d`
@@ -62,6 +65,29 @@ cargo run -p uihost -- --app hero-main --screenshot out.png --frames 10
 
 Arrows = D-pad, Z/Enter = CROSS, X = CIRCLE, A/S = SQUARE/TRIANGLE,
 Q/W = triggers, Tab = SELECT, Space = START, Esc quits.
+
+## handheld — a 3D PSP on your desk
+
+The first pocket-widget runtime (WIDGET.md): a transparent, undecorated,
+always-on-top window framing a procedurally built PSP. Its screen is a live
+`ui` surface (an `OffscreenTarget` bound onto the screen mesh), its buttons
+are pickable parts that feed real BTN bits — the same unmodified bundle
+uihost runs, inside a handheld you can click.
+
+```sh
+bun scripts/build.ts hero-main   # from the repo root
+cd pocket3d
+cargo run -p handheld -- --app hero-main
+cargo run -p handheld -- --app hero-main --screenshot out.png --frames 30
+```
+
+Click caps to press them, drag the nub, double-click the screen to zoom
+into a screen-filling focus framing (`--focus` starts there), drag the body
+to move the window. The uihost key map works throughout. Headless scripting:
+`--click x,y` presses that window pixel mid-run, `--tap circle@30` holds a
+button for six ticks, `--hold circle` holds it for the whole run. The guest
+ticks at a fixed 60 Hz; GPU frames render only when something changed
+(watch the `pocket-widget: … frames rendered` line on exit).
 
 ## The substrate, briefly
 

--- a/pocket3d/crates/pocket-ui-wgpu/src/render.rs
+++ b/pocket3d/crates/pocket-ui-wgpu/src/render.rs
@@ -235,9 +235,27 @@ impl UiRenderer {
         target_px: (u32, u32),
         load: wgpu::LoadOp<wgpu::Color>,
     ) -> Result<()> {
-        self.sync_textures(gpu, ui);
         let words: Vec<u32> = ui.draw().words.clone();
-        self.build_batches(&words, target_px);
+        self.render_words(gpu, ui, &words, encoder, view, target_px, load)
+    }
+
+    /// Like [`render`](Self::render), but over a DrawList the host already
+    /// built with `ui.draw()`. Hosts that hash the DrawList per tick to skip
+    /// unchanged frames (pocket-widget's demand rendering) pass the words
+    /// they hashed instead of paying for a second tree walk.
+    #[allow(clippy::too_many_arguments)]
+    pub fn render_words(
+        &mut self,
+        gpu: &Gpu,
+        ui: &Ui,
+        words: &[u32],
+        encoder: &mut wgpu::CommandEncoder,
+        view: &wgpu::TextureView,
+        target_px: (u32, u32),
+        load: wgpu::LoadOp<wgpu::Color>,
+    ) -> Result<()> {
+        self.sync_textures(gpu, ui);
+        self.build_batches(words, target_px);
 
         // Upload vertices.
         let bytes: &[u8] = bytemuck::cast_slice(&self.verts);

--- a/pocket3d/crates/pocket-widget/Cargo.toml
+++ b/pocket3d/crates/pocket-widget/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pocket-widget"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Desktop widgets as a runtime-family capability: widget window shell with demand rendering, embedded `ui` surfaces on meshes, part picking, PSP input packing"
+
+[dependencies]
+pocket3d = { workspace = true }
+pocket-ui-wgpu = { workspace = true }
+pocketjs-core = { workspace = true }
+wgpu = { workspace = true }
+winit = { workspace = true }
+glam = { workspace = true, features = ["std"] }
+anyhow = { workspace = true }
+log = { workspace = true }

--- a/pocket3d/crates/pocket-widget/src/embed.rs
+++ b/pocket3d/crates/pocket-widget/src/embed.rs
@@ -1,0 +1,130 @@
+//! A PocketJS `ui` surface embedded in a 3D widget.
+//!
+//! The core renders off-window into an [`OffscreenTarget`] whose texture
+//! view binds onto any mesh via `ModelAsset::from_geometry_textured` — the
+//! screen inside a widget is a real app, not a video. The per-tick DrawList
+//! content hash doubles as the dirty signal: an app showing a settled frame
+//! re-renders nothing, which is the heart of the shell's demand rendering.
+
+use anyhow::Result;
+use pocket3d::gpu::{Gpu, OFFSCREEN_FORMAT, OffscreenTarget};
+use pocket_ui_wgpu::{UiRenderer, UiSurface};
+
+pub struct EmbeddedUi {
+    surface: UiSurface,
+    renderer: UiRenderer,
+    target: OffscreenTarget,
+    px: (u32, u32),
+    /// The DrawList words of the latest tick (what render draws).
+    words: Vec<u32>,
+    hash: u64,
+    /// The target holds a frame older than `words`.
+    texture_dirty: bool,
+}
+
+impl EmbeddedUi {
+    /// Wrap a booted surface (pak fed, mounted, bundle evaluated) with a
+    /// render target of `px` pixels. For 1:1 rendering `px` must equal the
+    /// surface's logical viewport — (480, 272) for stock PSP apps.
+    pub fn new(gpu: &Gpu, surface: UiSurface, px: (u32, u32)) -> EmbeddedUi {
+        EmbeddedUi {
+            surface,
+            renderer: UiRenderer::new(gpu, OFFSCREEN_FORMAT),
+            target: OffscreenTarget::new(gpu, px.0, px.1),
+            px,
+            words: Vec::new(),
+            hash: 0,
+            texture_dirty: true,
+        }
+    }
+
+    /// Advance the core one frame — call once per host tick, after the
+    /// guest turn. Returns true when the DrawList changed, i.e. the widget
+    /// needs a GPU frame to show it.
+    pub fn tick(&mut self) -> bool {
+        self.surface.tick();
+        let (hash, words) = self.surface.with_ui(|ui| {
+            let words = &ui.draw().words;
+            let hash = fnv1a64(words);
+            (hash, (hash != self.hash).then(|| words.clone()))
+        });
+        let Some(words) = words else { return false };
+        self.words = words;
+        self.hash = hash;
+        self.texture_dirty = true;
+        true
+    }
+
+    /// Render the latest DrawList into the target if it changed since the
+    /// last render (self-submitting; call before the scene pass that samples
+    /// the texture). Returns whether a pass was recorded.
+    pub fn render_if_dirty(&mut self, gpu: &Gpu) -> Result<bool> {
+        if !self.texture_dirty {
+            return Ok(false);
+        }
+        let mut encoder = gpu.device.create_command_encoder(&Default::default());
+        self.surface.with_ui(|ui| {
+            self.renderer.render_words(
+                gpu,
+                ui,
+                &self.words,
+                &mut encoder,
+                &self.target.view,
+                self.px,
+                wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+            )
+        })?;
+        gpu.queue.submit([encoder.finish()]);
+        self.texture_dirty = false;
+        Ok(true)
+    }
+
+    /// The texture view a screen mesh's material binds.
+    pub fn view(&self) -> &wgpu::TextureView {
+        &self.target.view
+    }
+
+    /// The render target (headless capture: `read_rgba` / `save_png`).
+    pub fn target(&self) -> &OffscreenTarget {
+        &self.target
+    }
+
+    pub fn surface(&self) -> &UiSurface {
+        &self.surface
+    }
+
+    pub fn size(&self) -> (u32, u32) {
+        self.px
+    }
+}
+
+/// FNV-1a 64 over the DrawList words. Texture contents are covered too:
+/// handles in the words are generation-tagged, so re-uploaded pixels change
+/// the handle and therefore the hash.
+fn fnv1a64(words: &[u32]) -> u64 {
+    let mut h: u64 = 0xcbf2_9ce4_8422_2325;
+    for w in words {
+        for b in w.to_le_bytes() {
+            h ^= b as u64;
+            h = h.wrapping_mul(0x0000_0100_0000_01b3);
+        }
+    }
+    h
+}
+
+#[cfg(test)]
+mod tests {
+    use super::fnv1a64;
+
+    #[test]
+    fn hash_distinguishes_word_streams() {
+        assert_ne!(fnv1a64(&[1, 2, 3]), fnv1a64(&[1, 2, 4]));
+        assert_ne!(fnv1a64(&[]), fnv1a64(&[0]));
+        assert_eq!(fnv1a64(&[7, 7]), fnv1a64(&[7, 7]));
+    }
+
+    #[test]
+    fn hash_is_order_sensitive() {
+        assert_ne!(fnv1a64(&[1, 2]), fnv1a64(&[2, 1]));
+    }
+}

--- a/pocket3d/crates/pocket-widget/src/lib.rs
+++ b/pocket3d/crates/pocket-widget/src/lib.rs
@@ -1,0 +1,33 @@
+//! pocket-widget — desktop widgets as a runtime-family capability.
+//!
+//! The mechanism layer named in WIDGET.md: what pocket-character proved
+//! (a transparent, undecorated, always-on-top window that costs almost
+//! nothing at rest), generalized so any Pocket runtime can take the desktop
+//! widget form. Four pieces:
+//!
+//!   - [`shell`] — the widget window contract and its event loop. The guest
+//!     ticks at a fixed rate, always (Law 3: one guest turn per host tick);
+//!     GPU frames are demand-driven — no dirt, no render pass, no present.
+//!     An idle widget burns ticks (microseconds), not frames.
+//!   - [`embed`] — a full PocketJS `ui` surface rendered off-window into an
+//!     offscreen target whose texture view binds onto any pocket3d mesh
+//!     (`ModelAsset::from_geometry_textured`). The screen inside a widget is
+//!     a real app, not a video. The per-tick DrawList hash is the dirty
+//!     signal the shell's demand rendering keys off.
+//!   - [`pick`] — cursor-ray picking against oriented boxes, event-shaped
+//!     (runs on mouse events, never per frame).
+//!   - [`parts`] — the interaction vocabulary: named part shapes mapped to
+//!     spec BTN bits, analog packing (raw extremes 255/1, never 0), and the
+//!     shared uihost keyboard map.
+//!
+//! What stays out: any specific model, part layout, or behavior — those are
+//! the product (see `examples/handheld` for the first one).
+
+pub mod embed;
+pub mod parts;
+pub mod pick;
+pub mod shell;
+
+pub use embed::EmbeddedUi;
+pub use parts::{PartMap, PartShape, analog_pack, key_button};
+pub use shell::{WidgetConfig, WidgetGame, run};

--- a/pocket3d/crates/pocket-widget/src/parts.rs
+++ b/pocket3d/crates/pocket-widget/src/parts.rs
@@ -1,0 +1,165 @@
+//! The interaction vocabulary: named part shapes → PSP input.
+//!
+//! A part is a pickable region of the widget's model (a button cap, the
+//! analog nub, the screen) with the BTN bits it holds down while pressed.
+//! The map is deliberately dumb — a static table, no gameplay logic — so
+//! that what a click does is auditable at a glance.
+
+use glam::{Mat4, Vec3};
+use winit::keyboard::KeyCode;
+
+use crate::pick::ray_obb;
+
+/// The spec BTN bits (spec/spec.ts) — the PSP pad register layout every
+/// `frame(buttons, analog)` guest sees, identical across hardware and hosts.
+pub mod btn {
+    pub const SELECT: u32 = 0x0001;
+    pub const START: u32 = 0x0008;
+    pub const UP: u32 = 0x0010;
+    pub const RIGHT: u32 = 0x0020;
+    pub const DOWN: u32 = 0x0040;
+    pub const LEFT: u32 = 0x0080;
+    pub const LTRIGGER: u32 = 0x0100;
+    pub const RTRIGGER: u32 = 0x0200;
+    pub const TRIANGLE: u32 = 0x1000;
+    pub const CIRCLE: u32 = 0x2000;
+    pub const CROSS: u32 = 0x4000;
+    pub const SQUARE: u32 = 0x8000;
+}
+
+/// One pickable part: a local AABB placed by a world transform.
+pub struct PartShape {
+    /// Semantic name (`btn_cross`, `dpad_up`, `nub`, `screen`, `body`, …).
+    pub name: String,
+    /// BTN bits held while this part is pressed (0 for non-button parts).
+    pub buttons: u32,
+    pub transform: Mat4,
+    pub aabb: (Vec3, Vec3),
+}
+
+/// All pickable parts of a widget. Picking returns the nearest hit along
+/// the ray, so overlapping parts (a button proud of the body) resolve to
+/// what the user visually clicked.
+#[derive(Default)]
+pub struct PartMap {
+    parts: Vec<PartShape>,
+}
+
+impl PartMap {
+    /// Register a part; returns its index (stable — parts are never removed).
+    pub fn push(&mut self, part: PartShape) -> usize {
+        self.parts.push(part);
+        self.parts.len() - 1
+    }
+
+    /// Nearest part hit by the ray, as (index, t).
+    pub fn pick(&self, origin: Vec3, dir: Vec3) -> Option<(usize, f32)> {
+        let mut best: Option<(usize, f32)> = None;
+        for (i, p) in self.parts.iter().enumerate() {
+            if let Some(t) = ray_obb(origin, dir, &p.transform, p.aabb)
+                && best.is_none_or(|(_, bt)| t < bt)
+            {
+                best = Some((i, t));
+            }
+        }
+        best
+    }
+
+    pub fn get(&self, index: usize) -> Option<&PartShape> {
+        self.parts.get(index)
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &PartShape> {
+        self.parts.iter()
+    }
+
+    pub fn len(&self) -> usize {
+        self.parts.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.parts.is_empty()
+    }
+}
+
+/// Pack analog axes into the spec `frame(buttons, analog)` word:
+/// `((128 + x·127) << 8) | (128 + y·127)`, inputs in −1..1 (x right,
+/// y down — the PSP nub convention). Extremes land on raw 255/1, never 0,
+/// matching the input-tape convention hardware pads produce.
+pub fn analog_pack(x: f32, y: f32) -> u32 {
+    let axis = |v: f32| (128 + (v.clamp(-1.0, 1.0) * 127.0).round() as i32) as u32;
+    (axis(x) << 8) | axis(y)
+}
+
+/// The shared keyboard map (uihost's): arrows = D-pad, Z/Enter = CROSS,
+/// X/Backspace = CIRCLE, A = SQUARE, S = TRIANGLE, Q/W = L/R triggers,
+/// Tab = SELECT, Space = START. Mouse-on-model is the magic; keys are the
+/// daily driver — widgets mount both.
+pub fn key_button(code: KeyCode) -> Option<u32> {
+    Some(match code {
+        KeyCode::ArrowUp => btn::UP,
+        KeyCode::ArrowDown => btn::DOWN,
+        KeyCode::ArrowLeft => btn::LEFT,
+        KeyCode::ArrowRight => btn::RIGHT,
+        KeyCode::KeyZ | KeyCode::Enter => btn::CROSS,
+        KeyCode::KeyX | KeyCode::Backspace => btn::CIRCLE,
+        KeyCode::KeyA => btn::SQUARE,
+        KeyCode::KeyS => btn::TRIANGLE,
+        KeyCode::KeyQ => btn::LTRIGGER,
+        KeyCode::KeyW => btn::RTRIGGER,
+        KeyCode::Tab => btn::SELECT,
+        KeyCode::Space => btn::START,
+        _ => return None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn analog_center_matches_spec() {
+        assert_eq!(analog_pack(0.0, 0.0), pocketjs_core::spec::ANALOG_CENTER);
+    }
+
+    #[test]
+    fn analog_extremes_are_255_and_1_never_0() {
+        assert_eq!(analog_pack(1.0, 1.0), (255 << 8) | 255);
+        assert_eq!(analog_pack(-1.0, -1.0), (1 << 8) | 1);
+        // Out-of-range input clamps instead of wrapping through 0.
+        assert_eq!(analog_pack(-2.0, 2.0), (1 << 8) | 255);
+    }
+
+    #[test]
+    fn pick_prefers_nearest_part() {
+        let mut map = PartMap::default();
+        let unit = (Vec3::splat(-1.0), Vec3::splat(1.0));
+        map.push(PartShape {
+            name: "far".into(),
+            buttons: btn::CIRCLE,
+            transform: Mat4::from_translation(Vec3::new(0.0, 0.0, -10.0)),
+            aabb: unit,
+        });
+        let near = map.push(PartShape {
+            name: "near".into(),
+            buttons: btn::CROSS,
+            transform: Mat4::IDENTITY,
+            aabb: unit,
+        });
+        let (idx, _) = map.pick(Vec3::new(0.0, 0.0, 5.0), Vec3::NEG_Z).unwrap();
+        assert_eq!(idx, near);
+        assert_eq!(map.get(idx).unwrap().buttons, btn::CROSS);
+    }
+
+    #[test]
+    fn pick_misses_cleanly() {
+        let mut map = PartMap::default();
+        map.push(PartShape {
+            name: "box".into(),
+            buttons: 0,
+            transform: Mat4::IDENTITY,
+            aabb: (Vec3::splat(-1.0), Vec3::splat(1.0)),
+        });
+        assert!(map.pick(Vec3::new(5.0, 5.0, 5.0), Vec3::NEG_Z).is_none());
+    }
+}

--- a/pocket3d/crates/pocket-widget/src/pick.rs
+++ b/pocket3d/crates/pocket-widget/src/pick.rs
@@ -1,0 +1,85 @@
+//! Cursor-ray picking against oriented boxes.
+//!
+//! Widgets pick on mouse events, never per frame — a handful of slab tests
+//! against part bounds is a cold path. Rays come from
+//! [`pocket3d::camera::Camera::screen_ray`]; boxes are a part's local AABB
+//! under its instance transform.
+
+use glam::{Mat4, Vec3};
+
+/// Ray / oriented-box intersection. `aabb` is the box in local space,
+/// `transform` places it in the world. Returns the ray parameter `t` of the
+/// nearest hit at or in front of the origin (`t` is preserved by the
+/// local-space transform, so callers compare `t` across boxes directly).
+pub fn ray_obb(origin: Vec3, dir: Vec3, transform: &Mat4, aabb: (Vec3, Vec3)) -> Option<f32> {
+    let inv = transform.inverse();
+    let o = inv.transform_point3(origin);
+    let d = inv.transform_vector3(dir);
+
+    let mut tmin = 0.0f32;
+    let mut tmax = f32::MAX;
+    for axis in 0..3 {
+        let (o, d) = (o[axis], d[axis]);
+        let (lo, hi) = (aabb.0[axis], aabb.1[axis]);
+        if d.abs() < 1e-8 {
+            if o < lo || o > hi {
+                return None;
+            }
+            continue;
+        }
+        let (t0, t1) = ((lo - o) / d, (hi - o) / d);
+        tmin = tmin.max(t0.min(t1));
+        tmax = tmax.min(t0.max(t1));
+        if tmax < tmin {
+            return None;
+        }
+    }
+    Some(tmin)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::FRAC_PI_4;
+
+    const BOX: (Vec3, Vec3) = (Vec3::new(-1.0, -1.0, -1.0), Vec3::new(1.0, 1.0, 1.0));
+
+    #[test]
+    fn hits_axis_aligned_box() {
+        let t = ray_obb(Vec3::new(0.0, 0.0, 5.0), Vec3::NEG_Z, &Mat4::IDENTITY, BOX);
+        assert!((t.unwrap() - 4.0).abs() < 1e-4);
+    }
+
+    #[test]
+    fn misses_beside_box() {
+        assert!(ray_obb(Vec3::new(3.0, 0.0, 5.0), Vec3::NEG_Z, &Mat4::IDENTITY, BOX).is_none());
+    }
+
+    #[test]
+    fn misses_box_behind_origin() {
+        assert!(ray_obb(Vec3::new(0.0, 0.0, 5.0), Vec3::Z, &Mat4::IDENTITY, BOX).is_none());
+    }
+
+    #[test]
+    fn origin_inside_box_hits_at_zero() {
+        let t = ray_obb(Vec3::ZERO, Vec3::NEG_Z, &Mat4::IDENTITY, BOX);
+        assert_eq!(t, Some(0.0));
+    }
+
+    #[test]
+    fn t_is_world_scale_under_rotation_and_translation() {
+        // Box rotated 45° around Y and pushed to x=10: a ray down -X from
+        // (20, 0, 0) hits the corner-on silhouette at 10 - sqrt(2).
+        let m = Mat4::from_translation(Vec3::new(10.0, 0.0, 0.0))
+            * Mat4::from_rotation_y(FRAC_PI_4);
+        let t = ray_obb(Vec3::new(20.0, 0.0, 0.0), Vec3::NEG_X, &m, BOX).unwrap();
+        assert!((t - (10.0 - 2.0f32.sqrt())).abs() < 1e-3, "t = {t}");
+    }
+
+    #[test]
+    fn parallel_ray_outside_slab_misses() {
+        assert!(
+            ray_obb(Vec3::new(0.0, 2.0, 5.0), Vec3::NEG_Z, &Mat4::IDENTITY, BOX).is_none()
+        );
+    }
+}

--- a/pocket3d/crates/pocket-widget/src/shell.rs
+++ b/pocket3d/crates/pocket-widget/src/shell.rs
@@ -1,0 +1,346 @@
+//! The widget window shell: two rates, one clock.
+//!
+//! The guest ticks at a fixed rate, always — one guest turn per host tick
+//! (Law 3), so tapes, goldens and replays hold inside a widget. GPU frames
+//! are demand-driven: a frame renders only when the game reports dirt (the
+//! embedded UI changed, a part moved, the camera eased). No dirt → no render
+//! pass, no present — the compositor retains the last frame and an idle
+//! widget costs ticks (microseconds), not frames. macOS occlusion suspends
+//! rendering entirely while ticks keep the app live behind other windows.
+//!
+//! This is a sibling of [`pocket3d::app::run`], not a wrapper: that loop
+//! ties simulation to redraws (right for games rendering every frame),
+//! while a widget must tick without rendering.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use anyhow::Result;
+use glam::Vec2;
+use winit::application::ApplicationHandler;
+use winit::event::{ElementState, MouseButton, WindowEvent};
+use winit::event_loop::{ActiveEventLoop, ControlFlow, EventLoop};
+use winit::window::{Window, WindowId, WindowLevel};
+
+use pocket3d::app::pick_alpha_mode;
+use pocket3d::camera::Camera;
+use pocket3d::gpu::Gpu;
+use pocket3d::hud::Hud;
+use pocket3d::input::Input;
+use pocket3d::renderer::Renderer;
+use pocket3d::scene::Scene;
+
+pub struct WidgetConfig {
+    pub title: String,
+    /// Window size in logical px — fixed; widgets don't resize.
+    pub size: (u32, u32),
+    /// Fixed simulation rate — the guest cadence (60 = the PSP's).
+    pub tick_hz: f32,
+    /// Render cap for the active case (eases, drags). The loop sleeps
+    /// between frames; dirt reported while pacing is latched, never lost.
+    pub max_fps: f32,
+    pub transparent: bool,
+    pub decorations: bool,
+    pub always_on_top: bool,
+}
+
+impl Default for WidgetConfig {
+    fn default() -> Self {
+        Self {
+            title: "Pocket Widget".into(),
+            size: (480, 260),
+            tick_hz: 60.0,
+            max_fps: 60.0,
+            transparent: true,
+            decorations: false,
+            always_on_top: true,
+        }
+    }
+}
+
+/// What the widget loop needs from a product.
+pub trait WidgetGame {
+    /// Called once after the GPU exists — build assets, boot guests.
+    fn init(&mut self, gpu: &Gpu, renderer: &mut Renderer) -> Result<()>;
+    /// One fixed-step tick: the guest turn (`frame(buttons, analog)`), the
+    /// embedded UI tick, interaction state. Runs whether or not a frame
+    /// will render. `window_px` is the surface size in physical pixels —
+    /// the space cursor positions live in, for picking. Mark dirt
+    /// internally; the shell collects it via [`take_dirty`](Self::take_dirty).
+    fn tick(&mut self, dt: f32, input: &Input, window_px: (u32, u32)) -> Result<()>;
+    /// Consume the "needs a GPU frame" flag. Latched by the shell until a
+    /// frame actually renders, so fps pacing never drops dirt.
+    fn take_dirty(&mut self) -> bool;
+    /// Record offscreen work that must land before the scene pass samples
+    /// it (the embedded UI render). Called only on frames that render.
+    fn prepare(&mut self, gpu: &Gpu) -> Result<()>;
+    /// Provide the frame to draw. `time` is seconds since launch.
+    fn compose(&mut self, time: f32, size: (u32, u32)) -> (&Scene, &Camera, &Hud);
+    /// Left-press policy: return true to start an OS window drag at this
+    /// cursor position (widget-style move) instead of interacting.
+    fn drag_at(&mut self, cursor: Vec2) -> bool {
+        let _ = cursor;
+        false
+    }
+    fn wants_exit(&self) -> bool {
+        false
+    }
+}
+
+pub fn run(config: WidgetConfig, game: impl WidgetGame) -> Result<()> {
+    let event_loop = EventLoop::new()?;
+    let mut app = WidgetApp {
+        config,
+        game,
+        state: None,
+        error: None,
+        ticks: 0,
+        frames: 0,
+    };
+    event_loop.run_app(&mut app)?;
+    // The governor's receipt: how many fixed ticks ran vs. GPU frames
+    // actually rendered. A settled widget should show frames ≪ ticks.
+    log::info!(
+        "pocket-widget: {} ticks, {} frames rendered ({:.1}%)",
+        app.ticks,
+        app.frames,
+        100.0 * app.frames as f64 / app.ticks.max(1) as f64
+    );
+    match app.error {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
+/// Catch-up bound: after an app-nap the loop resyncs instead of replaying
+/// the gap (a widget needs liveness, not history).
+const MAX_CATCHUP_TICKS: u32 = 6;
+
+struct WindowState {
+    window: Arc<Window>,
+    surface: wgpu::Surface<'static>,
+    surface_config: wgpu::SurfaceConfiguration,
+    gpu: Gpu,
+    renderer: Renderer,
+    input: Input,
+    start: Instant,
+    next_tick: Instant,
+    last_render: Instant,
+    /// Dirt latched from the game, waiting for a paced render.
+    render_pending: bool,
+    occluded: bool,
+}
+
+struct WidgetApp<G: WidgetGame> {
+    config: WidgetConfig,
+    game: G,
+    state: Option<WindowState>,
+    error: Option<anyhow::Error>,
+    ticks: u64,
+    frames: u64,
+}
+
+impl<G: WidgetGame> WidgetApp<G> {
+    fn init_state(&mut self, event_loop: &ActiveEventLoop) -> Result<WindowState> {
+        let attrs = Window::default_attributes()
+            .with_title(self.config.title.clone())
+            .with_inner_size(winit::dpi::LogicalSize::new(
+                self.config.size.0,
+                self.config.size.1,
+            ))
+            .with_transparent(self.config.transparent)
+            .with_decorations(self.config.decorations)
+            .with_resizable(false)
+            .with_window_level(if self.config.always_on_top {
+                WindowLevel::AlwaysOnTop
+            } else {
+                WindowLevel::Normal
+            });
+        let window = Arc::new(event_loop.create_window(attrs)?);
+        let instance = Gpu::new_instance();
+        let surface = instance.create_surface(window.clone())?;
+        let gpu = Gpu::from_instance_for_surface(instance, &surface)?;
+
+        let px = window.inner_size();
+        let mut surface_config = surface
+            .get_default_config(&gpu.adapter, px.width.max(1), px.height.max(1))
+            .ok_or_else(|| anyhow::anyhow!("surface not supported by adapter"))?;
+        surface_config.present_mode = wgpu::PresentMode::AutoVsync;
+        if self.config.transparent {
+            surface_config.alpha_mode = pick_alpha_mode(&surface, &gpu.adapter)?;
+        }
+        surface.configure(&gpu.device, &surface_config);
+
+        let mut renderer = Renderer::new(&gpu, surface_config.format)?;
+        self.game.init(&gpu, &mut renderer)?;
+
+        let now = Instant::now();
+        Ok(WindowState {
+            window,
+            surface,
+            surface_config,
+            gpu,
+            renderer,
+            input: Input::default(),
+            start: now,
+            next_tick: now,
+            last_render: now - Duration::from_secs(1),
+            render_pending: true, // first frame
+            occluded: false,
+        })
+    }
+
+    /// The governor: run due fixed ticks, collect dirt, schedule the next
+    /// wake at whichever comes first — the next tick or a due render.
+    fn pump(&mut self, event_loop: &ActiveEventLoop) {
+        let Some(state) = self.state.as_mut() else {
+            return;
+        };
+        let tick_dt = 1.0 / self.config.tick_hz.max(1.0);
+        let tick_interval = Duration::from_secs_f32(tick_dt);
+        let now = Instant::now();
+
+        let window_px = (state.surface_config.width, state.surface_config.height);
+        let mut ran = 0u32;
+        while now >= state.next_tick && ran < MAX_CATCHUP_TICKS {
+            if let Err(e) = self.game.tick(tick_dt, &state.input, window_px) {
+                self.error = Some(e);
+                event_loop.exit();
+                return;
+            }
+            state.next_tick += tick_interval;
+            ran += 1;
+        }
+        self.ticks += ran as u64;
+        if ran == MAX_CATCHUP_TICKS && now >= state.next_tick {
+            state.next_tick = now + tick_interval;
+        }
+        if ran > 0 {
+            state.input.end_frame();
+        }
+
+        if self.game.wants_exit() {
+            event_loop.exit();
+            return;
+        }
+
+        if self.game.take_dirty() {
+            state.render_pending = true;
+        }
+
+        let frame_interval = Duration::from_secs_f32(1.0 / self.config.max_fps.max(1.0));
+        let mut wake = state.next_tick;
+        if state.render_pending && !state.occluded {
+            let due = state.last_render + frame_interval;
+            if now >= due {
+                state.window.request_redraw();
+            } else {
+                wake = wake.min(due);
+            }
+        }
+        event_loop.set_control_flow(ControlFlow::WaitUntil(wake));
+    }
+
+    fn redraw(&mut self) -> Result<()> {
+        let Some(state) = self.state.as_mut() else {
+            return Ok(());
+        };
+        self.game.prepare(&state.gpu)?;
+
+        let frame = match state.surface.get_current_texture() {
+            Ok(f) => f,
+            Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                state
+                    .surface
+                    .configure(&state.gpu.device, &state.surface_config);
+                return Ok(()); // render_pending stays latched; next wake retries
+            }
+            Err(e) => return Err(anyhow::anyhow!("surface error: {e}")),
+        };
+        let view = frame
+            .texture
+            .create_view(&wgpu::TextureViewDescriptor::default());
+        let size = (state.surface_config.width, state.surface_config.height);
+        let (scene, camera, hud) =
+            self.game
+                .compose(state.start.elapsed().as_secs_f32(), size);
+        state
+            .renderer
+            .render(&state.gpu, &view, size, scene, camera, hud);
+        state.window.pre_present_notify();
+        frame.present();
+
+        state.render_pending = false;
+        state.last_render = Instant::now();
+        self.frames += 1;
+        Ok(())
+    }
+}
+
+impl<G: WidgetGame> ApplicationHandler for WidgetApp<G> {
+    fn resumed(&mut self, event_loop: &ActiveEventLoop) {
+        if self.state.is_none() {
+            match self.init_state(event_loop) {
+                Ok(s) => self.state = Some(s),
+                Err(e) => {
+                    self.error = Some(e);
+                    event_loop.exit();
+                }
+            }
+        }
+    }
+
+    fn window_event(
+        &mut self,
+        event_loop: &ActiveEventLoop,
+        _window_id: WindowId,
+        event: WindowEvent,
+    ) {
+        let Some(state) = self.state.as_mut() else {
+            return;
+        };
+        state.input.on_window_event(&event);
+        match event {
+            WindowEvent::CloseRequested => event_loop.exit(),
+            WindowEvent::Resized(size) => {
+                state.surface_config.width = size.width.max(1);
+                state.surface_config.height = size.height.max(1);
+                state
+                    .surface
+                    .configure(&state.gpu.device, &state.surface_config);
+                state.render_pending = true;
+            }
+            WindowEvent::Occluded(occluded) => {
+                state.occluded = occluded;
+                if !occluded {
+                    state.render_pending = true; // repaint on reveal
+                }
+            }
+            WindowEvent::MouseInput {
+                state: elem_state,
+                button: MouseButton::Left,
+                ..
+            } if elem_state == ElementState::Pressed => {
+                if let Some(cursor) = state.input.cursor()
+                    && self.game.drag_at(cursor)
+                {
+                    let _ = state.window.drag_window();
+                    // macOS swallows the release once the OS drag session
+                    // starts; clear the button so the next press edges.
+                    state.input.inject_mouse_button(MouseButton::Left, false);
+                }
+            }
+            WindowEvent::RedrawRequested => {
+                if let Err(e) = self.redraw() {
+                    self.error = Some(e);
+                    event_loop.exit();
+                }
+            }
+            _ => {}
+        }
+    }
+
+    fn about_to_wait(&mut self, event_loop: &ActiveEventLoop) {
+        self.pump(event_loop);
+    }
+}

--- a/pocket3d/crates/pocket3d/src/app.rs
+++ b/pocket3d/crates/pocket3d/src/app.rs
@@ -237,8 +237,10 @@ impl<G: Game> WinitApp<G> {
 
 /// The scene pass writes premultiplied-style output (opaque pixels carry
 /// their own alpha, transparent clear is all-zero), so prefer PreMultiplied
-/// and fall back to PostMultiplied — at alpha 0 and 1 they agree.
-fn pick_alpha_mode(
+/// and fall back to PostMultiplied — at alpha 0 and 1 they agree. Public so
+/// alternative shells (pocket-widget) configure transparent surfaces the
+/// same way.
+pub fn pick_alpha_mode(
     surface: &wgpu::Surface<'_>,
     adapter: &wgpu::Adapter,
 ) -> Result<wgpu::CompositeAlphaMode> {

--- a/pocket3d/crates/pocket3d/src/camera.rs
+++ b/pocket3d/crates/pocket3d/src/camera.rs
@@ -65,4 +65,20 @@ impl Camera {
         self.yaw = (-d.x).atan2(-d.z);
         self.pitch = d.y.atan2(flat);
     }
+
+    /// World-space ray through a window pixel (origin, normalized direction).
+    /// `cursor` is in pixels from the top-left, `viewport` the target size in
+    /// the same units — cursor picking for widgets and editors.
+    pub fn screen_ray(&self, cursor: glam::Vec2, viewport: (f32, f32)) -> (Vec3, Vec3) {
+        let aspect = viewport.0 / viewport.1.max(1.0);
+        let inv = self.view_proj(aspect).inverse();
+        let ndc = glam::Vec2::new(
+            cursor.x / viewport.0 * 2.0 - 1.0,
+            1.0 - cursor.y / viewport.1 * 2.0,
+        );
+        // wgpu clip depth is 0..1; unproject the near and far plane points.
+        let near = inv.project_point3(Vec3::new(ndc.x, ndc.y, 0.0));
+        let far = inv.project_point3(Vec3::new(ndc.x, ndc.y, 1.0));
+        (near, (far - near).normalize_or_zero())
+    }
 }

--- a/pocket3d/crates/pocket3d/src/input.rs
+++ b/pocket3d/crates/pocket3d/src/input.rs
@@ -137,4 +137,9 @@ impl Input {
     pub fn inject_mouse_delta(&mut self, dx: f32, dy: f32) {
         self.mouse_delta += Vec2::new(dx, dy);
     }
+
+    /// Place the cursor at a window-pixel position (scripted picking).
+    pub fn inject_cursor(&mut self, x: f32, y: f32) {
+        self.cursor = Some(Vec2::new(x, y));
+    }
 }

--- a/pocket3d/crates/pocket3d/src/model.rs
+++ b/pocket3d/crates/pocket3d/src/model.rs
@@ -353,6 +353,77 @@ impl ModelAsset {
         })
     }
 
+    /// Build an asset from raw geometry whose material samples an external
+    /// texture view (an [`crate::gpu::OffscreenTarget`], a video frame, …).
+    /// The bind group keeps the underlying texture alive; render into it
+    /// each frame and every instance of this asset shows the update — this
+    /// is how a live 2D surface lands on a 3D mesh (pocket-widget screens).
+    pub fn from_geometry_textured(
+        gpu: &Gpu,
+        layout: &wgpu::BindGroupLayout,
+        label: &str,
+        vertices: &[ModelVertex],
+        indices: &[u32],
+        view: &wgpu::TextureView,
+        sampler: &wgpu::Sampler,
+    ) -> Arc<Self> {
+        use wgpu::util::DeviceExt;
+        let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some(label),
+            layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(sampler),
+                },
+            ],
+        });
+        let vbuf = gpu
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some(label),
+                contents: bytemuck::cast_slice(vertices),
+                usage: wgpu::BufferUsages::VERTEX,
+            });
+        let ibuf = gpu
+            .device
+            .create_buffer_init(&wgpu::util::BufferInitDescriptor {
+                label: Some(label),
+                contents: bytemuck::cast_slice(indices),
+                usage: wgpu::BufferUsages::INDEX,
+            });
+        let mut aabb = (Vec3::splat(f32::MAX), Vec3::splat(f32::MIN));
+        for v in vertices {
+            let p = Vec3::from(v.pos);
+            aabb.0 = aabb.0.min(p);
+            aabb.1 = aabb.1.max(p);
+        }
+        Arc::new(Self {
+            vbuf,
+            ibuf,
+            primitives: vec![Primitive {
+                first_index: 0,
+                index_count: indices.len() as u32,
+                bind_group,
+            }],
+            skeleton: Skeleton {
+                parents: Vec::new(),
+                rest: Vec::new(),
+                order: Vec::new(),
+            },
+            skins: Vec::new(),
+            clips: Vec::new(),
+            morph_meshes: Vec::new(),
+            prim_morph: vec![None],
+            aabb,
+            textures: Vec::new(),
+        })
+    }
+
     pub fn load_glb(
         gpu: &Gpu,
         layout: &wgpu::BindGroupLayout,

--- a/pocket3d/examples/handheld/Cargo.toml
+++ b/pocket3d/examples/handheld/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "handheld"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "A borderless 3D PSP on the desktop that runs Pocket apps: the first pocket-widget runtime"
+
+[dependencies]
+pocket3d = { workspace = true }
+pocket-mod = { workspace = true }
+pocket-ui-wgpu = { workspace = true }
+pocket-widget = { workspace = true }
+wgpu = { workspace = true }
+winit = { workspace = true }
+glam = { workspace = true, features = ["std"] }
+anyhow = { workspace = true }
+log = { workspace = true }
+env_logger = { workspace = true }

--- a/pocket3d/examples/handheld/src/device.rs
+++ b/pocket3d/examples/handheld/src/device.rs
@@ -1,0 +1,390 @@
+//! The PSP shell, authored procedurally.
+//!
+//! An original PSP-1000-silhouette handheld built from primitives at load
+//! time — no committed binary asset, no ripped geometry (Sony's trade dress
+//! is why WIDGET.md wants the shape "generic handheld, obviously
+//! PSP-adjacent"). Every interactive part is its own `ModelAsset` +
+//! `ModelInstance`, so a press animates by nudging the instance transform
+//! and picking reuses the asset's AABB under that same transform.
+//!
+//! Units are millimeters, device centered at the origin, front face +Z,
+//! +Y up. Real PSP-1000: 170 × 74 × 23 mm with a 480×272 screen.
+
+use std::sync::Arc;
+
+use glam::{Mat4, Vec2, Vec3};
+use pocket3d::gpu::Gpu;
+use pocket3d::model::{ModelAsset, ModelInstance, ModelVertex};
+use pocket3d::renderer::Renderer;
+use pocket3d::scene::Scene;
+use pocket_widget::parts::{PartMap, PartShape, btn};
+
+pub const BODY_W: f32 = 170.0;
+pub const BODY_H: f32 = 74.0;
+pub const BODY_D: f32 = 20.0;
+/// PSP screen glass: 480×272 px at this physical width.
+pub const SCREEN_W: f32 = 86.0;
+pub const SCREEN_H: f32 = SCREEN_W * 272.0 / 480.0;
+/// Screen center sits slightly above the device midline, like the original.
+pub const SCREEN_CENTER: Vec3 = Vec3::new(0.0, 2.0, 10.3);
+/// How far a pressed cap travels into the body.
+pub const PRESS_TRAVEL: f32 = 1.8;
+/// Maximum analog-nub slide from center.
+pub const NUB_TRAVEL: f32 = 4.0;
+
+const FACE_Z: f32 = BODY_D / 2.0; // 10.0
+
+/// One built part: scene instance index + picking shape index share `name`.
+pub struct DevicePart {
+    pub name: &'static str,
+    pub buttons: u32,
+    /// Index into `Scene::models`.
+    pub instance: usize,
+    /// Rest transform (presses/nub slides offset from this).
+    pub base: Mat4,
+    /// Rest tint (hover highlights scale from this).
+    pub tint: [f32; 4],
+}
+
+pub struct Device {
+    pub parts: Vec<DevicePart>,
+    pub map: PartMap,
+}
+
+/// Build every part into `scene.models` and the pick map. `screen_view` is
+/// the embedded UI's render target; colors are instance tints over white
+/// geometry so parts share the plain-material path.
+pub fn build(gpu: &Gpu, renderer: &Renderer, scene: &mut Scene, screen_view: &wgpu::TextureView) -> Device {
+    let layout = &renderer.model_material_layout;
+    let samplers = &renderer.samplers;
+    let mut parts = Vec::new();
+    let mut map = PartMap::default();
+
+    let body_grey = [0.062, 0.062, 0.072, 1.0];
+    let cap_grey = [0.135, 0.135, 0.152, 1.0];
+
+    let push = |scene: &mut Scene,
+                    map: &mut PartMap,
+                    parts: &mut Vec<DevicePart>,
+                    name: &'static str,
+                    buttons: u32,
+                    asset: Arc<ModelAsset>,
+                    at: Vec3,
+                    tint: [f32; 4],
+                    lit: f32,
+                    pick_pad: Vec3| {
+        let base = Mat4::from_translation(at);
+        let mut inst = ModelInstance::new(asset.clone());
+        inst.transform = base;
+        inst.tint = tint;
+        inst.lit = lit;
+        let instance = scene.models.len();
+        scene.models.push(inst);
+        map.push(PartShape {
+            name: name.into(),
+            buttons,
+            transform: base,
+            aabb: (asset.aabb.0 - pick_pad, asset.aabb.1 + pick_pad),
+        });
+        parts.push(DevicePart {
+            name,
+            buttons,
+            instance,
+            base,
+            tint,
+        });
+    };
+
+    // --- body: rounded-rect slab, near-black matte ------------------------
+    let body = {
+        let (v, i) = rounded_slab(BODY_W, BODY_H, BODY_D, 30.0, 12);
+        ModelAsset::from_geometry(gpu, layout, samplers, "hh body", &v, &i, None)
+    };
+    push(scene, &mut map, &mut parts, "body", 0, body, Vec3::ZERO, body_grey, 1.0, Vec3::ZERO);
+
+    // --- screen bezel (glossy inset) + the live screen --------------------
+    let bezel = {
+        let (v, i) = quad(SCREEN_W + 18.0, SCREEN_H + 10.0);
+        ModelAsset::from_geometry(gpu, layout, samplers, "hh bezel", &v, &i, None)
+    };
+    push(
+        scene, &mut map, &mut parts,
+        "bezel", 0, bezel,
+        Vec3::new(0.0, SCREEN_CENTER.y, FACE_Z + 0.15),
+        [0.045, 0.045, 0.055, 1.0], 1.0, Vec3::ZERO,
+    );
+    let screen = {
+        let (v, i) = quad(SCREEN_W, SCREEN_H);
+        ModelAsset::from_geometry_textured(
+            gpu, layout, "hh screen", &v, &i, screen_view, &samplers.linear_clamp,
+        )
+    };
+    // Unlit: the app's own pixels, full brightness. Pick pad thickens the
+    // flat quad so the slab test is robust.
+    push(
+        scene, &mut map, &mut parts,
+        "screen", 0, screen, SCREEN_CENTER,
+        [1.0; 4], 0.0, Vec3::new(0.0, 0.0, 0.5),
+    );
+
+    // --- D-pad (left): four caps + a dead center hub ----------------------
+    let dpad_center = Vec2::new(-62.0, 2.0);
+    let cap = {
+        let (v, i) = box_mesh(11.0, 11.0, 3.0);
+        ModelAsset::from_geometry(gpu, layout, samplers, "hh dpad cap", &v, &i, None)
+    };
+    let dirs: [(&'static str, u32, Vec2); 4] = [
+        ("dpad_up", btn::UP, Vec2::new(0.0, 12.0)),
+        ("dpad_down", btn::DOWN, Vec2::new(0.0, -12.0)),
+        ("dpad_left", btn::LEFT, Vec2::new(-12.0, 0.0)),
+        ("dpad_right", btn::RIGHT, Vec2::new(12.0, 0.0)),
+    ];
+    for (name, bits, off) in dirs {
+        push(
+            scene, &mut map, &mut parts,
+            name, bits, cap.clone(),
+            Vec3::new(dpad_center.x + off.x, dpad_center.y + off.y, FACE_Z + 1.5),
+            cap_grey, 1.0, Vec3::ZERO,
+        );
+    }
+    let hub = {
+        let (v, i) = box_mesh(11.0, 11.0, 2.4);
+        ModelAsset::from_geometry(gpu, layout, samplers, "hh dpad hub", &v, &i, None)
+    };
+    push(
+        scene, &mut map, &mut parts,
+        "dpad_hub", 0, hub,
+        Vec3::new(dpad_center.x, dpad_center.y, FACE_Z + 1.2),
+        cap_grey, 1.0, Vec3::ZERO,
+    );
+
+    // --- face buttons (right): the four glyph hues ------------------------
+    let face_center = Vec2::new(62.0, 2.0);
+    let button = {
+        let (v, i) = cylinder(5.5, 3.0, 24);
+        ModelAsset::from_geometry(gpu, layout, samplers, "hh button", &v, &i, None)
+    };
+    let faces: [(&'static str, u32, Vec2, [f32; 4]); 4] = [
+        ("btn_triangle", btn::TRIANGLE, Vec2::new(0.0, 12.0), [0.22, 0.38, 0.28, 1.0]),
+        ("btn_circle", btn::CIRCLE, Vec2::new(12.0, 0.0), [0.42, 0.22, 0.26, 1.0]),
+        ("btn_cross", btn::CROSS, Vec2::new(0.0, -12.0), [0.22, 0.30, 0.44, 1.0]),
+        ("btn_square", btn::SQUARE, Vec2::new(-12.0, 0.0), [0.37, 0.26, 0.40, 1.0]),
+    ];
+    for (name, bits, off, tint) in faces {
+        push(
+            scene, &mut map, &mut parts,
+            name, bits, button.clone(),
+            Vec3::new(face_center.x + off.x, face_center.y + off.y, FACE_Z + 1.5),
+            tint, 1.0, Vec3::ZERO,
+        );
+    }
+
+    // --- analog nub (bottom-left) -----------------------------------------
+    let nub = {
+        let (v, i) = cylinder(7.0, 2.5, 24);
+        ModelAsset::from_geometry(gpu, layout, samplers, "hh nub", &v, &i, None)
+    };
+    push(
+        scene, &mut map, &mut parts,
+        "nub", 0, nub,
+        Vec3::new(-62.0, -25.0, FACE_Z + 1.25),
+        [0.185, 0.185, 0.205, 1.0], 1.0,
+        // Generous pad: the nub is grabbed, not clicked precisely.
+        Vec3::new(2.0, 2.0, 0.5),
+    );
+
+    // --- start / select (bottom-right) ------------------------------------
+    let pill = {
+        let (v, i) = box_mesh(11.0, 4.5, 2.0);
+        ModelAsset::from_geometry(gpu, layout, samplers, "hh pill", &v, &i, None)
+    };
+    push(
+        scene, &mut map, &mut parts,
+        "btn_select", btn::SELECT, pill.clone(),
+        Vec3::new(50.0, -25.0, FACE_Z + 1.0),
+        cap_grey, 1.0, Vec3::splat(1.0),
+    );
+    push(
+        scene, &mut map, &mut parts,
+        "btn_start", btn::START, pill,
+        Vec3::new(66.0, -25.0, FACE_Z + 1.0),
+        cap_grey, 1.0, Vec3::splat(1.0),
+    );
+
+    // --- shoulder triggers: mostly seated in the body, a lip proud of the
+    // top edge and slightly proud of the face so front clicks land ----------
+    let trigger = {
+        let (v, i) = box_mesh(26.0, 6.0, 6.5);
+        ModelAsset::from_geometry(gpu, layout, samplers, "hh trigger", &v, &i, None)
+    };
+    push(
+        scene, &mut map, &mut parts,
+        "trig_l", btn::LTRIGGER, trigger.clone(),
+        Vec3::new(-66.0, BODY_H / 2.0 + 0.2, FACE_Z - 2.9),
+        cap_grey, 1.0, Vec3::ZERO,
+    );
+    push(
+        scene, &mut map, &mut parts,
+        "trig_r", btn::RTRIGGER, trigger,
+        Vec3::new(66.0, BODY_H / 2.0 + 0.2, FACE_Z - 2.9),
+        cap_grey, 1.0, Vec3::ZERO,
+    );
+
+    Device { parts, map }
+}
+
+// ---------------------------------------------------------------------------
+// procedural meshes
+// ---------------------------------------------------------------------------
+
+/// Emit one triangle wound to face `normal` (auto-orients, so builders never
+/// fight the pipeline's back-face culling).
+fn tri(
+    verts: &mut Vec<ModelVertex>,
+    indices: &mut Vec<u32>,
+    normal: Vec3,
+    a: Vec3,
+    b: Vec3,
+    c: Vec3,
+    uv: [[f32; 2]; 3],
+) {
+    let (b, c, uv) = if (b - a).cross(c - a).dot(normal) >= 0.0 {
+        (b, c, uv)
+    } else {
+        (c, b, [uv[0], uv[2], uv[1]])
+    };
+    let base = verts.len() as u32;
+    for (p, uv) in [(a, uv[0]), (b, uv[1]), (c, uv[2])] {
+        verts.push(ModelVertex {
+            pos: p.to_array(),
+            normal: normal.to_array(),
+            uv,
+            joints: [0; 4],
+            weights: [1.0, 0.0, 0.0, 0.0],
+        });
+    }
+    indices.extend([base, base + 1, base + 2]);
+}
+
+const NO_UV: [[f32; 2]; 3] = [[0.0, 0.0]; 3];
+
+/// A front-facing quad (+Z normal) with full 0..1 UVs, v=0 at the top —
+/// exactly how an offscreen UI texture reads.
+fn quad(w: f32, h: f32) -> (Vec<ModelVertex>, Vec<u32>) {
+    let (hw, hh) = (w / 2.0, h / 2.0);
+    let (mut v, mut i) = (Vec::new(), Vec::new());
+    let tl = Vec3::new(-hw, hh, 0.0);
+    let tr = Vec3::new(hw, hh, 0.0);
+    let br = Vec3::new(hw, -hh, 0.0);
+    let bl = Vec3::new(-hw, -hh, 0.0);
+    tri(&mut v, &mut i, Vec3::Z, tl, tr, br, [[0.0, 0.0], [1.0, 0.0], [1.0, 1.0]]);
+    tri(&mut v, &mut i, Vec3::Z, tl, br, bl, [[0.0, 0.0], [1.0, 1.0], [0.0, 1.0]]);
+    (v, i)
+}
+
+/// Axis-aligned box centered at the origin.
+fn box_mesh(w: f32, h: f32, depth: f32) -> (Vec<ModelVertex>, Vec<u32>) {
+    let half = Vec3::new(w / 2.0, h / 2.0, depth / 2.0);
+    let (mut verts, mut indices) = (Vec::new(), Vec::new());
+    for axis in 0..3 {
+        for side in [-1.0f32, 1.0] {
+            let normal = {
+                let mut n = Vec3::ZERO;
+                n[axis] = side;
+                n
+            };
+            let (u, w_axis) = ((axis + 1) % 3, (axis + 2) % 3);
+            let corner = |su: f32, sw: f32| {
+                let mut p = normal * half;
+                p[u] = su * half[u];
+                p[w_axis] = sw * half[w_axis];
+                p
+            };
+            let (a, b, c, d) = (
+                corner(-1.0, -1.0),
+                corner(1.0, -1.0),
+                corner(1.0, 1.0),
+                corner(-1.0, 1.0),
+            );
+            tri(&mut verts, &mut indices, normal, a, b, c, NO_UV);
+            tri(&mut verts, &mut indices, normal, a, c, d, NO_UV);
+        }
+    }
+    (verts, indices)
+}
+
+/// Cylinder along Z, centered, with flat caps.
+fn cylinder(r: f32, depth: f32, segments: usize) -> (Vec<ModelVertex>, Vec<u32>) {
+    let hz = depth / 2.0;
+    let (mut verts, mut indices) = (Vec::new(), Vec::new());
+    let ring: Vec<Vec2> = (0..segments)
+        .map(|s| {
+            let a = s as f32 / segments as f32 * std::f32::consts::TAU;
+            Vec2::new(a.cos(), a.sin()) * r
+        })
+        .collect();
+    for s in 0..segments {
+        let (p0, p1) = (ring[s], ring[(s + 1) % segments]);
+        // Caps.
+        tri(
+            &mut verts, &mut indices, Vec3::Z,
+            Vec3::new(0.0, 0.0, hz), p0.extend(hz), p1.extend(hz), NO_UV,
+        );
+        tri(
+            &mut verts, &mut indices, Vec3::NEG_Z,
+            Vec3::new(0.0, 0.0, -hz), p0.extend(-hz), p1.extend(-hz), NO_UV,
+        );
+        // Wall (flat-shaded per segment; reads as molded plastic).
+        let n = ((p0 + p1) / 2.0).extend(0.0).normalize();
+        tri(&mut verts, &mut indices, n, p0.extend(hz), p1.extend(hz), p1.extend(-hz), NO_UV);
+        tri(&mut verts, &mut indices, n, p0.extend(hz), p1.extend(-hz), p0.extend(-hz), NO_UV);
+    }
+    (verts, indices)
+}
+
+/// Rounded-rectangle slab: the PSP body silhouette extruded front-to-back.
+fn rounded_slab(
+    w: f32,
+    h: f32,
+    depth: f32,
+    radius: f32,
+    corner_segments: usize,
+) -> (Vec<ModelVertex>, Vec<u32>) {
+    let hz = depth / 2.0;
+    let r = radius.min(w / 2.0).min(h / 2.0);
+    let (cx, cy) = (w / 2.0 - r, h / 2.0 - r);
+    // CCW outline seen from the front: corner arc centers TR, TL, BL, BR.
+    let corners = [
+        (Vec2::new(cx, cy), 0.0f32),
+        (Vec2::new(-cx, cy), 90.0),
+        (Vec2::new(-cx, -cy), 180.0),
+        (Vec2::new(cx, -cy), 270.0),
+    ];
+    let mut outline: Vec<Vec2> = Vec::new();
+    for (center, start_deg) in corners {
+        for s in 0..=corner_segments {
+            let a = (start_deg + 90.0 * s as f32 / corner_segments as f32).to_radians();
+            outline.push(center + Vec2::new(a.cos(), a.sin()) * r);
+        }
+    }
+    let (mut verts, mut indices) = (Vec::new(), Vec::new());
+    let n = outline.len();
+    for s in 0..n {
+        let (p0, p1) = (outline[s], outline[(s + 1) % n]);
+        // Front + back caps as fans from the center.
+        tri(
+            &mut verts, &mut indices, Vec3::Z,
+            Vec3::new(0.0, 0.0, hz), p0.extend(hz), p1.extend(hz), NO_UV,
+        );
+        tri(
+            &mut verts, &mut indices, Vec3::NEG_Z,
+            Vec3::new(0.0, 0.0, -hz), p0.extend(-hz), p1.extend(-hz), NO_UV,
+        );
+        // Side wall; outward normal of a CCW edge is (dy, -dx).
+        let e = p1 - p0;
+        let wall_n = Vec3::new(e.y, -e.x, 0.0).normalize_or_zero();
+        tri(&mut verts, &mut indices, wall_n, p0.extend(hz), p1.extend(hz), p1.extend(-hz), NO_UV);
+        tri(&mut verts, &mut indices, wall_n, p0.extend(hz), p1.extend(-hz), p0.extend(-hz), NO_UV);
+    }
+    (verts, indices)
+}

--- a/pocket3d/examples/handheld/src/main.rs
+++ b/pocket3d/examples/handheld/src/main.rs
@@ -1,0 +1,580 @@
+//! handheld — a borderless 3D PSP on the desktop that runs Pocket apps.
+//!
+//! The first pocket-widget runtime (WIDGET.md): a transparent, undecorated,
+//! always-on-top window framing a procedurally built PSP whose screen is a
+//! live 480×272 PocketJS `ui` surface and whose buttons feed real BTN bits
+//! to an unmodified app bundle. The same bundle boots on PSP hardware, in
+//! uihost, on the Vita — and inside this widget, and cannot tell the
+//! difference.
+//!
+//!   cargo run -p handheld -- --app hero
+//!   cargo run -p handheld -- --app im --screenshot out.png --frames 30
+//!
+//! Interactions: click the caps (they depress and hold their BTN bit),
+//! drag the analog nub, double-click the screen to zoom between the desk
+//! framing and a screen-filling focus framing, drag the body to move the
+//! window, Esc quits. The uihost keyboard map works throughout: arrows =
+//! D-pad, Z/Enter = CROSS, X = CIRCLE, A = SQUARE, S = TRIANGLE, Q/W = L/R,
+//! Tab = SELECT, Space = START, I/J/K/L = nub.
+//!
+//! Bundles/paks come from the PocketJS build (`bun scripts/build.ts <app>`);
+//! the widget looks in `<repo>/dist` (override: POCKETJS_DIST or --js/--pak).
+
+mod device;
+
+use std::path::PathBuf;
+
+use anyhow::{Context, Result, anyhow};
+use glam::{Mat4, Vec2, Vec3};
+use pocket3d::camera::Camera;
+use pocket3d::gpu::{Gpu, OFFSCREEN_FORMAT, OffscreenTarget};
+use pocket3d::hud::Hud;
+use pocket3d::input::Input;
+use pocket3d::renderer::Renderer;
+use pocket3d::scene::Scene;
+use pocket_mod::Guest;
+use pocket_ui_wgpu::UiSurface;
+use pocket_widget::embed::EmbeddedUi;
+use pocket_widget::parts::{analog_pack, btn, key_button};
+use pocket_widget::shell::{WidgetConfig, WidgetGame};
+use winit::keyboard::KeyCode;
+
+use device::{Device, NUB_TRAVEL, PRESS_TRAVEL, SCREEN_CENTER};
+
+const UI_W: u32 = 480;
+const UI_H: u32 = 272;
+/// Window size, logical px.
+const WIN_W: u32 = 480;
+const WIN_H: u32 = 260;
+
+/// Keys the widget polls for held state (the shared uihost map + I/J/K/L
+/// as a keyboard nub).
+const KEYS: [KeyCode; 14] = [
+    KeyCode::ArrowUp,
+    KeyCode::ArrowDown,
+    KeyCode::ArrowLeft,
+    KeyCode::ArrowRight,
+    KeyCode::KeyZ,
+    KeyCode::Enter,
+    KeyCode::KeyX,
+    KeyCode::Backspace,
+    KeyCode::KeyA,
+    KeyCode::KeyS,
+    KeyCode::KeyQ,
+    KeyCode::KeyW,
+    KeyCode::Tab,
+    KeyCode::Space,
+];
+
+/// Camera framings: "desk" shows the whole device; "focus" fills the window
+/// with the screen (effectively uihost with a bezel). Double-click the
+/// screen to toggle; the camera eases between them.
+const DESK_POS: Vec3 = Vec3::new(0.0, 46.0, 190.0);
+const DESK_TARGET: Vec3 = Vec3::ZERO;
+const FOCUS_POS: Vec3 = Vec3::new(0.0, SCREEN_CENTER.y, 106.3);
+const FOCUS_TARGET: Vec3 = SCREEN_CENTER;
+/// Framing ease duration in ticks (60 Hz).
+const FRAMING_TICKS: f32 = 21.0;
+/// Double-click window in ticks.
+const DOUBLE_CLICK_TICKS: u64 = 21;
+
+struct HandheldGame {
+    // Boot state (pre-GPU) — consumed by init.
+    boot_surface: Option<UiSurface>,
+    guest: Guest,
+
+    embedded: Option<EmbeddedUi>,
+    dev: Option<Device>,
+    scene: Scene,
+    camera: Camera,
+    hud: Hud,
+
+    window_px: (u32, u32),
+    ticks: u64,
+    prev_buttons: u32,
+    /// Part index held by the mouse (its BTN bits stay down until release).
+    mouse_part: Option<usize>,
+    hover: Option<usize>,
+    /// Cursor position where the nub was grabbed.
+    nub_grab: Option<Vec2>,
+    /// Nub deflection, −1..1 per axis (x right, y down).
+    nub: Vec2,
+    last_cursor: Option<Vec2>,
+    /// 0 = desk framing, 1 = focus framing.
+    focus: bool,
+    blend: f32,
+    last_screen_click: Option<u64>,
+    /// Extra BTN bits held for the whole run (headless --hold).
+    hold_mask: u32,
+    /// Exit after this many ticks (--auto-quit smoke tests).
+    quit_after: Option<u64>,
+    dirty: bool,
+    exit: bool,
+}
+
+impl HandheldGame {
+    fn new(guest: Guest, surface: UiSurface, hold_mask: u32) -> Self {
+        let mut scene = Scene::default();
+        scene.transparent_clear = true;
+        let mut camera = Camera {
+            pos: DESK_POS,
+            fov_y: 30f32.to_radians(),
+            znear: 10.0,
+            zfar: 2000.0,
+            ..Default::default()
+        };
+        camera.look_at(DESK_TARGET);
+        Self {
+            boot_surface: Some(surface),
+            guest,
+            embedded: None,
+            dev: None,
+            scene,
+            camera,
+            hud: Hud::default(),
+            window_px: (WIN_W, WIN_H),
+            ticks: 0,
+            prev_buttons: 0,
+            mouse_part: None,
+            hover: None,
+            nub_grab: None,
+            nub: Vec2::ZERO,
+            last_cursor: None,
+            focus: false,
+            blend: 0.0,
+            last_screen_click: None,
+            hold_mask,
+            quit_after: None,
+            dirty: true,
+            exit: false,
+        }
+    }
+
+    fn pick(&self, cursor: Vec2) -> Option<usize> {
+        let dev = self.dev.as_ref()?;
+        let (origin, dir) = self.camera.screen_ray(
+            cursor,
+            (self.window_px.0 as f32, self.window_px.1 as f32),
+        );
+        dev.map.pick(origin, dir).map(|(i, _)| i)
+    }
+
+    /// Press/hover/nub state → instance transforms and tints. Runs every
+    /// tick; the scene mutation is a handful of matrix writes.
+    fn apply_visuals(&mut self, buttons: u32) {
+        let Some(dev) = self.dev.as_ref() else { return };
+        for (i, part) in dev.parts.iter().enumerate() {
+            let inst = &mut self.scene.models[part.instance];
+            let pressed = part.buttons != 0 && buttons & part.buttons == part.buttons;
+            let mut offset = Vec3::ZERO;
+            if pressed {
+                offset.z -= PRESS_TRAVEL;
+            }
+            if part.name == "nub" {
+                offset += Vec3::new(self.nub.x, -self.nub.y, 0.0) * NUB_TRAVEL;
+            }
+            inst.transform = Mat4::from_translation(offset) * part.base;
+            let hovered = self.hover == Some(i) && part.buttons != 0;
+            inst.tint = if hovered && !pressed {
+                let t = part.tint;
+                [t[0] * 1.35, t[1] * 1.35, t[2] * 1.35, t[3]]
+            } else {
+                part.tint
+            };
+        }
+    }
+}
+
+impl WidgetGame for HandheldGame {
+    fn init(&mut self, gpu: &Gpu, renderer: &mut Renderer) -> Result<()> {
+        let surface = self.boot_surface.take().expect("init runs once");
+        let embedded = EmbeddedUi::new(gpu, surface, (UI_W, UI_H));
+        self.dev = Some(device::build(gpu, renderer, &mut self.scene, embedded.view()));
+        self.embedded = Some(embedded);
+        Ok(())
+    }
+
+    fn tick(&mut self, dt: f32, input: &Input, window_px: (u32, u32)) -> Result<()> {
+        self.window_px = window_px;
+        if input.key_pressed(KeyCode::Escape)
+            || self.quit_after.is_some_and(|limit| self.ticks >= limit)
+        {
+            self.exit = true;
+        }
+
+        // --- keyboard: held BTN bits + I/J/K/L nub ------------------------
+        let mut buttons = self.hold_mask;
+        for code in KEYS {
+            if input.key_down(code)
+                && let Some(bit) = key_button(code)
+            {
+                buttons |= bit;
+            }
+        }
+        let key_axis = |neg: KeyCode, pos: KeyCode| {
+            (input.key_down(pos) as i32 - input.key_down(neg) as i32) as f32
+        };
+        let key_nub = Vec2::new(
+            key_axis(KeyCode::KeyJ, KeyCode::KeyL),
+            key_axis(KeyCode::KeyI, KeyCode::KeyK),
+        );
+
+        // --- mouse: hover, press, nub drag --------------------------------
+        let cursor = input.cursor();
+        if let Some(c) = cursor {
+            if self.nub_grab.is_none() && self.last_cursor != Some(c) {
+                let hover = self.pick(c);
+                if hover != self.hover {
+                    self.hover = hover;
+                    self.dirty = true;
+                }
+            }
+            if input.mouse_button_pressed(winit::event::MouseButton::Left) {
+                let hit = self.pick(c).map(|i| {
+                    let p = &self.dev.as_ref().unwrap().parts[i];
+                    (i, p.name, p.buttons)
+                });
+                log::debug!(
+                    "press at {c:?}: {}",
+                    hit.map_or("nothing", |(_, name, _)| name)
+                );
+                match hit {
+                    Some((i, "nub", _)) => {
+                        let _ = i;
+                        self.nub_grab = Some(c);
+                    }
+                    Some((_, "screen", _)) => {
+                        let double = self
+                            .last_screen_click
+                            .is_some_and(|t| self.ticks - t <= DOUBLE_CLICK_TICKS);
+                        self.last_screen_click = Some(self.ticks);
+                        if double {
+                            self.focus = !self.focus;
+                        }
+                    }
+                    Some((i, _, bits)) if bits != 0 => {
+                        self.mouse_part = Some(i);
+                    }
+                    _ => {}
+                }
+            }
+            if let Some(grab) = self.nub_grab {
+                // Full tilt at 30 logical px of drag (scaled to physical).
+                let full = 30.0 * self.window_px.0 as f32 / WIN_W as f32;
+                let mut v = (c - grab) / full;
+                if v.length() > 1.0 {
+                    v = v.normalize();
+                }
+                if v != self.nub {
+                    self.nub = v;
+                    self.dirty = true;
+                }
+            }
+            self.last_cursor = Some(c);
+        }
+        if !input.mouse_button_down(winit::event::MouseButton::Left) {
+            if self.mouse_part.take().is_some() {
+                self.dirty = true;
+            }
+            if self.nub_grab.take().is_some() {
+                self.nub = Vec2::ZERO;
+                self.dirty = true;
+            }
+        }
+        if let Some(i) = self.mouse_part {
+            buttons |= self.dev.as_ref().unwrap().parts[i].buttons;
+        }
+        if buttons != self.prev_buttons {
+            self.prev_buttons = buttons;
+            self.dirty = true;
+        }
+
+        // --- the guest turn (Law 3: exactly one per tick) ------------------
+        let nub = if self.nub_grab.is_some() { self.nub } else { key_nub };
+        let analog = analog_pack(nub.x, nub.y);
+        self.guest.frame_with_analog(buttons, analog)?;
+        if let Some(embedded) = self.embedded.as_mut()
+            && embedded.tick()
+        {
+            self.dirty = true;
+        }
+
+        // --- camera framing ease ------------------------------------------
+        let target = if self.focus { 1.0 } else { 0.0 };
+        if self.blend != target {
+            let step = dt * 60.0 / FRAMING_TICKS;
+            self.blend = if self.blend < target {
+                (self.blend + step).min(target)
+            } else {
+                (self.blend - step).max(target)
+            };
+            self.dirty = true;
+        }
+
+        self.apply_visuals(buttons);
+        self.ticks += 1;
+        Ok(())
+    }
+
+    fn take_dirty(&mut self) -> bool {
+        std::mem::take(&mut self.dirty)
+    }
+
+    fn prepare(&mut self, gpu: &Gpu) -> Result<()> {
+        if let Some(embedded) = self.embedded.as_mut() {
+            embedded.render_if_dirty(gpu)?;
+        }
+        Ok(())
+    }
+
+    fn compose(&mut self, time: f32, _size: (u32, u32)) -> (&Scene, &Camera, &Hud) {
+        let t = self.blend * self.blend * (3.0 - 2.0 * self.blend); // smoothstep
+        self.camera.pos = DESK_POS.lerp(FOCUS_POS, t);
+        self.camera.look_at(DESK_TARGET.lerp(FOCUS_TARGET, t));
+        self.scene.time = time;
+        (&self.scene, &self.camera, &self.hud)
+    }
+
+    fn drag_at(&mut self, cursor: Vec2) -> bool {
+        // Dragging anything inert moves the window — the pocket-character
+        // "drag anywhere" feel, minus the interactive parts.
+        match self.pick(cursor) {
+            None => true,
+            Some(i) => {
+                let p = &self.dev.as_ref().unwrap().parts[i];
+                p.buttons == 0 && !matches!(p.name, "nub" | "screen")
+            }
+        }
+    }
+
+    fn wants_exit(&self) -> bool {
+        self.exit
+    }
+}
+
+// ---------------------------------------------------------------------------
+// boot + CLI
+// ---------------------------------------------------------------------------
+
+struct Args {
+    app: String,
+    js: Option<PathBuf>,
+    pak: Option<PathBuf>,
+    screenshot: Option<PathBuf>,
+    frames: u32,
+    hold: u32,
+    /// Headless: click this window pixel (press mid-run, release at 2/3).
+    click: Option<(f32, f32)>,
+    /// Headless: (BTN bits, frame) taps — held for 6 ticks from that frame.
+    taps: Vec<(u32, u32)>,
+    /// Start in the screen-filling focus framing.
+    focus: bool,
+    /// Windowed smoke test: quit after this many seconds.
+    auto_quit: Option<f32>,
+}
+
+fn parse_args() -> Result<Args> {
+    let mut args = Args {
+        app: "hero-main".into(),
+        js: None,
+        pak: None,
+        screenshot: None,
+        frames: 30,
+        hold: 0,
+        click: None,
+        taps: Vec::new(),
+        focus: false,
+        auto_quit: None,
+    };
+    let mut it = std::env::args().skip(1);
+    while let Some(a) = it.next() {
+        let mut val = |name: &str| -> Result<String> {
+            it.next().ok_or_else(|| anyhow!("{name} needs a value"))
+        };
+        match a.as_str() {
+            "--app" => args.app = val("--app")?,
+            "--js" => args.js = Some(PathBuf::from(val("--js")?)),
+            "--pak" => args.pak = Some(PathBuf::from(val("--pak")?)),
+            "--screenshot" => args.screenshot = Some(PathBuf::from(val("--screenshot")?)),
+            "--frames" => args.frames = val("--frames")?.parse()?,
+            "--hold" => {
+                for name in val("--hold")?.split(',') {
+                    args.hold |= hold_bit(name)?;
+                }
+            }
+            "--click" => {
+                let v = val("--click")?;
+                let (x, y) = v
+                    .split_once(',')
+                    .ok_or_else(|| anyhow!("--click wants x,y"))?;
+                args.click = Some((x.trim().parse()?, y.trim().parse()?));
+            }
+            "--tap" => {
+                let v = val("--tap")?;
+                let (name, frame) = v
+                    .split_once('@')
+                    .ok_or_else(|| anyhow!("--tap wants name@frame"))?;
+                args.taps.push((hold_bit(name)?, frame.parse()?));
+            }
+            "--focus" => args.focus = true,
+            "--auto-quit" => args.auto_quit = Some(val("--auto-quit")?.parse()?),
+            other => return Err(anyhow!("unknown flag {other}")),
+        }
+    }
+    Ok(args)
+}
+
+fn hold_bit(name: &str) -> Result<u32> {
+    Ok(match name {
+        "up" => btn::UP,
+        "down" => btn::DOWN,
+        "left" => btn::LEFT,
+        "right" => btn::RIGHT,
+        "cross" => btn::CROSS,
+        "circle" => btn::CIRCLE,
+        "square" => btn::SQUARE,
+        "triangle" => btn::TRIANGLE,
+        "start" => btn::START,
+        "select" => btn::SELECT,
+        "l" => btn::LTRIGGER,
+        "r" => btn::RTRIGGER,
+        other => return Err(anyhow!("unknown button '{other}'")),
+    })
+}
+
+/// `<repo>/dist` — relative to this crate in the source tree, or
+/// POCKETJS_DIST, or ./dist for standalone binaries.
+fn dist_dir() -> Option<PathBuf> {
+    if let Ok(d) = std::env::var("POCKETJS_DIST") {
+        return Some(PathBuf::from(d));
+    }
+    let from_manifest = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../../../dist")
+        .canonicalize()
+        .ok();
+    from_manifest.or_else(|| {
+        let cwd = PathBuf::from("dist");
+        cwd.is_dir().then_some(cwd)
+    })
+}
+
+fn resolve_asset(explicit: Option<PathBuf>, app: &str, ext: &str) -> Result<PathBuf> {
+    if let Some(p) = explicit {
+        return p
+            .canonicalize()
+            .with_context(|| format!("missing {}", p.display()));
+    }
+    let dist =
+        dist_dir().ok_or_else(|| anyhow!("cannot find PocketJS dist/ (set POCKETJS_DIST)"))?;
+    let candidates = [format!("{app}.{ext}"), format!("{app}-main.{ext}")];
+    for c in &candidates {
+        let p = dist.join(c);
+        if p.is_file() {
+            return Ok(p);
+        }
+    }
+    Err(anyhow!(
+        "no {ext} for app '{app}' in {} — build it first: bun scripts/build.ts {app}",
+        dist.display()
+    ))
+}
+
+/// Boot the guest: feed the pak, mount `ui`, eval the bundle.
+fn boot(args: &Args) -> Result<(Guest, UiSurface)> {
+    let js_path = resolve_asset(args.js.clone(), &args.app, "js")?;
+    let pak_path = resolve_asset(args.pak.clone(), &args.app, "pak")?;
+    let bundle = std::fs::read_to_string(&js_path)
+        .with_context(|| format!("reading {}", js_path.display()))?;
+    let pak =
+        std::fs::read(&pak_path).with_context(|| format!("reading {}", pak_path.display()))?;
+
+    let surface = UiSurface::new((UI_W as f32, UI_H as f32));
+    surface.feed_pak(&pak);
+    let guest = Guest::new()?;
+    surface.mount(&guest)?;
+    guest.eval(&args.app, &bundle)?;
+    if !guest.has_frame() {
+        return Err(anyhow!(
+            "bundle evaluated but installed no frame() — is this a PocketJS app?"
+        ));
+    }
+    log::info!(
+        "handheld: booted {} ({} bytes js, {} bytes pak)",
+        args.app,
+        bundle.len(),
+        pak.len()
+    );
+    Ok((guest, surface))
+}
+
+fn main() -> Result<()> {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    let args = parse_args()?;
+    let (guest, surface) = boot(&args)?;
+    let mut game = HandheldGame::new(guest, surface, args.hold);
+    game.quit_after = args.auto_quit.map(|s| (s * 60.0) as u64);
+    if args.focus {
+        game.focus = true;
+        game.blend = 1.0;
+    }
+    if let Some(out) = args.screenshot.clone() {
+        headless(game, &args, &out)
+    } else {
+        pocket_widget::run(
+            WidgetConfig {
+                title: "Pocket Handheld".into(),
+                size: (WIN_W, WIN_H),
+                ..Default::default()
+            },
+            game,
+        )
+    }
+}
+
+/// Headless: N fixed ticks, then one composite PNG at 2× (its alpha channel
+/// is the actual window transparency). `--click x,y` scripts a cursor press
+/// on that pixel for the middle third of the run — the full pick → part →
+/// BTN → guest path, no window required.
+fn headless(mut game: HandheldGame, args: &Args, out: &std::path::Path) -> Result<()> {
+    let (w, h) = (WIN_W * 2, WIN_H * 2);
+    let gpu = Gpu::new_headless()?;
+    let mut renderer = Renderer::new(&gpu, OFFSCREEN_FORMAT)?;
+    game.init(&gpu, &mut renderer)?;
+
+    let mut input = Input::default();
+    let base_hold = args.hold;
+    let (press_at, release_at) = (args.frames / 3, args.frames * 2 / 3);
+    for frame in 0..args.frames {
+        game.hold_mask = base_hold
+            | args
+                .taps
+                .iter()
+                .filter(|&&(_, at)| (at..at + 6).contains(&frame))
+                .fold(0, |acc, &(bits, _)| acc | bits);
+        if let Some((x, y)) = args.click {
+            input.inject_cursor(x, y);
+            if frame == press_at {
+                input.inject_mouse_button(winit::event::MouseButton::Left, true);
+            }
+            if frame == release_at {
+                input.inject_mouse_button(winit::event::MouseButton::Left, false);
+            }
+        }
+        game.tick(1.0 / 60.0, &input, (w, h))?;
+        input.end_frame();
+    }
+    game.take_dirty();
+    game.prepare(&gpu)?;
+    let target = OffscreenTarget::new(&gpu, w, h);
+    let (scene, camera, hud) = game.compose(args.frames as f32 / 60.0, (w, h));
+    renderer.render(&gpu, &target.view, (w, h), scene, camera, hud);
+    target.save_png(&gpu, out)?;
+    println!(
+        "handheld: wrote {} after {} frames (app {}, hold {:#06x})",
+        out.display(),
+        args.frames,
+        args.app,
+        args.hold
+    );
+    Ok(())
+}

--- a/scripts/widget.ts
+++ b/scripts/widget.ts
@@ -1,0 +1,46 @@
+// bun run widget [app] [flags…] — build + launch the 3D PSP desktop widget
+// (pocket3d/examples/handheld, the first pocket-widget runtime; WIDGET.md).
+//
+//   bun run widget                # the hero demo inside the widget
+//   bun run widget im             # any demo (name resolves to <name>-main)
+//   bun run widget -- --focus     # extra flags pass through to the binary
+//   bun run widget --proof        # headless acceptance: scripted D-pad +
+//                                 # CIRCLE taps drive hero to "Count: 2",
+//                                 # screenshot lands in dist/
+//
+// The windowed run stays attached to your terminal — quit with Esc (or
+// Ctrl-C). On exit the shell prints its governor receipt:
+// "pocket-widget: N ticks, M frames rendered" — a settled app should show
+// M ≪ N.
+import { $ } from "bun";
+
+const root = new URL("..", import.meta.url).pathname;
+const args = process.argv.slice(2).filter((a) => a !== "--");
+const flags = args.filter((a) => a.startsWith("--"));
+const names = args.filter((a) => !a.startsWith("--"));
+const proof = flags.includes("--proof");
+const pass = flags.filter((f) => f !== "--proof");
+
+// Demo names resolve to their mounted -main entry (demos/<name>/main.tsx);
+// the bare name would build the side-effect-free component module.
+const name = names[0] ?? "hero";
+const app = name.includes("/") || name.endsWith("-main") ? name : `${name}-main`;
+
+await $`bun scripts/build.ts ${app}`.cwd(root);
+await $`cargo build --release -p handheld`.cwd(`${root}pocket3d`);
+
+const bin = `${root}pocket3d/target/release/handheld`;
+const env = { ...process.env, RUST_LOG: process.env.RUST_LOG ?? "info" };
+
+if (proof) {
+  const shot = `${root}dist/handheld-proof.png`;
+  await $`${bin} --app ${app} --screenshot ${shot} --frames 90 --tap down@10 --tap circle@30 --tap circle@50 ${pass}`.env(env);
+  console.log(
+    "\nproof: a D-pad tap focused the app, then two CIRCLE taps went through" +
+      '\nthe 3D buttons — with the hero demo the screen reads "Count: 2".' +
+      `\n${shot}`,
+  );
+  await $`open ${shot}`.nothrow();
+} else {
+  await $`${bin} --app ${app} ${pass}`.env(env);
+}


### PR DESCRIPTION
## What

The **pocket-widget** capability — designed in `WIDGET.md` (first commit) and implemented in-tree (second commit): desktop widgets as a runtime-family capability, plus the first runtime built on it — **a borderless 3D PSP on macOS that runs unmodified Pocket apps**.

## Design (WIDGET.md, sibling of RUNTIMES.md)

A widget is one always-on-top, transparent, undecorated window that lives on the desktop for hours, so idle must cost almost nothing and behavior must be a bundle, not a build. pocket-character proved the economics; pocket-widget names and generalizes the mechanism.

## Implementation

- **pocket3d**: `ModelAsset::from_geometry_textured` (bind an external texture view — an `OffscreenTarget` — as a mesh material), `Camera::screen_ray`, `Input::inject_cursor`, `pick_alpha_mode` public.
- **pocket-ui-wgpu**: `UiRenderer::render_words` — render a DrawList the host already built, so the per-tick dirty hash costs one tree walk, not two.
- **pocket-widget** (new mechanism crate, RUNTIMES.md row added): `shell` — the widget loop: guest ticks at a fixed 60 Hz (Law 3 intact), GPU frames render **only on dirt**, occlusion suspends rendering, a ticks-vs-frames receipt logs on exit; `embed` — a full `ui` surface offscreen with an FNV-1a DrawList hash as the dirty signal; `parts`/`pick` — named parts → spec BTN bits, 255/1-never-0 analog packing, shared uihost key map, ray/OBB picking. 12 unit tests.
- **examples/handheld**: the runtime — a procedurally built PSP-1000-silhouette handheld (original by construction; no committed or fetched asset). The screen is a live 480×272 `ui` surface; clicking caps holds real BTN bits with press animation; the nub drags; the body drags the window; double-click the screen for a screen-filling **focus** framing (`--focus`).

## Verified

- `cargo test`: 19 passing across the workspace crates.
- End-to-end script through the 3D buttons: `--tap down@10 --tap circle@30 --tap circle@50` drives the **unmodified hero bundle** to `Count: 2` (D-pad establishes focus, CIRCLE presses — hero's semantics on real hardware too). `--click 875,262` picks `btn_circle` through the cursor ray.
- Windowed smoke test on an M3 Max (`--auto-quit`), plus the governor's receipt over 10 s: a settled app rendered **103 frames across 601 ticks** (~0 once settled), the always-spinning hero 365; RSS ~87 MB, one process.

Repro:
```sh
bun scripts/build.ts hero-main
cd pocket3d
cargo run -p handheld -- --app hero-main                        # the widget
cargo run -p handheld -- --app hero-main --screenshot out.png --frames 90 \
  --tap down@10 --tap circle@30 --tap circle@50                  # headless proof
```

## Still ahead (tracked in WIDGET.md §9)

Golden-specs wiring against the widget surface, density-2 screens, the optional `widget` surface, click-through, extraction to `pocket-stack/pocket-handheld` with the steady-state measurement harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)