### PR TITLE
refactor(contracts): target semantics as fields, viewport intent as policy

### DIFF
--- a/WIDGET.md
+++ b/WIDGET.md
@@ -115,10 +115,13 @@ one `render_words_scaled` pass on dirty frames. It exercises everything the
   registered capability ids name it (`input.text`, `input.pointer`,
   `input.ime`, `host.clipboard`, `display.viewport.live`,
   `text.glyphs.runtime` — each a distinct observable guarantee; a real
-  pointer is NOT `input.cursor`), and a `desktop-widget-macos` target
+  pointer is NOT `input.cursor`), and a `macos-widget` target
   profile (hostAbi 3, density 2, `dynamicViewport` range) provides them.
-  Target ids for host-windowed platforms follow `<class>-<form>-<os>`
-  (future: `desktop-app-macos`, `desktop-kiosk-linux`). The note's
+  Target semantics live in queryable profile FIELDS (`platform`,
+  `form` — takeover/window/widget/kiosk/embedded); ids are labels
+  (convention `<platform>-<form>`, future: `macos-app`, `linux-kiosk`),
+  and apps declare viewport intent per policy (`fixed`/`dynamic`
+  variants), not per target. The note's
   pocket.json is the reference dual-nature manifest: the desktop surface
   sits in `enhances`, so the app ADMITS everywhere and lights up per
   target (`hasFeature("input.text")` gates the editor — a PSP build never

--- a/demos/cafe/pocket.json
+++ b/demos/cafe/pocket.json
@@ -18,11 +18,13 @@
     "output": "cafe-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/cards/pocket.json
+++ b/demos/cards/pocket.json
@@ -18,11 +18,13 @@
     "output": "cards-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/chrome/pocket.json
+++ b/demos/chrome/pocket.json
@@ -18,11 +18,13 @@
     "output": "chrome-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/cursor/pocket.json
+++ b/demos/cursor/pocket.json
@@ -21,11 +21,13 @@
     "output": "cursor-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/gallery/pocket.json
+++ b/demos/gallery/pocket.json
@@ -18,11 +18,13 @@
     "output": "gallery-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/hero-vue-vapor/pocket.json
+++ b/demos/hero-vue-vapor/pocket.json
@@ -18,11 +18,13 @@
     "output": "hero-vue-vapor-main",
     "framework": "vue-vapor",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/hero/pocket.json
+++ b/demos/hero/pocket.json
@@ -18,11 +18,13 @@
     "output": "hero-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/im/pocket.json
+++ b/demos/im/pocket.json
@@ -21,11 +21,13 @@
     "output": "im-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/library/pocket.json
+++ b/demos/library/pocket.json
@@ -18,11 +18,13 @@
     "output": "library-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/motions/pocket.json
+++ b/demos/motions/pocket.json
@@ -18,11 +18,13 @@
     "output": "motions-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/music/pocket.json
+++ b/demos/music/pocket.json
@@ -18,11 +18,13 @@
     "output": "music-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/note/pocket.json
+++ b/demos/note/pocket.json
@@ -26,8 +26,16 @@
     "output": "note-main",
     "framework": "solid",
     "viewport": {
-      "logical": [420, 560],
-      "presentation": "native"
+      "dynamic": {
+        "default": [
+          420,
+          560
+        ],
+        "min": [
+          240,
+          180
+        ]
+      }
     }
   }
 }

--- a/demos/notifications/pocket.json
+++ b/demos/notifications/pocket.json
@@ -18,11 +18,13 @@
     "output": "notifications-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/settings/pocket.json
+++ b/demos/settings/pocket.json
@@ -18,11 +18,13 @@
     "output": "settings-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/stats/pocket.json
+++ b/demos/stats/pocket.json
@@ -18,11 +18,13 @@
     "output": "stats-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/demos/zoomlab/pocket.json
+++ b/demos/zoomlab/pocket.json
@@ -18,11 +18,13 @@
     "output": "zoomlab-main",
     "framework": "solid",
     "viewport": {
-      "logical": [
-        480,
-        272
-      ],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/pocket.json
+++ b/pocket.json
@@ -19,8 +19,13 @@
     "output": "hero-main",
     "framework": "solid",
     "viewport": {
-      "logical": [480, 272],
-      "presentation": "integer-fit"
+      "fixed": {
+        "logical": [
+          480,
+          272
+        ],
+        "presentation": "integer-fit"
+      }
     }
   }
 }

