### PR TITLE
fix(video-outro): add X-compatible exports

### DIFF
--- a/skills/pocketjs-video-outro/SKILL.md
+++ b/skills/pocketjs-video-outro/SKILL.md
@@ -45,6 +45,24 @@ bun skills/pocketjs-video-outro/scripts/make-outro.ts -i ~/Downloads/clip.mov
 # prints the output path on stdout; progress/summary on stderr
 ```
 
+For an X upload, enable the compatibility mode. It produces 30 fps CFR video,
+uses a conventional 30 kHz track timebase, closes GOPs, caps bitrate, and scales
+landscape/portrait footage within 1920x1080 or 1080x1900:
+
+```bash
+bun skills/pocketjs-video-outro/scripts/make-outro.ts -i ~/Downloads/clip.mov --x
+# writes ~/Downloads/clip_outro_x.mp4, leaving a standard outro export untouched
+```
+
+For X-mode verification, both reported rates must be `30/1`, the timebase must be
+`1/30000`, and the dimensions must stay within the orientation-aware 1080p bounds:
+
+```bash
+ffprobe -v error -select_streams v:0 \
+  -show_entries stream=width,height,r_frame_rate,avg_frame_rate,time_base \
+  -of default=nw=1 ~/Downloads/clip_outro_x.mp4
+```
+
 Then **verify visually** — extract a frame near the end and eyeball the card, and
 confirm the tail is silent while the body kept its audio (the animation is the
 whole point; always look):
@@ -63,18 +81,24 @@ ffprobe -v error -select_streams v:0 \
 | Flag | Default | Purpose |
 |------|---------|---------|
 | `-i` / `--input` | — (required) | input video |
-| `-o` / `--output` | `<input>_outro.mp4` next to input | output path |
+| `-o` / `--output` | `<input>_outro.mp4` next to input | output path (`_outro_x.mp4` with `--x`) |
 | `--tagline` | `Bare Metal Modern Web` | hero line (wraps on narrow/portrait frames) |
 | `--brand` | `PocketJS` | wordmark next to the glyph |
 | `--url` | `pocketjs.dev` | footer line; pass `--url ""` to hide it |
 | `--outro` | `5.5` | end-card length in seconds |
 | `--xfade` | `0.8` | crossfade length; text entrance keys off it |
 | `--crf` / `--preset` | `18` / `medium` | x264 quality/speed |
+| `--x` / `--x-compatible` | off | emit an X-safe 30fps CFR social upload |
 
 ## How it adapts to the input
 
-- Probes width/height/fps/duration; the card is rendered at the source's native
-  resolution and re-timed to its fps, so the crossfade is seamless.
+- Probes width/height/fps/duration; VFR inputs use `avg_frame_rate` rather than
+  treating `r_frame_rate` as the real cadence. The selected rational rate is passed
+  directly to FFmpeg, avoiding floating-point timebases.
+- By default the card uses the source's native resolution and selected frame rate.
+  `--x` switches to 30 fps CFR and orientation-aware 1920x1080/1080x1900 bounds.
+- Display-matrix rotation is applied to the probed dimensions before rendering the
+  card, matching FFmpeg's default autorotation for portrait phone footage.
 - **Color:** SDR inputs keep the existing path. HLG and PQ inputs (including the
   HLG base layer in iPhone Dolby Vision clips) are tone-mapped to 8-bit BT.709 SDR;
   Dolby Vision metadata is intentionally not carried into the shareable H.264 file.
@@ -109,6 +133,9 @@ ffprobe -v error -select_streams v:0 \
   4:4:4 or non-faststart MP4s.
 - `xfade` needs both sides normalized to identical size/fps/sar/pix_fmt; the graph
   does this. If you feed a variable-frame-rate capture, the `fps` filter conforms it.
+- ReplayKit and other VFR captures can report a high `r_frame_rate` that represents
+  their smallest frame interval, not their real cadence. Keep average-rate priority
+  and the original rational expression when changing probe logic.
 - Do not remove the explicit sRGB-to-BT.709 conversion from the card layers when
   changing HDR handling. Retagging Chrome's SDR PNG values as HLG/PQ is not a valid
   color conversion and makes the card shift on an HDR-aware display.

--- a/skills/pocketjs-video-outro/scripts/make-outro.ts
+++ b/skills/pocketjs-video-outro/scripts/make-outro.ts
@@ -11,7 +11,7 @@
 // Usage:
 //   bun skills/pocketjs-video-outro/scripts/make-outro.ts -i input.mov [-o out.mp4]
 //        [--tagline STR] [--brand STR] [--url STR] [--outro SECS] [--xfade SECS]
-//        [--crf N] [--preset P]
+//        [--crf N] [--preset P] [--x]
 //
 // Defaults: brand "PocketJS", tagline "Bare Metal Modern Web", url "pocketjs.dev",
 // outro 5.5s, xfade 0.8s, crf 18, preset medium. Pass --url "" to hide the url.
@@ -35,6 +35,7 @@ type Args = {
   xfade: number;
   crf: number;
   preset: string;
+  xCompatible: boolean;
 };
 
 function usage(): never {
@@ -44,7 +45,7 @@ function usage(): never {
       "  bun skills/pocketjs-video-outro/scripts/make-outro.ts -i <input> [options]",
       "",
       "options:",
-      "  -o, --output <path>   output file (default: <input>_outro.mp4 next to input)",
+      "  -o, --output <path>   output file (default: <input>_outro[_x].mp4 next to input)",
       '  --tagline <str>       hero line (default: "Bare Metal Modern Web")',
       '  --brand <str>         wordmark (default: "PocketJS")',
       '  --url <str>           footer line (default: "pocketjs.dev"; "" hides it)',
@@ -52,6 +53,7 @@ function usage(): never {
       "  --xfade <secs>        crossfade length (default: 0.8)",
       "  --crf <n>             x264 quality (default: 18)",
       "  --preset <p>          x264 preset (default: medium)",
+      "  --x, --x-compatible   export X-safe 30fps CFR within web upload bounds",
     ].join("\n"),
   );
   process.exit(2);
@@ -62,7 +64,7 @@ function need(v: string | undefined, flag: string): string {
   return v;
 }
 
-function parseArgs(argv: string[]): Args {
+export function parseArgs(argv: string[]): Args {
   if (argv.includes("-h") || argv.includes("--help")) usage();
   let input: string | undefined;
   let output: string | undefined;
@@ -73,6 +75,7 @@ function parseArgs(argv: string[]): Args {
   let xfade = 0.8;
   let crf = 18;
   let preset = "medium";
+  let xCompatible = false;
 
   for (let i = 0; i < argv.length; i += 1) {
     const a = argv[i];
@@ -85,6 +88,7 @@ function parseArgs(argv: string[]): Args {
     else if (a === "--xfade") xfade = Number(need(argv[++i], a));
     else if (a === "--crf") crf = Number(need(argv[++i], a));
     else if (a === "--preset") preset = need(argv[++i], a);
+    else if (a === "--x" || a === "--x-compatible") xCompatible = true;
     else usage();
   }
 
@@ -95,9 +99,10 @@ function parseArgs(argv: string[]): Args {
 
   if (!output) {
     const dir = resolve(dirname(input));
-    output = join(dir, `${basename(input, extname(input))}_outro.mp4`);
+    const suffix = xCompatible ? "_outro_x.mp4" : "_outro.mp4";
+    output = join(dir, `${basename(input, extname(input))}${suffix}`);
   }
-  return { input, output, brand, tagline, url, outro, xfade, crf, preset };
+  return { input, output, brand, tagline, url, outro, xfade, crf, preset, xCompatible };
 }
 
 const CHROME_CANDIDATES = [
@@ -126,6 +131,8 @@ type ProbeStream = {
   color_transfer?: string;
   color_primaries?: string;
   color_range?: string;
+  tags?: { rotate?: string };
+  side_data_list?: Array<{ rotation?: number | string }>;
 };
 
 type ProbeOutput = {
@@ -141,6 +148,51 @@ function frameRate(value: string | undefined): number {
   return Number.isFinite(fps) ? fps : 0;
 }
 
+type ParsedFrameRate = { fps: number; rate: string };
+
+function parsedFrameRate(value: string | undefined): ParsedFrameRate | undefined {
+  const fps = frameRate(value);
+  return fps > 0 && value ? { fps, rate: value } : undefined;
+}
+
+export function displayDimensions(video: ProbeStream) {
+  const codedW = Number(video.width);
+  const codedH = Number(video.height);
+  const sideRotation = video.side_data_list?.find((entry) => entry.rotation !== undefined)?.rotation;
+  const parsedRotation = Number(sideRotation ?? video.tags?.rotate ?? 0);
+  const rotation = Number.isFinite(parsedRotation) ? ((parsedRotation % 360) + 360) % 360 : 0;
+  const swapsAxes = Math.abs(rotation - 90) < 0.5 || Math.abs(rotation - 270) < 0.5;
+  return swapsAxes
+    ? { w: codedH, h: codedW, rotation }
+    : { w: codedW, h: codedH, rotation };
+}
+
+export function fitWithin(w: number, h: number, maxW: number, maxH: number) {
+  const factor = Math.min(1, maxW / w, maxH / h);
+  const even = (value: number, limit: number) => (
+    Math.min(limit - (limit % 2), Math.max(2, (factor < 1 ? Math.round(value / 2) : Math.floor(value / 2)) * 2))
+  );
+  return { w: even(w * factor, maxW), h: even(h * factor, maxH) };
+}
+
+export function resolveOutputSpec(
+  input: { w: number; h: number; fps: number; fpsRate: string },
+  xCompatible: boolean,
+) {
+  if (!xCompatible) return input;
+  const limits = input.h > input.w ? { w: 1080, h: 1900 } : { w: 1920, h: 1080 };
+  return { ...fitWithin(input.w, input.h, limits.w, limits.h), fps: 30, fpsRate: "30/1" };
+}
+
+export function xCompatibilityArgs(enabled: boolean): string[] {
+  if (!enabled) return [];
+  return [
+    "-level:v", "4.0", "-r", "30", "-fps_mode:v", "cfr", "-video_track_timescale", "30000",
+    "-g", "60", "-keyint_min", "60", "-sc_threshold", "0", "-flags:v", "+cgop",
+    "-x264-params", "open-gop=0", "-maxrate", "8M", "-bufsize", "16M",
+  ];
+}
+
 export function parseProbeOutput(raw: string) {
   let output: ProbeOutput;
   try {
@@ -150,9 +202,13 @@ export function parseProbeOutput(raw: string) {
   }
 
   const video = output.streams?.find((stream) => stream.codec_type === "video");
-  const w = Number(video?.width);
-  const h = Number(video?.height);
-  const fps = frameRate(video?.r_frame_rate) || frameRate(video?.avg_frame_rate);
+  const { w, h, rotation } = displayDimensions(video ?? {});
+  // For VFR captures r_frame_rate is often only the stream's smallest frame
+  // interval (ReplayKit commonly reports 120/1). avg_frame_rate represents the
+  // actual timeline and must win; preserve its rational form for FFmpeg filters.
+  const selectedFrameRate = parsedFrameRate(video?.avg_frame_rate) ?? parsedFrameRate(video?.r_frame_rate);
+  const fps = selectedFrameRate?.fps ?? 0;
+  const fpsRate = selectedFrameRate?.rate ?? "";
   const dur = Number(output.format?.duration);
   const audioStreams = output.streams?.filter((stream) => stream.codec_type === "audio").length ?? 0;
   const colorSpace = video?.color_space ?? "";
@@ -163,11 +219,11 @@ export function parseProbeOutput(raw: string) {
   if (![w, h, fps, dur].every((value) => Number.isFinite(value) && value > 0)) {
     throw new Error("could not probe input width/height/fps/duration");
   }
-  return { w, h, fps, dur, audioStreams, colorSpace, colorTransfer, colorPrimaries, colorRange };
+  return { w, h, rotation, fps, fpsRate, dur, audioStreams, colorSpace, colorTransfer, colorPrimaries, colorRange };
 }
 
 async function probe(input: string) {
-  const entries = "stream=codec_type,width,height,r_frame_rate,avg_frame_rate,color_space,color_transfer,color_primaries,color_range:format=duration";
+  const entries = "stream=codec_type,width,height,r_frame_rate,avg_frame_rate,color_space,color_transfer,color_primaries,color_range:stream_tags=rotate:stream_side_data=rotation:format=duration";
   const raw = await $`ffprobe -v error -show_entries ${entries} -of json ${input}`.quiet().text();
   return parseProbeOutput(raw);
 }
@@ -199,8 +255,12 @@ async function main() {
   await $`command -v ffprobe`.quiet().then(undefined, () => { throw new Error("ffprobe not found on PATH"); });
 
   const chrome = await findChrome();
-  const { w, h, fps, dur, audioStreams, colorSpace, colorTransfer, colorPrimaries, colorRange } = await probe(a.input);
+  const input = await probe(a.input);
+  const { w, h, fps, fpsRate } = resolveOutputSpec(input, a.xCompatible);
+  const { w: inputW, h: inputH, rotation, fps: inputFps, fpsRate: inputFpsRate, dur, audioStreams, colorSpace, colorTransfer, colorPrimaries, colorRange } = input;
   const isHdr = colorTransfer === "arib-std-b67" || colorTransfer === "smpte2084";
+  const isBt709 = colorSpace === "bt709" && colorTransfer === "bt709" && colorPrimaries === "bt709";
+  const outputIsBt709Tv = isHdr || (isBt709 && colorRange !== "pc");
   const hdrColorSpace = isHdr
     ? hdrColorValue(colorSpace, SWSCALE_MATRICES, "bt2020nc", "matrix")
     : "";
@@ -231,8 +291,9 @@ async function main() {
   const t0 = l0 + 0.35;
   const u0 = t0 + 0.6;
 
-  console.error(`input : ${w}x${h} @ ${fps.toFixed(3)}fps  dur=${dur}s  audio-streams=${audioStreams}`);
+  console.error(`input : ${inputW}x${inputH} @ ${inputFps.toFixed(3)}fps (${inputFpsRate})  dur=${dur}s  audio-streams=${audioStreams}${rotation ? `  rotation=${rotation}` : ""}`);
   console.error(`color : ${[colorSpace, colorTransfer, colorPrimaries, colorRange].filter(Boolean).join("/") || "unspecified"}${isHdr ? " -> bt709 SDR" : ""}`);
+  console.error(`video : ${w}x${h} @ ${fps.toFixed(3)}fps (${fpsRate})${a.xCompatible ? "  X-compatible CFR" : ""}`);
   console.error(`card  : scale=${scale.toFixed(4)}  outro=${a.outro}s  xfade=${a.xfade}s (offset=${offset.toFixed(3)}s)`);
   console.error(`output: ${a.output}`);
 
@@ -259,14 +320,14 @@ async function main() {
       : `scale=${w}:${h},setsar=1,format=yuv420p`;
     const outputColor = isHdr ? `,${bt709}` : "";
     const graphLines = [
-      `[1:v]${cardColor}setsar=1,fps=${fps},format=yuv420p${outputColor},setpts=PTS-STARTPTS[bg];`,
-      `[2:v]${cardColor}fps=${fps},format=yuva420p${outputColor},fade=t=in:st=${f(l0)}:d=0.60:alpha=1,setpts=PTS-STARTPTS[lg];`,
-      `[3:v]${cardColor}fps=${fps},format=yuva420p${outputColor},fade=t=in:st=${f(t0)}:d=0.60:alpha=1,setpts=PTS-STARTPTS[tg];`,
-      `[4:v]${cardColor}fps=${fps},format=yuva420p${outputColor},fade=t=in:st=${f(u0)}:d=0.50:alpha=1,setpts=PTS-STARTPTS[ur];`,
+      `[1:v]${cardColor}setsar=1,fps=${fpsRate},format=yuv420p${outputColor},setpts=PTS-STARTPTS[bg];`,
+      `[2:v]${cardColor}fps=${fpsRate},format=yuva420p${outputColor},fade=t=in:st=${f(l0)}:d=0.60:alpha=1,setpts=PTS-STARTPTS[lg];`,
+      `[3:v]${cardColor}fps=${fpsRate},format=yuva420p${outputColor},fade=t=in:st=${f(t0)}:d=0.60:alpha=1,setpts=PTS-STARTPTS[tg];`,
+      `[4:v]${cardColor}fps=${fpsRate},format=yuva420p${outputColor},fade=t=in:st=${f(u0)}:d=0.50:alpha=1,setpts=PTS-STARTPTS[ur];`,
       `[bg][lg]overlay=x=0:y='${slideL}*pow(1-clip((t-${f(l0)})/0.60,0,1),3)'[o1];`,
       `[o1][tg]overlay=x=0:y='${slideT}*pow(1-clip((t-${f(t0)})/0.60,0,1),3)'[o2];`,
       `[o2][ur]overlay=x=0:y='${slideU}*pow(1-clip((t-${f(u0)})/0.50,0,1),3)',format=yuv420p${outputColor},setpts=PTS-STARTPTS[outro];`,
-      `[0:v]fps=${fps},${mainColor},setpts=PTS-STARTPTS[main];`,
+      `[0:v]fps=${fpsRate},${mainColor},setpts=PTS-STARTPTS[main];`,
       `[main][outro]xfade=transition=fade:duration=${a.xfade}:offset=${offset.toFixed(3)},format=yuv420p${outputColor}[v];`,
     ];
 
@@ -296,7 +357,8 @@ async function main() {
       "-filter_complex_script", graphPath,
       ...maps,
       "-c:v", "libx264", "-profile:v", "high", "-crf", String(a.crf), "-preset", a.preset, "-pix_fmt", "yuv420p",
-      ...(isHdr ? ["-color_range", "tv", "-colorspace", "bt709", "-color_trc", "bt709", "-color_primaries", "bt709"] : []),
+      ...(outputIsBt709Tv ? ["-color_range", "tv", "-colorspace", "bt709", "-color_trc", "bt709", "-color_primaries", "bt709"] : []),
+      ...xCompatibilityArgs(a.xCompatible),
       "-movflags", "+faststart", "-shortest",
       a.output,
     ];

--- a/test/video-outro.test.ts
+++ b/test/video-outro.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, test } from "bun:test";
-import { parseProbeOutput } from "../skills/pocketjs-video-outro/scripts/make-outro.ts";
+import {
+  parseArgs,
+  parseProbeOutput,
+  resolveOutputSpec,
+  xCompatibilityArgs,
+} from "../skills/pocketjs-video-outro/scripts/make-outro.ts";
 
 describe("parseProbeOutput", () => {
   test("reads an iPhone HDR MOV with audio and data streams", () => {
@@ -30,7 +35,9 @@ describe("parseProbeOutput", () => {
     expect(result).toEqual({
       w: 1920,
       h: 1080,
+      rotation: 0,
       fps: 30,
+      fpsRate: "30/1",
       dur: 77.2,
       audioStreams: 2,
       colorSpace: "bt2020nc",
@@ -40,20 +47,131 @@ describe("parseProbeOutput", () => {
     });
   });
 
-  test("falls back to the average frame rate", () => {
+  test("prefers the average frame rate for a VFR ReplayKit capture", () => {
     const result = parseProbeOutput(JSON.stringify({
       streams: [
-        { codec_type: "video", width: "1080", height: "1920", r_frame_rate: "0/0", avg_frame_rate: "30000/1001" },
+        { codec_type: "video", width: "2200", height: "1428", r_frame_rate: "120/1", avg_frame_rate: "117600/2633" },
+      ],
+      format: { duration: 43.541667 },
+    }));
+
+    expect(result.fps).toBeCloseTo(44.664, 3);
+    expect(result.fpsRate).toBe("117600/2633");
+  });
+
+  test("falls back to the nominal frame rate when the average is unavailable", () => {
+    const result = parseProbeOutput(JSON.stringify({
+      streams: [
+        { codec_type: "video", width: "1080", height: "1920", r_frame_rate: "30000/1001", avg_frame_rate: "0/0" },
       ],
       format: { duration: 12.5 },
     }));
 
     expect(result.fps).toBeCloseTo(29.97, 2);
+    expect(result.fpsRate).toBe("30000/1001");
+  });
+
+  test("uses display dimensions for a rotated portrait video", () => {
+    const result = parseProbeOutput(JSON.stringify({
+      streams: [{
+        codec_type: "video",
+        width: 1920,
+        height: 1080,
+        r_frame_rate: "30/1",
+        avg_frame_rate: "30/1",
+        side_data_list: [{ rotation: 90 }],
+      }],
+      format: { duration: 10 },
+    }));
+
+    expect({ w: result.w, h: result.h, rotation: result.rotation }).toEqual({ w: 1080, h: 1920, rotation: 90 });
+    expect(resolveOutputSpec(result, true)).toEqual({ w: 1068, h: 1900, fps: 30, fpsRate: "30/1" });
+  });
+
+  test("normalizes a negative rotation tag", () => {
+    const result = parseProbeOutput(JSON.stringify({
+      streams: [{
+        codec_type: "video",
+        width: 1920,
+        height: 1080,
+        r_frame_rate: "30/1",
+        avg_frame_rate: "30/1",
+        tags: { rotate: "-90" },
+      }],
+      format: { duration: 10 },
+    }));
+
+    expect({ w: result.w, h: result.h, rotation: result.rotation }).toEqual({ w: 1080, h: 1920, rotation: 270 });
   });
 
   test("rejects incomplete metadata", () => {
     expect(() => parseProbeOutput('{"streams":[],"format":{}}')).toThrow(
       "could not probe input width/height/fps/duration",
     );
+  });
+});
+
+describe("resolveOutputSpec", () => {
+  test("makes a landscape ReplayKit capture X-compatible", () => {
+    expect(resolveOutputSpec({ w: 2200, h: 1428, fps: 44.664, fpsRate: "117600/2633" }, true)).toEqual({
+      w: 1664,
+      h: 1080,
+      fps: 30,
+      fpsRate: "30/1",
+    });
+  });
+
+  test("keeps portrait output within X's 1900px web-upload height", () => {
+    expect(resolveOutputSpec({ w: 1440, h: 2560, fps: 60, fpsRate: "60/1" }, true)).toEqual({
+      w: 1068,
+      h: 1900,
+      fps: 30,
+      fpsRate: "30/1",
+    });
+  });
+
+  test("preserves the source spec without the X preset", () => {
+    const input = { w: 3840, h: 2160, fps: 60, fpsRate: "60/1" };
+    expect(resolveOutputSpec(input, false)).toEqual(input);
+  });
+
+  test("does not enlarge an already-small odd-sized source", () => {
+    expect(resolveOutputSpec({ w: 1279, h: 719, fps: 24, fpsRate: "24/1" }, true)).toEqual({
+      w: 1278,
+      h: 718,
+      fps: 30,
+      fpsRate: "30/1",
+    });
+  });
+
+  test("fits a 4K source exactly into a 1080p canvas", () => {
+    expect(resolveOutputSpec({ w: 3840, h: 2160, fps: 60, fpsRate: "60/1" }, true)).toEqual({
+      w: 1920,
+      h: 1080,
+      fps: 30,
+      fpsRate: "30/1",
+    });
+  });
+});
+
+describe("X compatibility CLI", () => {
+  test("accepts both X flags and uses a non-destructive output suffix", () => {
+    for (const flag of ["--x", "--x-compatible"]) {
+      const result = parseArgs(["-i", import.meta.path, flag]);
+      expect(result.xCompatible).toBe(true);
+      expect(result.output.endsWith("video-outro.test_outro_x.mp4")).toBe(true);
+    }
+  });
+
+  test("requests CFR, a conventional timebase, and closed GOPs", () => {
+    const args = xCompatibilityArgs(true);
+    expect(args).toContain("-fps_mode:v");
+    expect(args).toContain("cfr");
+    expect(args).toContain("30");
+    expect(args).toContain("4.0");
+    expect(args).toContain("30000");
+    expect(args).toContain("+cgop");
+    expect(args).toContain("open-gop=0");
+    expect(xCompatibilityArgs(false)).toEqual([]);
   });
 });


### PR DESCRIPTION
## Summary

- prefer `avg_frame_rate` for VFR captures while preserving the exact rational rate for FFmpeg
- add `--x` / `--x-compatible` exports with 30 fps CFR, bounded dimensions, closed GOPs, a conventional MP4 timebase, and a non-destructive `_outro_x.mp4` suffix
- honor display-matrix rotation so portrait phone footage and its branded card use the same orientation
- document the X workflow and add regression coverage for ReplayKit, sizing, CLI, encoding parameters, and rotation

## Root cause

The failing ReplayKit capture reported `r_frame_rate=120/1` but actually averaged `117600/2633` (about 44.66 fps). The outro pipeline preferred the nominal rate and expanded the result to 5,791 frames at 120 fps. That output also exceeded X web upload bounds, allowing its transcode path to reinterpret a 48-second clip as several minutes and push the end card out of view.

## Validation

- `bun run test`
- focused outro tests: 13 passed, 0 failed
- real ReplayKit capture: 1664x1080, 30/1 CFR, 1/30000 timebase, H.264 High Level 4.0, 48.266667 seconds, 1,448 frames, full decode passes
- rotated portrait fixture: coded 1920x1080 + 90-degree display matrix becomes 1068x1900, 30/1 CFR, with a visually verified portrait end card
- default non-X path retains native 2200x1428 dimensions and emits the exact `117600/2633` average rate instead of 120 fps
