### PR TITLE
fix(vue-vapor): guard node.children access

### DIFF
--- a/src/native-tree.ts
+++ b/src/native-tree.ts
@@ -365,8 +365,10 @@ export function release(node: NodeMirror): void {
 function subtreeHasRetained(node: NodeMirror): boolean {
   if (!node) return false;
   if (retained.has(node)) return true;
-  for (let i = 0; i < node.children.length; i++) {
-    if (subtreeHasRetained(node.children[i])) return true;
+  if (node.children) {
+    for (let i = 0; i < node.children.length; i++) {
+      if (subtreeHasRetained(node.children[i])) return true;
+    }
   }
   return false;
 }


### PR DESCRIPTION
When switching `tab.value`, a null/undefined node will be rendered as a text node, which does not have a `children` property.
```ts
<View class="grow flex-col">
        {tab.value === 0 ? <Overview /> : null}
 </View>
```
<img width="2222" height="1850" alt="image" src="https://github.com/user-attachments/assets/24b4843a-f06b-4ab3-b684-48ca5773c388" />