--- a/pocket3d/examples/note-widget/src/main.rs
+++ b/pocket3d/examples/note-widget/src/main.rs
@@ -738,8 +738,8 @@ fn boot(args: &Args) -> Result<(Guest, UiSurface)> {
         args.density,
     );
     // The platform-contract identity plan-built bundles assert
-    // (spec/platforms.ts POCKET_TARGETS["desktop-widget-macos"]).
-    surface.set_identity("desktop-widget-macos", 3);
+    // (spec/platforms.ts POCKET_TARGETS["macos-widget"]).
+    surface.set_identity("macos-widget", 3);
     surface.feed_pak(&pak);
     let guest = Guest::new()?;
     surface.mount(&guest)?;

--- a/schema/pocket-2.json
+++ b/schema/pocket-2.json
@@ -103,32 +103,106 @@
           ]
         },
         "viewport": {
-          "type": "object",
-          "additionalProperties": false,
-          "required": [
-            "logical",
-            "presentation"
-          ],
-          "properties": {
-            "logical": {
-              "type": "array",
-              "items": {
-                "type": "integer",
-                "minimum": 1
-              },
-              "minItems": 2,
-              "maxItems": 2
+          "anyOf": [
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "required": [
+                "logical",
+                "presentation"
+              ],
+              "properties": {
+                "logical": {
+                  "type": "array",
+                  "items": {
+                    "type": "integer",
+                    "minimum": 1
+                  },
+                  "minItems": 2,
+                  "maxItems": 2
+                },
+                "presentation": {
+                  "enum": [
+                    "fill",
+                    "fit",
+                    "integer-fit",
+                    "native",
+                    "stretch"
+                  ]
+                }
+              }
             },
-            "presentation": {
-              "enum": [
-                "fill",
-                "fit",
-                "integer-fit",
-                "native",
-                "stretch"
-              ]
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "fixed": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "logical",
+                    "presentation"
+                  ],
+                  "properties": {
+                    "logical": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "presentation": {
+                      "enum": [
+                        "fill",
+                        "fit",
+                        "integer-fit",
+                        "native",
+                        "stretch"
+                      ]
+                    }
+                  }
+                },
+                "dynamic": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "required": [
+                    "default"
+                  ],
+                  "properties": {
+                    "default": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "min": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    },
+                    "max": {
+                      "type": "array",
+                      "items": {
+                        "type": "integer",
+                        "minimum": 1
+                      },
+                      "minItems": 2,
+                      "maxItems": 2
+                    }
+                  }
+                }
+              }
             }
-          }
+          ]
         }
       }
     }

--- a/scripts/note.ts
+++ b/scripts/note.ts
@@ -23,11 +23,11 @@ const args = process.argv.slice(2).filter((a) => a !== "--");
 const proof = args.includes("--proof");
 const pass = args.filter((f) => f !== "--proof");
 
-// The note builds through its manifest against the desktop-widget-macos
+// The note builds through its manifest against the macos-widget
 // target profile — density, viewport and capability features all come from
 // the platform contract, not flags.
 const manifest = await Bun.file(`${root}demos/note/pocket.json`).json();
