### PR TITLE
fix(vue-vapor): skip onFrame scheduling

### DIFF
--- a/src/components-vue-vapor.ts
+++ b/src/components-vue-vapor.ts
@@ -242,11 +242,7 @@ function createPrimitiveNode(
     prev = next;
     assignRef(rawProps.nodeRef ?? rawProps.ref, node);
   };
-  const hasFrameDynamicProps =
-    typeof opts.extra === "function" ||
-    Object.keys(rawProps).some((key) => !omit.has(key) && typeof rawProps[key] === "function");
   watchEffect(apply);
-  if (hasFrameDynamicProps) onFrame(apply);
   return node;
 }
 


### PR DESCRIPTION
Remove dynamic-prop detection and the onFrame call so primitive nodes no longer register per-frame callbacks, preventing unnecessary frame updates.