### PR TITLE
fix(framework): route prelude setTimeout polyfill cast through unknown

### DIFF
--- a/framework/src/prelude.ts
+++ b/framework/src/prelude.ts
@@ -11,7 +11,7 @@ if (typeof (globalThis as { queueMicrotask?: unknown }).queueMicrotask !== "func
 }
 
 if (typeof (globalThis as { setTimeout?: unknown }).setTimeout !== "function") {
-  (globalThis as { setTimeout?: (fn: () => void, delay?: number) => number }).setTimeout = (
+  (globalThis as unknown as { setTimeout?: (fn: () => void, delay?: number) => number }).setTimeout = (
     fn: () => void,
   ) => {
     queueMicrotask(fn);


### PR DESCRIPTION
## What

The pocketjs.dev deploy has failed on the last two pushes to main (#145's merge and #150's merge): `site:build` compiles `apps/hero-vue-sfc` for PSP, whose app-check now pulls in `framework/src/prelude.ts` and dies with

```
prelude.ts:14:4 TS2352: Conversion of type 'typeof globalThis' to type
'{ setTimeout?: ... => number }' may be a mistake ...
  Type 'Timer' is not comparable to type 'number'.
```

Bun's `setTimeout` returns `Timer`, so the direct cast's shapes don't overlap. The `console` polyfill a few lines below already casts through `unknown`; this makes the `setTimeout` polyfill do the same. One line.

## Validation

- `bun tools/pocket.ts compile --target psp --manifest apps/hero-vue-sfc/pocket.json --project-root .` — the exact failing deploy step — now completes.
- `bun run site:build` — full deploy build passes (docs 16 pages, blog 10 posts incl. pocket-vapor).
- `bun run test` — the full chain passes.

Merging this re-runs the deploy and finally puts the Pocket Vapor blog post live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)