-const resolution = validateAndResolveBuildPlan(manifest, { target: "desktop-widget-macos" });
+const resolution = validateAndResolveBuildPlan(manifest, { target: "macos-widget" });
 if (!resolution.ok) {
   throw new Error(
     `pocket-note: manifest did not resolve: ${resolution.diagnostics

--- a/spec/platforms.ts
+++ b/spec/platforms.ts
@@ -19,16 +19,45 @@ export const PRESENTATION_MODES = ["fill", "fit", "integer-fit", "native", "stre
 export type PresentationMode = (typeof PRESENTATION_MODES)[number];
 export type Viewport = readonly [width: number, height: number];
 
+/**
+ * Shell posture of a target — a semantic FIELD, deliberately not encoded in
+ * the target id (ids are labels; nothing may parse them):
+ *
+ * - "takeover":  the app owns the whole device (consoles, fullscreen).
+ * - "window":    an ordinary OS window among others.
+ * - "widget":    a small always-on-top ambient surface.
+ * - "kiosk":     fullscreen on a host OS, single-purpose installation.
+ * - "embedded":  a surface framed inside another runtime (a launcher tile,
+ *                a screen mesh in a 3D scene).
+ *
+ * Forms split into two viewport POLICIES: window/widget viewports are
+ * runtime variables (`display.dynamicViewport` required); every other form
+ * has a fixed screen (`dynamicViewport` forbidden). Apps declare viewport
+ * variants per policy, not per target.
+ */
+export const TARGET_FORMS = ["takeover", "window", "widget", "kiosk", "embedded"] as const;
+export type TargetForm = (typeof TARGET_FORMS)[number];
+
+/** The forms whose logical viewport is a runtime variable. */
+export const DYNAMIC_FORMS: readonly TargetForm[] = ["window", "widget"];
+
 export interface DisplayProfile {
   readonly physicalViewport: Viewport;
   readonly logicalViewports: readonly Viewport[];
   /**
-   * Present when the logical viewport is runtime-mutable (desktop windows):
-   * any logical size within [min, max] is admissible, and the host resizes
-   * the core live (`display.viewport.live`). `logicalViewports` then lists
-   * the DEFAULT size a plan bakes assets for.
+   * Present exactly when the target's form is dynamic (window/widget): any
+   * logical size within [min, max] is admissible, and the host resizes the
+   * core live (`display.viewport.live`). `logicalViewports` then lists the
+   * DEFAULT size a plan bakes assets for. `acceptsFixed` opts the target
+   * into hosting fixed-viewport apps in a size-locked window (an app-form
+   * host would set it; a widget shell is not a general app frame and
+   * leaves it off).
    */
-  readonly dynamicViewport?: { readonly min: Viewport; readonly max: Viewport };
+  readonly dynamicViewport?: {
+    readonly min: Viewport;
+    readonly max: Viewport;
+    readonly acceptsFixed?: boolean;
+  };
   readonly presentations: readonly PresentationMode[];
   /**
    * Target raster samples per logical pixel for baked text, vectors, masks,
@@ -41,6 +70,11 @@ export interface DisplayProfile {
 export interface TargetProfile<C extends string = string> {
   /** JS/native HostOps wire generation embedded by the selected backend. */
   readonly hostAbi: number;
+  /** Device/OS substrate ("psp", "vita", "macos", …). Queryable data — the
+   *  target id is only a label. */
+  readonly platform: string;
+  /** Shell posture (see TARGET_FORMS). */
+  readonly form: TargetForm;
   readonly display: DisplayProfile;
   /** Framework APIs implemented and tested by this stock host. */
   readonly capabilities: readonly C[];
@@ -97,22 +131,22 @@ export const POCKET_CAPABILITIES = defineCapabilityRegistry([
 export type PocketCapabilityId = CapabilityId<typeof POCKET_CAPABILITIES>;
 
 /**
- * Production profiles advertise only capabilities delivered by stock hosts.
- *
- * Console targets are named by device (`psp`, `vita`). Host-windowed targets
- * follow `<class>-<form>-<os>`: class names the device family (`desktop`),
- * form the shell posture (`widget` — small always-on-top surface; future
- * `app`, `kiosk`), os the platform (`macos`; future `linux`, `windows`).
- * Form and os both change the truthful profile (viewport ranges, densities,
- * IME/clipboard semantics), so both belong in the id.
+ * Production profiles advertise only capabilities delivered by stock hosts —
+ * the registry is an inventory of REAL, tested hosts, never a combinatorial
+ * grammar. Ids are LABELS: consoles keep bare device names ("psp"), host-
+ * windowed targets read `<platform>-<form>` ("macos-widget") by convention,
+ * and no tooling may parse an id — platform/form are queryable fields on the
+ * profile.
  */
 export const POCKET_TARGETS = defineTargetRegistry<PocketCapabilityId, {
   readonly psp: TargetProfile<PocketCapabilityId>;
   readonly vita: TargetProfile<PocketCapabilityId>;
-  readonly "desktop-widget-macos": TargetProfile<PocketCapabilityId>;
+  readonly "macos-widget": TargetProfile<PocketCapabilityId>;
 }>({
   psp: {
     hostAbi: 1,
+    platform: "psp",
+    form: "takeover",
     display: {
       physicalViewport: [480, 272],
       logicalViewports: [[480, 272]],
@@ -130,6 +164,8 @@ export const POCKET_TARGETS = defineTargetRegistry<PocketCapabilityId, {
   },
   vita: {
     hostAbi: 2,
+    platform: "vita",
+    form: "takeover",
     display: {
       physicalViewport: [960, 544],
       logicalViewports: [[480, 272]],
@@ -148,9 +184,12 @@ export const POCKET_TARGETS = defineTargetRegistry<PocketCapabilityId, {
   // a resizable always-on-top window whose logical viewport IS the window,
   // rendered at density 2 for Retina. No nub, no synthesized cursor — the
   // pointer is real, text comes from the keyboard/IME, and unseen glyphs
-  // bake at runtime.
-  "desktop-widget-macos": {
+  // bake at runtime. A widget shell is not a general app frame, so it does
+  // not accept fixed-viewport apps (a future macos-app target would).
+  "macos-widget": {
     hostAbi: 3,
+    platform: "macos",
+    form: "widget",
     display: {
       physicalViewport: [840, 1120],
       logicalViewports: [[420, 560]],

--- a/spec/pocket-manifest.ts
+++ b/spec/pocket-manifest.ts
@@ -48,12 +48,35 @@ export interface PocketManifestV2 {
     readonly entry: string;
     readonly output?: string;
     readonly framework: "solid" | "vue-vapor";
-    readonly viewport: {
-      readonly logical: Viewport;
-      readonly presentation: PresentationMode;
-    };
+    readonly viewport: ManifestViewport;
   };
 }
+
+/** A fixed-screen viewport declaration (takeover/kiosk/embedded targets). */
+export interface FixedViewportSpec {
+  readonly logical: Viewport;
+  readonly presentation: PresentationMode;
+}
+
+/** A dynamic-window viewport declaration (window/widget targets). */
+export interface DynamicViewportSpec {
+  readonly default: Viewport;
+  readonly min?: Viewport;
+  readonly max?: Viewport;
+}
+
+/**
+ * Apps declare viewport intent per POLICY, not per target: `fixed` admits
+ * on fixed-screen forms, `dynamic` on window forms; declaring both makes a
+ * dual-nature app. The bare `{logical, presentation}` spelling remains
+ * valid as shorthand for `{fixed: …}` (format-2 compatibility).
+ */
+export type ManifestViewport =
+  | FixedViewportSpec
+  | {
+      readonly fixed?: FixedViewportSpec;
+      readonly dynamic?: DynamicViewportSpec;
+    };
 
 const capabilityIdSchema = {
   type: "string",
@@ -130,18 +153,71 @@ export const pocketManifestV2Schema = {
         },
         framework: { enum: ["solid", "vue-vapor"] },
         viewport: {
-          type: "object",
-          additionalProperties: false,
-          required: ["logical", "presentation"],
-          properties: {
-            logical: {
-              type: "array",
-              items: { type: "integer", minimum: 1 },
-              minItems: 2,
-              maxItems: 2,
+          anyOf: [
+            // Shorthand: a bare fixed viewport (format-2 compatibility).
+            {
+              type: "object",
+              additionalProperties: false,
+              required: ["logical", "presentation"],
+              properties: {
+                logical: {
+                  type: "array",
+                  items: { type: "integer", minimum: 1 },
+                  minItems: 2,
+                  maxItems: 2,
+                },
+                presentation: { enum: PRESENTATION_MODES },
+              },
             },
-            presentation: { enum: PRESENTATION_MODES },
-          },
+            // Policy variants: fixed and/or dynamic. An empty object is
+            // schema-valid but semantically caught by the resolver
+            // (viewport.fixedRequired / viewport.dynamicRequired).
+            {
+              type: "object",
+              additionalProperties: false,
+              properties: {
+                fixed: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: ["logical", "presentation"],
+                  properties: {
+                    logical: {
+                      type: "array",
+                      items: { type: "integer", minimum: 1 },
+                      minItems: 2,
+                      maxItems: 2,
+                    },
+                    presentation: { enum: PRESENTATION_MODES },
+                  },
+                },
+                dynamic: {
+                  type: "object",
+                  additionalProperties: false,
+                  required: ["default"],
+                  properties: {
+                    default: {
+                      type: "array",
+                      items: { type: "integer", minimum: 1 },
+                      minItems: 2,
+                      maxItems: 2,
+                    },
+                    min: {
+                      type: "array",
+                      items: { type: "integer", minimum: 1 },
+                      minItems: 2,
+                      maxItems: 2,
+                    },
+                    max: {
+                      type: "array",
+                      items: { type: "integer", minimum: 1 },
+                      minItems: 2,
+                      maxItems: 2,
+                    },
+                  },
+                },
+              },
+            },
+          ],
         },
       },
     },

--- a/src/manifest/resolve.ts
+++ b/src/manifest/resolve.ts
@@ -1,3 +1,4 @@
+import { DYNAMIC_FORMS, TARGET_FORMS } from "../../spec/platforms.ts";
 import type { PocketManifestV2 } from "../../spec/pocket-manifest.ts";
 import {
   POCKET_PLATFORM_CONTRACTS,
@@ -28,27 +29,106 @@ function sameViewport(left: Viewport, right: Viewport): boolean {
   return left[0] === right[0] && left[1] === right[1];
 }
 
-function validateViewport(
+/** The app's viewport intent, normalized: the bare `{logical, presentation}`
+ *  spelling is shorthand for `{fixed: ...}`. */
+function normalizeViewport(viewport: PocketManifestV2["app"]["viewport"]): {
+  fixed?: { logical: Viewport; presentation: PresentationMode };
+  dynamic?: { default: Viewport; min?: Viewport; max?: Viewport };
+} {
+  if ("logical" in viewport) {
+    return { fixed: { logical: viewport.logical, presentation: viewport.presentation } };
+  }
+  return { fixed: viewport.fixed as never, dynamic: viewport.dynamic as never };
+}
+
+const within = (v: Viewport, min: Viewport, max: Viewport): boolean =>
+  v[0] >= min[0] && v[1] >= min[1] && v[0] <= max[0] && v[1] <= max[1];
+
+/**
+ * Pick and validate the viewport variant the target's FORM calls for.
+ * Window/widget forms take the app's `dynamic` variant (or its `fixed` one
+ * size-locked, when the target opts in via acceptsFixed); every other form
+ * requires `fixed`. Returns the resolved plan viewport, or null after
+ * pushing diagnostics.
+ */
+function resolveViewport(
   manifest: PocketManifestV2,
   profile: TargetProfile,
   diagnostics: ContractDiagnostic[],
-): void {
-  const { logical, presentation } = manifest.app.viewport;
-  const { physicalViewport, logicalViewports, dynamicViewport, presentations } = profile.display;
-  // A dynamic target (desktop windows) admits any logical size in range —
-  // the listed logicalViewports are only the default the plan bakes for.
-  const logicalSupported = dynamicViewport
-    ? logical[0] >= dynamicViewport.min[0] &&
-      logical[1] >= dynamicViewport.min[1] &&
-      logical[0] <= dynamicViewport.max[0] &&
-      logical[1] <= dynamicViewport.max[1]
-    : logicalViewports.some((supported) => sameViewport(supported, logical));
-  if (!logicalSupported) {
+): { logical: Viewport; presentation: PresentationMode; physical: Viewport } | null {
+  const viewport = normalizeViewport(manifest.app.viewport);
+  const { physicalViewport, logicalViewports, dynamicViewport, presentations, rasterDensity } =
+    profile.display;
+  const dynamicTarget = DYNAMIC_FORMS.includes(profile.form);
+
+  if (dynamicTarget) {
+    const range = dynamicViewport!;
+    if (viewport.dynamic) {
+      const size = viewport.dynamic.default;
+      if (!within(size, range.min, range.max)) {
+        diagnostics.push({
+          code: "viewport.logicalUnsupported",
+          path: "/app/viewport/dynamic/default",
+          message: `target admits ${range.min[0]}x${range.min[1]} through ${range.max[0]}x${range.max[1]}, not ${size[0]}x${size[1]}`,
+        });
+        return null;
+      }
+      return {
+        logical: size,
+        presentation: "native",
+        physical: [size[0] * rasterDensity, size[1] * rasterDensity],
+      };
+    }
+    if (viewport.fixed) {
+      if (!range.acceptsFixed) {
+        diagnostics.push({
+          code: "viewport.fixedUnhosted",
+          path: "/app/viewport",
+          message: `${profile.form}-form target does not host fixed-viewport apps — declare a dynamic viewport variant`,
+        });
+        return null;
+      }
+      const size = viewport.fixed.logical;
+      if (!within(size, range.min, range.max)) {
+        diagnostics.push({
+          code: "viewport.logicalUnsupported",
+          path: "/app/viewport/fixed/logical",
+          message: `target admits ${range.min[0]}x${range.min[1]} through ${range.max[0]}x${range.max[1]}, not ${size[0]}x${size[1]}`,
+        });
+        return null;
+      }
+      // Size-locked window: presented 1 logical px = density physical px.
+      return {
+        logical: size,
+        presentation: "native",
+        physical: [size[0] * rasterDensity, size[1] * rasterDensity],
+      };
+    }
+    diagnostics.push({
+      code: "viewport.dynamicRequired",
+      path: "/app/viewport",
+      message: "target has a dynamic window — declare a dynamic viewport variant",
+    });
+    return null;
+  }
+
+  if (!viewport.fixed) {
+    diagnostics.push({
+      code: "viewport.fixedRequired",
+      path: "/app/viewport",
+      message: "target has a fixed screen — declare a fixed viewport variant",
+    });
+    return null;
+  }
+  const { logical, presentation } = viewport.fixed;
+  let ok = true;
+  if (!logicalViewports.some((supported) => sameViewport(supported, logical))) {
     diagnostics.push({
       code: "viewport.logicalUnsupported",
       path: "/app/viewport/logical",
       message: `target does not support logical viewport ${logical[0]}x${logical[1]}`,
     });
+    ok = false;
   }
   if (!presentations.includes(presentation)) {
     diagnostics.push({
@@ -56,23 +136,19 @@ function validateViewport(
       path: "/app/viewport/presentation",
       message: `target does not support ${JSON.stringify(presentation)} presentation`,
     });
+    ok = false;
   }
   // Native presentation: one logical px maps to rasterDensity physical px.
-  // Fixed targets must match their panel exactly; dynamic targets size the
-  // window to the viewport, so there is nothing to mismatch.
   if (
     presentation === "native" &&
-    !dynamicViewport &&
-    !sameViewport(
-      [logical[0] * profile.display.rasterDensity, logical[1] * profile.display.rasterDensity],
-      physicalViewport,
-    )
+    !sameViewport([logical[0] * rasterDensity, logical[1] * rasterDensity], physicalViewport)
   ) {
     diagnostics.push({
       code: "viewport.nativeMismatch",
       path: "/app/viewport",
       message: "native presentation requires the logical viewport to fill the panel",
     });
+    ok = false;
   }
   if (presentation === "integer-fit") {
     const x = physicalViewport[0] / logical[0];
@@ -83,8 +159,10 @@ function validateViewport(
         path: "/app/viewport",
         message: "integer-fit requires one positive integer scale on both axes",
       });
+      ok = false;
     }
   }
+  return ok ? { logical, presentation, physical: [physicalViewport[0], physicalViewport[1]] } : null;
 }
 
 /** Validate framework-owned registry data before trusting it in resolution. */
@@ -114,6 +192,28 @@ export function validatePlatformContractRegistry(
         code: "registry.invalidRasterDensity",
         path: `/targets/${targetId}/display/rasterDensity`,
         message: "target rasterDensity must be an integer from 1 through 255",
+      });
+    }
+    if (!TARGET_FORMS.includes(target.form)) {
+      diagnostics.push({
+        code: "registry.invalidForm",
+        path: `/targets/${targetId}/form`,
+        message: `target form must be one of ${TARGET_FORMS.join(", ")}`,
+      });
+    }
+    const dynamicForm = DYNAMIC_FORMS.includes(target.form);
+    if (dynamicForm && !target.display.dynamicViewport) {
+      diagnostics.push({
+        code: "registry.dynamicViewportMissing",
+        path: `/targets/${targetId}/display`,
+        message: `${target.form}-form targets must declare display.dynamicViewport`,
+      });
+    }
+    if (!dynamicForm && target.display.dynamicViewport) {
+      diagnostics.push({
+        code: "registry.dynamicViewportForbidden",
+        path: `/targets/${targetId}/display/dynamicViewport`,
+        message: `${target.form}-form targets have a fixed screen — remove dynamicViewport`,
       });
     }
     const provided = new Set<string>();
@@ -155,7 +255,7 @@ export function resolveBuildPlan(
     return { ok: false, diagnostics };
   }
 
-  validateViewport(manifest, profile, diagnostics);
+  const resolvedViewport = resolveViewport(manifest, profile, diagnostics);
 
   const known = new Set<string>(registry.capabilities);
   const provided = new Set<string>(profile.capabilities);
@@ -216,10 +316,10 @@ export function resolveBuildPlan(
     });
   }
 
-  if (diagnostics.length > 0) return { ok: false, diagnostics };
+  if (diagnostics.length > 0 || !resolvedViewport) return { ok: false, diagnostics };
 
-  const logical: Viewport = [manifest.app.viewport.logical[0], manifest.app.viewport.logical[1]];
-  const physical: Viewport = [profile.display.physicalViewport[0], profile.display.physicalViewport[1]];
+  const logical: Viewport = [resolvedViewport.logical[0], resolvedViewport.logical[1]];
+  const physical: Viewport = [resolvedViewport.physical[0], resolvedViewport.physical[1]];
   // Plain codepoint sort — the same ordering canonicalJson uses for the plan
   // hash, so the pretty plan.json never depends on ICU collation.
   const features = Object.fromEntries(
@@ -241,7 +341,7 @@ export function resolveBuildPlan(
     viewport: {
       logical,
       physical,
-      presentation: manifest.app.viewport.presentation,
+      presentation: resolvedViewport.presentation,
       rasterDensity: profile.display.rasterDensity,
     },
     features,

--- a/test/platform-contracts.test.ts
+++ b/test/platform-contracts.test.ts
@@ -42,6 +42,8 @@ const syntheticTargetDefinitions = {
   psp: POCKET_TARGETS.psp,
   "vita-test": {
     hostAbi: 2,
+    platform: "vita",
+    form: "takeover",
     display: {
       physicalViewport: [960, 544],
       logicalViewports: [[480, 272]],
@@ -122,7 +124,7 @@ describe("pocket.json v2 schema", () => {
 
 describe("platform registry", () => {
   test("production advertises only the truthful stock-host profiles", () => {
-    expect(Object.keys(POCKET_TARGETS)).toEqual(["psp", "vita", "desktop-widget-macos"]);
+    expect(Object.keys(POCKET_TARGETS)).toEqual(["psp", "vita", "macos-widget"]);
     expect(validatePlatformContractRegistry(POCKET_PLATFORM_CONTRACTS)).toEqual([]);
     expect(POCKET_TARGETS.psp.capabilities).toEqual([
       "input.analog.left",
@@ -145,7 +147,7 @@ describe("platform registry", () => {
     });
     // The desktop widget target: dynamic viewport, real pointer/text/IME,
     // runtime glyph baking — and honestly NO nub or synthesized cursor.
-    expect(POCKET_TARGETS["desktop-widget-macos"].capabilities).toEqual([
+    expect(POCKET_TARGETS["macos-widget"].capabilities).toEqual([
       "input.buttons",
       "input.ime",
       "input.pointer",
@@ -155,7 +157,7 @@ describe("platform registry", () => {
       "text.glyphs.baked",
       "text.glyphs.runtime",
     ]);
-    expect(POCKET_TARGETS["desktop-widget-macos"].display.dynamicViewport).toEqual({
+    expect(POCKET_TARGETS["macos-widget"].display.dynamicViewport).toEqual({
       min: [240, 180],
       max: [4096, 4096],
     });
@@ -220,10 +222,10 @@ describe("semantic resolution", () => {
 
   test("resolves the note's dual-nature manifest against the desktop widget", async () => {
     const manifest = await Bun.file(new URL("../demos/note/pocket.json", import.meta.url)).json();
-    const result = validateAndResolveBuildPlan(manifest, { target: "desktop-widget-macos" });
+    const result = validateAndResolveBuildPlan(manifest, { target: "macos-widget" });
     expect(result.ok).toBe(true);
     if (!result.ok) return;
-    expect(result.plan.target).toEqual({ id: "desktop-widget-macos", hostAbi: 3 });
+    expect(result.plan.target).toEqual({ id: "macos-widget", hostAbi: 3 });
     // Dynamic-viewport native presentation: density from the profile.
     expect(result.plan.viewport.rasterDensity).toBe(2);
     expect(result.plan.viewport.logical).toEqual([420, 560]);
@@ -249,20 +251,20 @@ describe("semantic resolution", () => {
   test("dynamic viewport admits in-range sizes and rejects out-of-range", async () => {
     const manifest = await Bun.file(new URL("../demos/note/pocket.json", import.meta.url)).json();
     const tiny = structuredClone(manifest) as any;
-    tiny.app.viewport.logical = [100, 100];
-    const rejected = validateAndResolveBuildPlan(tiny, { target: "desktop-widget-macos" });
+    tiny.app.viewport.dynamic.default = [100, 100];
+    const rejected = validateAndResolveBuildPlan(tiny, { target: "macos-widget" });
     expect(rejected.ok).toBe(false);
     if (rejected.ok) return;
     expect(rejected.diagnostics.map((d) => d.code)).toContain("viewport.logicalUnsupported");
 
     const roomy = structuredClone(manifest) as any;
-    roomy.app.viewport.logical = [800, 600];
-    expect(validateAndResolveBuildPlan(roomy, { target: "desktop-widget-macos" }).ok).toBe(true);
+    roomy.app.viewport.dynamic.default = [800, 600];
+    expect(validateAndResolveBuildPlan(roomy, { target: "macos-widget" }).ok).toBe(true);
   });
 
   test("every committed demo manifest lands on the expected admission matrix", async () => {
     const { readdirSync, existsSync } = await import("node:fs");
-    // demo -> [psp, vita, desktop-widget-macos] admission. Console demos
+    // demo -> [psp, vita, macos-widget] admission. Console demos
     // stay off the desktop widget (its profile presents "native" over a
     // dynamic viewport, not the console integer-fit contract); the note is
     // the inverse. A new demo missing here fails the test on purpose.
@@ -284,7 +286,7 @@ describe("semantic resolution", () => {
       stats: [true, true, false],
       zoomlab: [true, true, false],
     };
-    const targets = ["psp", "vita", "desktop-widget-macos"] as const;
+    const targets = ["psp", "vita", "macos-widget"] as const;
     for (const demo of readdirSync(new URL("../demos/", import.meta.url)).sort()) {
       const url = new URL(`../demos/${demo}/pocket.json`, import.meta.url);
       if (!existsSync(url)) continue;
@@ -299,6 +301,37 @@ describe("semantic resolution", () => {
     // manifests are shown — the note stays off the landing/playground.
     const note = await Bun.file(new URL("../demos/note/pocket.json", import.meta.url)).json();
     expect(validateAndResolveBuildPlan(note, { target: "psp" }).ok).toBe(false);
+  });
+
+  test("viewport policy: legacy shorthand, dynamic-required, fixed-unhosted", async () => {
+    // The bare {logical, presentation} spelling is shorthand for {fixed}.
+    const legacy = structuredClone(portableInput) as any;
+    legacy.app.viewport = { logical: [480, 272], presentation: "integer-fit" };
+    expect(validateAndResolveBuildPlan(legacy, { target: "psp" }).ok).toBe(true);
+
+    // A dynamic-only app is refused by fixed-screen forms…
+    const note = await Bun.file(new URL("../demos/note/pocket.json", import.meta.url)).json();
+    const onPsp = validateAndResolveBuildPlan(note, { target: "psp" });
+    expect(onPsp.ok).toBe(false);
+    if (!onPsp.ok) return;
+    expect(onPsp.diagnostics.map((d) => d.code)).toContain("viewport.fixedRequired");
+  });
+
+  test("widget form does not host fixed-viewport apps (acceptsFixed off)", () => {
+    const fixedOnly = structuredClone(portableInput) as any;
+    fixedOnly.engine.capabilities.requires = ["text.glyphs.baked", "input.buttons"];
+    const result = validateAndResolveBuildPlan(fixedOnly, { target: "macos-widget" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnostics.map((d) => d.code)).toContain("viewport.fixedUnhosted");
+  });
+
+  test("profiles carry queryable platform/form fields — ids are labels", () => {
+    expect(POCKET_TARGETS.psp.platform).toBe("psp");
+    expect(POCKET_TARGETS.psp.form).toBe("takeover");
+    expect(POCKET_TARGETS.vita.form).toBe("takeover");
+    expect(POCKET_TARGETS["macos-widget"].platform).toBe("macos");
+    expect(POCKET_TARGETS["macos-widget"].form).toBe("widget");
   });
 
   test("stock-demo builds prefer the demo's own manifest over synthesis", async () => {


### PR DESCRIPTION
Follows the review direction on #129: the framework will span console takeover, desktop apps/widgets, kiosks and launchers — so target **semantics move into queryable fields, and names go back to being labels**.

## What changed

- **`TargetProfile.platform` + `TargetProfile.form`** (`takeover | window | widget | kiosk | embedded`). Nothing may parse a target id anymore; the registry stays an inventory of real, tested hosts. `desktop-widget-macos` → **`macos-widget`** (label convention `<platform>-<form>`; consoles keep bare device names). Registry validation enforces coherence: dynamic forms must declare `display.dynamicViewport`, fixed forms must not.
- **Viewport intent is declared per policy, not per target**:

  ```json
  "viewport": {
    "fixed":   { "logical": [480, 272], "presentation": "integer-fit" },
    "dynamic": { "default": [420, 560], "min": [240, 180] }
  }
  ```

  Declaring both makes a dual-nature app. The bare `{logical, presentation}` spelling remains valid as fixed shorthand (schema `anyOf`, format-2 id unchanged, deployed schema regenerated).
- **Asymmetric hosting rule**: dynamic targets may opt into hosting fixed-viewport apps in a size-locked window (`dynamicViewport.acceptsFixed` — a future `macos-app` would set it; the widget shell honestly does not). Fixed targets never host dynamic-only apps: `viewport.fixedRequired` at resolve time.
- All 17 committed manifests migrated to the variant spelling; resolved plan shapes are byte-identical (plan fixtures untouched).
- **Launchers add nothing**: a launcher is an ordinary app; apps inside a launcher compose through capability pass-through. No per-launcher targets, by design.

## Verification

26 contract tests (policy admission both ways, registry coherence, field truthfulness, legacy shorthand), umbrella suite, 49/49 pixel goldens, site build, `bun run note --proof` — all green. Admission matrix unchanged: console demos psp ✓ / vita ✓ / macos-widget ✗, note the inverse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
