### PR TITLE
feat(vapor): board profiles as data, derived demands, execution classes

### DIFF
--- a/contracts/schema/pocket-2.json
+++ b/contracts/schema/pocket-2.json
@@ -41,6 +41,26 @@
       "type": "string",
       "pattern": "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$"
     },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "classes"
+      ],
+      "properties": {
+        "classes": {
+          "type": "array",
+          "items": {
+            "enum": [
+              "guest",
+              "aot"
+            ]
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        }
+      }
+    },
     "engine": {
       "type": "object",
       "additionalProperties": false,

--- a/contracts/spec/platforms.ts
+++ b/contracts/spec/platforms.ts
@@ -38,6 +38,27 @@ export type Viewport = readonly [width: number, height: number];
 export const TARGET_FORMS = ["takeover", "window", "widget", "kiosk", "embedded"] as const;
 export type TargetForm = (typeof TARGET_FORMS)[number];
 
+/**
+ * How an application artifact executes on a device — a semantic FIELD like
+ * TargetForm, and the top-level split in admission machinery:
+ *
+ * - "guest": one portable bundle runs on the embedded JS engine of every
+ *   stock host. Admission is the RUNTIME rule this file defines — manifest
+ *   `requires` ⊆ target profile `capabilities`.
+ * - "aot":   the same source is recompiled natively per device by an AOT
+ *   compiler family (Pocket Vapor, Pocket Static). There is no hostAbi, no
+ *   ops and no runtime capability check; admission is COMPILE-TIME — the
+ *   compiler derives the app's demands and checks them against a BOARD
+ *   PROFILE (data, not a registry entry — see vapor/BOARDS.md).
+ *
+ * The classes scale differently on purpose: guest targets stay an inventory
+ * of real, golden-tested hosts (this registry); aot boards are open-ended
+ * data files validated by schema plus a physical verifier, because the MCU
+ * cross product (chip × panel × input × RAM) cannot be enumerated here.
+ */
+export const EXECUTION_CLASSES = ["guest", "aot"] as const;
+export type ExecutionClass = (typeof EXECUTION_CLASSES)[number];
+
 /** The forms whose logical viewport is a runtime variable. */
 export const DYNAMIC_FORMS: readonly TargetForm[] = ["window", "widget"];
 

--- a/contracts/spec/pocket-manifest.ts
+++ b/contracts/spec/pocket-manifest.ts
@@ -1,4 +1,10 @@
-import { PRESENTATION_MODES, type PresentationMode, type Viewport } from "./platforms.ts";
+import {
+  EXECUTION_CLASSES,
+  PRESENTATION_MODES,
+  type ExecutionClass,
+  type PresentationMode,
+  type Viewport,
+} from "./platforms.ts";
 
 export const POCKET_MANIFEST_VERSION = 2 as const;
 export const POCKET_MANIFEST_SCHEMA_ID = "https://pocketjs.dev/schema/pocket-2.json";
@@ -38,6 +44,17 @@ export interface PocketManifestV2 {
   readonly name: string;
   readonly title: string;
   readonly version: string;
+  /**
+   * Execution classes this package ships as; omitted means ["guest"].
+   * Declaring "aot" states that the entry compiles under an AOT family
+   * (Pocket Vapor/Static) whose admission is compile-time derived demands
+   * against a board profile, not this manifest's capability ids. A package
+   * whose classes exclude "guest" is refused by the guest build resolver.
+   * Per-class blocks (e.g. an `aot` section) hang off this object later.
+   */
+  readonly execution?: {
+    readonly classes: readonly ExecutionClass[];
+  };
   readonly engine: {
     readonly capabilities: {
       readonly requires: readonly string[];
@@ -109,6 +126,19 @@ export const pocketManifestV2Schema = {
     version: {
       type: "string",
       pattern: "^(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)(?:-[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?(?:\\+[0-9A-Za-z-]+(?:\\.[0-9A-Za-z-]+)*)?$",
+    },
+    execution: {
+      type: "object",
+      additionalProperties: false,
+      required: ["classes"],
+      properties: {
+        classes: {
+          type: "array",
+          items: { enum: EXECUTION_CLASSES },
+          minItems: 1,
+          uniqueItems: true,
+        },
+      },
     },
     engine: {
       type: "object",

--- a/docs/PLATFORM.md
+++ b/docs/PLATFORM.md
@@ -26,6 +26,13 @@ guest can observe is a surface op behind a capability id — never a host
 branch. The launcher followed it (ops 39..41) and stayed testable on every
 host; distribution must follow it too.
 
+Everything in this document is the **guest** execution class — one portable
+bundle, runtime admission against the target registry. The AOT class
+(Pocket Vapor/Static: recompiled per device, compile-time admission against
+board *data*) scales by a different rule set on purpose; pocket.json's
+`execution.classes` names the split and [vapor/BOARDS.md](../vapor/BOARDS.md)
+is its constitution.
+
 ## The switch veil (system transition)
 
 A guest swap has a dead window: teardown is instant but the incoming

--- a/framework/src/manifest/resolve.ts
+++ b/framework/src/manifest/resolve.ts
@@ -261,6 +261,18 @@ export function resolveBuildPlan(
     return { ok: false, diagnostics };
   }
 
+  // This resolver only produces guest-class plans. AOT-class packages are
+  // admitted at compile time by their compiler family (see vapor/BOARDS.md);
+  // a manifest that ships no guest artifact has nothing for us to build.
+  const executionClasses = manifest.execution?.classes ?? ["guest"];
+  if (!executionClasses.includes("guest")) {
+    diagnostics.push({
+      code: "execution.guestExcluded",
+      path: "/execution/classes",
+      message: "manifest declares no guest execution class; this resolver only builds guest plans",
+    });
+  }
+
   const resolvedViewport = resolveViewport(manifest, profile, diagnostics);
 
   const known = new Set<string>(registry.capabilities);

--- a/tests/platform-contracts.test.ts
+++ b/tests/platform-contracts.test.ts
@@ -120,6 +120,23 @@ describe("pocket.json v2 schema", () => {
       message: "unknown property",
     });
   });
+
+  test("accepts declared execution classes and rejects unknown ones", () => {
+    const dual = structuredClone(portableInput) as Record<string, any>;
+    dual.execution = { classes: ["guest", "aot"] };
+    expect(validatePocketManifest(dual).ok).toBe(true);
+
+    const unknown = structuredClone(portableInput) as Record<string, any>;
+    unknown.execution = { classes: ["jit"] };
+    const result = validatePocketManifest(unknown);
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnostics).toContainEqual({
+      code: "schema.enum",
+      path: "/execution/classes/0",
+      message: 'expected one of "guest", "aot"',
+    });
+  });
 });
 
 describe("platform registry", () => {
@@ -195,6 +212,23 @@ describe("platform registry", () => {
 });
 
 describe("semantic resolution", () => {
+  test("guest resolution honors the declared execution classes", () => {
+    const dual = structuredClone(portableInput) as Record<string, any>;
+    dual.execution = { classes: ["guest", "aot"] };
+    expect(validateAndResolveBuildPlan(dual, { target: "psp" }).ok).toBe(true);
+
+    const aotOnly = structuredClone(portableInput) as Record<string, any>;
+    aotOnly.execution = { classes: ["aot"] };
+    const result = validateAndResolveBuildPlan(aotOnly, { target: "psp" });
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.diagnostics).toContainEqual({
+      code: "execution.guestExcluded",
+      path: "/execution/classes",
+      message: "manifest declares no guest execution class; this resolver only builds guest plans",
+    });
+  });
+
   test("resolves a small PSP build plan", () => {
     const result = validateAndResolveBuildPlan(portableInput, { target: "psp" });
     expect(result.ok).toBe(true);

--- a/vapor/BOARDS.md
+++ b/vapor/BOARDS.md
@@ -1,0 +1,141 @@
+# Boards: how the AOT target family scales
+
+The MeowBit (PR #154) made Pocket Vapor's problem concrete: PocketJS just
+built a capability system for PSP/Vita (`contracts/spec/platforms.ts`,
+pocket.json v2), and the ESP32 fits none of its assumptions. This document
+records the design that keeps both worlds honest as MCU boards multiply.
+
+## Two execution classes, two admission machineries
+
+The platform contract now names the split (`EXECUTION_CLASSES` in
+`contracts/spec/platforms.ts`):
+
+|  | `guest` | `aot` |
+|---|---|---|
+| what ships | one portable bundle | source, recompiled per device |
+| runs on | the embedded JS engine of a stock host | bare metal; no JS engine exists |
+| admission | runtime: manifest `requires` ⊆ target `capabilities` | compile time: derived demands ⊨ board profile |
+| device registry | `POCKET_TARGETS` — an inventory of real, golden-tested hosts | board files — open-ended data, schema + verifier validated |
+| identity | hostAbi + bundle | `esp32BuildId` — content hash of generated app + board definitions + runtime sources |
+
+The guest registry is small on purpose and must stay that way: every entry
+is a stock host somebody built, tested and goldens. That doctrine is exactly
+wrong for MCUs — the cross product of chip × panel × input × RAM is
+open-ended and mostly built by other people. Stretching capability ids over
+it ("esp32.lcd.st7735") would burn the registry's own first rule: ids name
+observable framework behavior, never hardware.
+
+A pocket.json may declare which classes it ships as
+(`execution.classes`, default `["guest"]`); the guest build resolver
+refuses a manifest that ships no guest artifact (`execution.guestExcluded`).
+
+## A board is data; the runtime contract stays code
+
+`vapor/boards/<name>.json` is the devicetree of one device:
+
+```jsonc
+{
+  "board": "meowbit",                    // = file name
+  "title": "Xueersi/KittenBot MeowBit",
+  "chip": "esp32",                       // selects runtime/esp32/
+  "lcd": {
+    "controller": "st7735",              // ili934x | st7789 | st7735
+    "width": 160, "height": 128,
+    "cell": [8, 7],                      // px per logical cell
+    "madctl": 96,                        // panel orientation register
+    "pins": { "sclk": 18, "mosi": 23, "cs": 5, "dc": 4, "rst": -1, "backlight": -1 }
+  },
+  "input": {
+    "pins": { "up": 2, "down": 13, "left": 27, "right": 35, "a": 34, "b": 12 },
+    "chorded": { "start": ["a","b"], "select": ["left","right"], "r": ["up","down"] },
+    "absent": ["l"]
+  }
+}
+```
+
+`vapor/compiler/boards.ts` loads and validates it, then derives the compile
+definitions the ESP-IDF build injects (`boardDefinitions`). Adding a device
+means adding a JSON file — never editing the compiler or the C.
+
+Two validation rules carry the weight:
+
+- **Chords are pinned to the runtime.** The release-latch chord decoder is
+  fixed in `runtime/esp32/vapor_esp32.c`; a board declares *which* of those
+  chords its pad exposes, and validation rejects any pair that differs from
+  the C. Data can describe the runtime; it cannot contradict it.
+- **Coverage is total.** Every one of the ten Pocket buttons must have
+  exactly one spelling per board: a direct pad key, a runtime chord, or an
+  explicit `absent`. Silence is how coverage claims rot.
+
+What deliberately stays code: the frame loop, the panel init sequences, the
+chord decoder, the UART receipt protocol. A board file selects among
+behaviors the runtime already has; it never programs new ones.
+
+## Demands are derived, never authored
+
+Guest apps hand-declare `requires` because the framework cannot always see
+what they use. The AOT compiler *can* see: which buttons the keymaps and
+handlers statically reference (`CompiledApp.buttonsUsed`), how many style
+pairs the class DSL resolved, which `SCREEN` folds the layout takes, the
+whole memory plan. So the demand block is compiler output:
+
+```sh
+bun vapor/compiler/cli.ts check app.tsx --json
+# { targets: { esp32: { ok, grid, stylePairs, buttonsUsed, ... } },
+#   boards:  { meowbit: { ok, issues: [...] } } }
+```
+
+Derived demands cannot lie, and they are per-target precise: code behind a
+false `SCREEN` fold is never compiled, so an app that only uses `R` on the
+GBA's wide layout doesn't demand `R` from a 20×18 board.
+
+## The admission rule
+
+`admitBoard(demands, board, grid)` is the whole aot-class admission rule:
+
+| code | severity | meaning |
+|---|---|---|
+| VB101 | error | logical grid × cell size does not fit the panel |
+| VB102 | error | app uses a button the board neither wires nor chords |
+| VB103 | warn | button only reachable as a two-key chord — the VS104 of input |
+
+`check` prints board rows in the same matrix as targets. Board rows inform;
+they never fail the check — an app is not obligated to fit every board, the
+verdict exists so a store, a CI, or a person can decide with facts.
+
+## Identity and the registration gate
+
+`esp32BuildId` hashes the generated app, the *derived* board definitions,
+the runtime sources and sdkconfig. Two consequences:
+
+- A board-file refactor that keeps the derived definitions byte-identical
+  keeps every flashed device's identity (locked by a test in
+  `tests/boards.test.ts`).
+- The physical verifier (`vapor:esp32:verify`) refuses firmware whose
+  receipt doesn't match the source-derived id — so "this board file works"
+  is a claim with a receipt, not a vibe.
+
+That receipt is the registration gate: a board file joins this directory
+with a passing device-parity receipt, the same way a guest target joins
+`POCKET_TARGETS` with goldens. Community boards without receipts can exist
+anywhere; the schema and verifier make them cheap to trust when they arrive.
+
+## What a store does with this (forward-looking)
+
+A store never enumerates boards. It stores the app's derived demands and
+lets the edge evaluate: the device's companion (the same Mac-side tooling
+that flashes and verifies today) loads its board file, runs the admission
+rule, then compiles from source with a pinned compiler version — cacheable
+by `esp32BuildId` for popular (app, board, toolchain) triples. Web apps
+don't enumerate monitors; they declare breakpoints and the client decides.
+`SCREEN` folds are compile-time breakpoints, so the analogy is exact.
+
+## Deliberately not built yet
+
+- **Per-board grid geometry.** Today the `esp32` target owns 20×18 and the
+  board must fit it. The second board with a different panel promotes
+  geometry to a board field and turns `VAPOR_TARGETS.esp32` into a family.
+- **Chord tables as data.** Needs the C decoder to read a generated table
+  first; until then data is pinned to the runtime's fixed chords.
+- **A build service.** Source + companion-local compile is enough until
+  board count makes server-side `esp32BuildId` caching worth running.

--- a/vapor/README.md
+++ b/vapor/README.md
@@ -117,14 +117,23 @@ luminance), with the whole diagnostics matrix one command away:
 
 ```
 $ bun run vapor:check
-gba  OK    30x20, 6 style pairs
-gb   OK    20x18, 6 style pairs
-     warn  VS104: 3 distinct color pairs render as the same glyph style ...
-nes  OK    22x18, 6 style pairs
-     warn  VS104: 3 distinct color pairs render as the same glyph style ...
-esp32 OK   20x18, 6 style pairs
+gba     OK    30x20, 6 style pairs
+gb      OK    20x18, 6 style pairs
+        warn  VS104: 3 distinct color pairs render as the same glyph style ...
+nes     OK    22x18, 6 style pairs
+        warn  VS104: 3 distinct color pairs render as the same glyph style ...
+esp32   OK    20x18, 6 style pairs
+meowbit OK    board (esp32)
+        warn  VB103: "start" is only reachable as the a+b chord on meowbit ...
 $ bun vapor/compiler/cli.ts check app.tsx --strict   # lossy lowering = failure
+$ bun vapor/compiler/cli.ts check app.tsx --json     # demands + verdicts as data
 ```
+
+Board rows are the AOT admission rule at work: MCU devices are data files
+(`boards/meowbit.json`), the compiler derives what the app demands (buttons
+used, style pairs, grid), and `check` judges every registered board against
+them — see [BOARDS.md](BOARDS.md) for how this scales past one store's
+ability to enumerate devices.
 
 And the oracle is visible: `bun run vapor:dev` serves the app on real Vue
 Vapor in your browser — inspectable DOM rows, keyboard as the pad,

--- a/vapor/boards/meowbit.json
+++ b/vapor/boards/meowbit.json
@@ -1,0 +1,22 @@
+{
+  "board": "meowbit",
+  "title": "Xueersi/KittenBot MeowBit",
+  "chip": "esp32",
+  "lcd": {
+    "controller": "st7735",
+    "width": 160,
+    "height": 128,
+    "cell": [8, 7],
+    "madctl": 96,
+    "pins": { "sclk": 18, "mosi": 23, "cs": 5, "dc": 4, "rst": -1, "backlight": -1 }
+  },
+  "input": {
+    "pins": { "up": 2, "down": 13, "left": 27, "right": 35, "a": 34, "b": 12 },
+    "chorded": {
+      "start": ["a", "b"],
+      "select": ["left", "right"],
+      "r": ["up", "down"]
+    },
+    "absent": ["l"]
+  }
+}

--- a/vapor/compiler/boards.ts
+++ b/vapor/compiler/boards.ts
@@ -1,0 +1,282 @@
+// vapor/compiler/boards.ts — AOT board profiles as data.
+//
+// A board file (vapor/boards/<name>.json) is the devicetree of a Pocket
+// Vapor MCU target: panel, pins and logical-pad coverage. The runtime
+// contract stays code (runtime/vapor.h + runtime/<chip>/); the board is
+// pure data validated here, so adding a device means adding a JSON file and
+// passing the physical verifier — never editing the compiler. See
+// vapor/BOARDS.md for the scaling argument (execution classes, derived
+// demands, admission).
+
+import { readdirSync, readFileSync } from "node:fs";
+import { basename, join } from "node:path";
+
+const BOARDS_DIR = join(import.meta.dir, "..", "boards");
+
+/** Pocket pad names in Button-id order (mirrors vapor/host/input.ts). */
+export const POCKET_PAD = [
+  "a", "b", "select", "start", "right", "left", "up", "down", "r", "l",
+] as const;
+export type PocketButtonName = (typeof POCKET_PAD)[number];
+
+/** The six physical keys the ESP32 runtime scans, in button_pins[] order. */
+export const PAD_KEYS = ["up", "down", "left", "right", "a", "b"] as const;
+export type PadKey = (typeof PAD_KEYS)[number];
+
+/**
+ * The chord decoder is FIXED in runtime/esp32/vapor_esp32.c (release-latched
+ * pairs). A board does not invent chords; it declares which of the runtime's
+ * chords its pad exposes, and validation pins the exact pairs so the data
+ * can never drift from the C.
+ */
+export const RUNTIME_CHORDS: Readonly<Partial<Record<PocketButtonName, readonly [PadKey, PadKey]>>> = {
+  start: ["a", "b"],
+  select: ["left", "right"],
+  r: ["up", "down"],
+};
+
+const LCD_CONTROLLERS = { ili934x: 1, st7789: 2, st7735: 3 } as const;
+export type LcdController = keyof typeof LCD_CONTROLLERS;
+
+export interface VaporBoard {
+  board: string;
+  title: string;
+  chip: "esp32";
+  lcd: {
+    controller: LcdController;
+    width: number;
+    height: number;
+    cell: readonly [number, number];
+    madctl: number;
+    pins: { sclk: number; mosi: number; cs: number; dc: number; rst: number; backlight: number };
+  };
+  input: {
+    pins: Record<PadKey, number>;
+    chorded: Partial<Record<PocketButtonName, readonly [PadKey, PadKey]>>;
+    absent: readonly PocketButtonName[];
+  };
+}
+
+export interface BoardIssue {
+  code: string;
+  severity: "error" | "warn";
+  message: string;
+}
+
+class BoardError extends Error {
+  constructor(name: string, message: string) {
+    super(`board ${name}: ${message}`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function requireInt(name: string, value: unknown, what: string, min: number, max: number): number {
+  if (typeof value !== "number" || !Number.isInteger(value) || value < min || value > max)
+    throw new BoardError(name, `${what} must be an integer in [${min}, ${max}], got ${JSON.stringify(value)}`);
+  return value;
+}
+
+/** Validate a raw board document; throws a descriptive error on any defect. */
+export function parseBoard(name: string, raw: unknown): VaporBoard {
+  if (!isRecord(raw)) throw new BoardError(name, "document must be a JSON object");
+  if (raw.board !== name)
+    throw new BoardError(name, `"board" must equal the file name, got ${JSON.stringify(raw.board)}`);
+  if (!/^[a-z][a-z0-9-]*$/.test(name)) throw new BoardError(name, "board names are lowercase kebab-case");
+  if (typeof raw.title !== "string" || raw.title.length === 0)
+    throw new BoardError(name, '"title" must be a non-empty string');
+  if (raw.chip !== "esp32")
+    throw new BoardError(name, `the only board runtime today is "esp32", got ${JSON.stringify(raw.chip)}`);
+
+  const lcd = raw.lcd;
+  if (!isRecord(lcd)) throw new BoardError(name, '"lcd" must be an object');
+  if (typeof lcd.controller !== "string" || !(lcd.controller in LCD_CONTROLLERS))
+    throw new BoardError(name, `lcd.controller must be one of ${Object.keys(LCD_CONTROLLERS).join(", ")}`);
+  const width = requireInt(name, lcd.width, "lcd.width", 1, 1024);
+  const height = requireInt(name, lcd.height, "lcd.height", 1, 1024);
+  if (!Array.isArray(lcd.cell) || lcd.cell.length !== 2)
+    throw new BoardError(name, "lcd.cell must be [width, height]");
+  const cell = [
+    requireInt(name, lcd.cell[0], "lcd.cell[0]", 1, 32),
+    requireInt(name, lcd.cell[1], "lcd.cell[1]", 1, 32),
+  ] as const;
+  const madctl = requireInt(name, lcd.madctl, "lcd.madctl", 0, 255);
+  const rawLcdPins = lcd.pins;
+  if (!isRecord(rawLcdPins)) throw new BoardError(name, "lcd.pins must be an object");
+  const lcdPinNames = ["sclk", "mosi", "cs", "dc", "rst", "backlight"] as const;
+  for (const extra of Object.keys(rawLcdPins))
+    if (!(lcdPinNames as readonly string[]).includes(extra))
+      throw new BoardError(name, `unknown lcd pin ${JSON.stringify(extra)}`);
+  const lcdPins = Object.fromEntries(
+    lcdPinNames.map((pin) => {
+      const wired = pin === "sclk" || pin === "mosi" || pin === "cs" || pin === "dc";
+      return [pin, requireInt(name, rawLcdPins[pin], `lcd.pins.${pin}`, wired ? 0 : -1, 48)];
+    }),
+  ) as VaporBoard["lcd"]["pins"];
+
+  const input = raw.input;
+  if (!isRecord(input)) throw new BoardError(name, '"input" must be an object');
+  const rawPadPins = input.pins;
+  if (!isRecord(rawPadPins)) throw new BoardError(name, '"input.pins" must be an object');
+  for (const extra of Object.keys(rawPadPins))
+    if (!(PAD_KEYS as readonly string[]).includes(extra))
+      throw new BoardError(name, `unknown input pin ${JSON.stringify(extra)}`);
+  // button_pins[] in the C runtime is positional over all six keys, so a
+  // board must wire the full pad; boards with fewer keys need the runtime
+  // taught first.
+  const pins = Object.fromEntries(
+    PAD_KEYS.map((key) => [key, requireInt(name, rawPadPins[key], `input.pins.${key}`, 0, 48)]),
+  ) as Record<PadKey, number>;
+
+  const chorded: VaporBoard["input"]["chorded"] = {};
+  if (input.chorded !== undefined) {
+    if (!isRecord(input.chorded)) throw new BoardError(name, '"input.chorded" must be an object');
+    for (const [button, pair] of Object.entries(input.chorded)) {
+      const runtimePair = RUNTIME_CHORDS[button as PocketButtonName];
+      if (!runtimePair)
+        throw new BoardError(name, `the esp32 runtime has no chord for ${JSON.stringify(button)}`);
+      if (!Array.isArray(pair) || pair.length !== 2 || pair[0] !== runtimePair[0] || pair[1] !== runtimePair[1])
+        throw new BoardError(
+          name,
+          `chord for "${button}" must be ${JSON.stringify(runtimePair)} (fixed by vapor_esp32.c), got ${JSON.stringify(pair)}`,
+        );
+      chorded[button as PocketButtonName] = runtimePair;
+    }
+  }
+
+  const absent: PocketButtonName[] = [];
+  if (input.absent !== undefined) {
+    if (!Array.isArray(input.absent)) throw new BoardError(name, '"input.absent" must be an array');
+    for (const button of input.absent) {
+      if (!(POCKET_PAD as readonly string[]).includes(button))
+        throw new BoardError(name, `unknown pocket button ${JSON.stringify(button)} in input.absent`);
+      absent.push(button as PocketButtonName);
+    }
+  }
+
+  // Every pocket button must be accounted for exactly once: direct pad key,
+  // runtime chord, or declared absent. Silence is how coverage claims rot.
+  for (const button of POCKET_PAD) {
+    const spellings = [
+      (PAD_KEYS as readonly string[]).includes(button),
+      button in chorded,
+      absent.includes(button),
+    ].filter(Boolean).length;
+    if (spellings !== 1)
+      throw new BoardError(
+        name,
+        `pocket button "${button}" must have exactly one spelling (direct pad key, chord, or absent), found ${spellings}`,
+      );
+  }
+
+  return {
+    board: name,
+    title: raw.title,
+    chip: "esp32",
+    lcd: { controller: lcd.controller as LcdController, width, height, cell, madctl, pins: lcdPins },
+    input: { pins, chorded, absent },
+  };
+}
+
+export function loadBoard(name: string): VaporBoard {
+  const path = join(BOARDS_DIR, `${name}.json`);
+  let text: string;
+  try {
+    text = readFileSync(path, "utf8");
+  } catch {
+    throw new BoardError(name, `no board file at ${path} (known: ${listBoards().join(", ")})`);
+  }
+  return parseBoard(name, JSON.parse(text));
+}
+
+export function listBoards(): string[] {
+  return readdirSync(BOARDS_DIR)
+    .filter((file) => file.endsWith(".json"))
+    .map((file) => basename(file, ".json"))
+    .sort();
+}
+
+/**
+ * Derive the compile definitions the ESP-IDF build injects. This is the
+ * board's whole codegen surface — and the board half of esp32BuildId, so
+ * the derivation must stay byte-stable for a given board file.
+ */
+export function boardDefinitions(board: VaporBoard): string[] {
+  const { lcd, input } = board;
+  return [
+    `VP_ESP32_BOARD=\\"${board.board}\\"`,
+    "VP_LCD_ENABLED=1",
+    `VP_LCD_CONTROLLER=${LCD_CONTROLLERS[lcd.controller]}`,
+    `VP_LCD_WIDTH=${lcd.width}`,
+    `VP_LCD_HEIGHT=${lcd.height}`,
+    `VP_LCD_CELL_W=${lcd.cell[0]}`,
+    `VP_LCD_CELL_H=${lcd.cell[1]}`,
+    `VP_LCD_MADCTL=0x${lcd.madctl.toString(16)}`,
+    `VP_LCD_SCLK=${lcd.pins.sclk}`,
+    `VP_LCD_MOSI=${lcd.pins.mosi}`,
+    `VP_LCD_CS=${lcd.pins.cs}`,
+    `VP_LCD_DC=${lcd.pins.dc}`,
+    `VP_LCD_RST=${lcd.pins.rst}`,
+    `VP_LCD_BL=${lcd.pins.backlight}`,
+    `VP_BUTTON_COUNT=${PAD_KEYS.length}`,
+    `VP_BUTTON_UP=${input.pins.up}`,
+    `VP_BUTTON_DOWN=${input.pins.down}`,
+    `VP_BUTTON_LEFT=${input.pins.left}`,
+    `VP_BUTTON_RIGHT=${input.pins.right}`,
+    `VP_BUTTON_A=${input.pins.a}`,
+    `VP_BUTTON_B=${input.pins.b}`,
+  ];
+}
+
+/** What one compiled app demands of a board (derived, never authored). */
+export interface AppDemands {
+  /** Button ids the source statically references (keymap keys + Button.X). */
+  buttonsUsed: readonly number[];
+}
+
+/**
+ * The aot-class admission rule: derived demands ⊨ board profile. Errors
+ * refuse the pairing; warnings flag interaction-quality degradation (a
+ * button only reachable as a two-key chord), the VS104 of input.
+ */
+export function admitBoard(
+  demands: AppDemands,
+  board: VaporBoard,
+  grid: { width: number; height: number },
+): BoardIssue[] {
+  const issues: BoardIssue[] = [];
+  const physW = grid.width * board.lcd.cell[0];
+  const physH = grid.height * board.lcd.cell[1];
+  if (physW > board.lcd.width || physH > board.lcd.height) {
+    issues.push({
+      code: "VB101",
+      severity: "error",
+      message: `${grid.width}x${grid.height} cells of ${board.lcd.cell[0]}x${board.lcd.cell[1]} px need ${physW}x${physH}, panel is ${board.lcd.width}x${board.lcd.height}`,
+    });
+  }
+  for (const id of demands.buttonsUsed) {
+    const button = POCKET_PAD[id];
+    if (button === undefined) {
+      issues.push({ code: "VB102", severity: "error", message: `unknown button id ${id} in demands` });
+      continue;
+    }
+    if ((PAD_KEYS as readonly string[]).includes(button)) continue;
+    if (button in board.input.chorded) {
+      const pair = board.input.chorded[button]!;
+      issues.push({
+        code: "VB103",
+        severity: "warn",
+        message: `"${button}" is only reachable as the ${pair[0]}+${pair[1]} chord on ${board.board}`,
+      });
+      continue;
+    }
+    issues.push({
+      code: "VB102",
+      severity: "error",
+      message: `app uses "${button}" but ${board.board} has no mapping for it`,
+    });
+  }
+  return issues;
+}

--- a/vapor/compiler/cli.ts
+++ b/vapor/compiler/cli.ts
@@ -2,14 +2,19 @@
 // vapor/compiler/cli.ts — compile a Pocket Vapor component to a cartridge.
 //
 //   bun vapor/compiler/cli.ts <component.tsx> [--target gba|gb|nes|esp32] [--out dist/vapor]
-//   bun vapor/compiler/cli.ts check <component.tsx> [--strict]
+//   bun vapor/compiler/cli.ts check <component.tsx> [--strict] [--json]
 //
 // `check` runs the compiler frontend for EVERY target and prints the
-// diagnostics matrix — the compile-time answer to "which consoles can run
-// this file, and what degrades where". No toolchains needed.
+// diagnostics matrix — the compile-time answer to "which devices can run
+// this file, and what degrades where". No toolchains needed. Board rows
+// evaluate the aot admission rule (derived demands ⊨ board profile); they
+// inform, they never fail the check — an app is not obligated to fit every
+// board. `--json` emits the same matrix plus the derived demands as data
+// (the machine-readable half a store or CI consumes; see vapor/BOARDS.md).
 
 import { basename, join, resolve } from "node:path";
-import { compileVaporApp, VAPOR_TARGETS, type VaporTargetName } from "./compile.ts";
+import { admitBoard, listBoards, loadBoard, POCKET_PAD, type BoardIssue } from "./boards.ts";
+import { compileVaporApp, VAPOR_TARGETS, type CompiledApp, type VaporTargetName } from "./compile.ts";
 import { buildRom } from "./rom.ts";
 
 let args = process.argv.slice(2);
@@ -18,24 +23,79 @@ if (args[0] === "check") {
   args = args.slice(1);
   const entry = args.find((a) => !a.startsWith("--"));
   if (!entry) {
-    console.error("usage: bun vapor/compiler/cli.ts check <component.tsx> [--strict]");
+    console.error("usage: bun vapor/compiler/cli.ts check <component.tsx> [--strict] [--json]");
     process.exit(2);
   }
   const strict = args.includes("--strict");
+  const json = args.includes("--json");
   const source = await Bun.file(entry).text();
+  const label = Math.max(5, ...listBoards().map((name) => name.length));
   let failed = false;
+
+  interface TargetRow {
+    ok: boolean;
+    grid: string;
+    stylePairs?: number;
+    buttonsUsed?: string[];
+    warnings: string[];
+    errors: string[];
+  }
+  const targets: Record<string, TargetRow> = {};
+  const apps: Partial<Record<VaporTargetName, CompiledApp>> = {};
   for (const target of Object.keys(VAPOR_TARGETS) as VaporTargetName[]) {
+    const t = VAPOR_TARGETS[target];
+    const grid = `${t.width}x${t.height}`;
     try {
       const app = compileVaporApp(entry, source, "CHECK", target, { strict });
-      const t = VAPOR_TARGETS[target];
-      console.log(`${target.padEnd(4)} OK    ${t.width}x${t.height}, ${app.styles.pairs.length} style pairs`);
-      for (const warning of app.diagnostics) console.log(`     warn  ${warning}`);
+      apps[target] = app;
+      targets[target] = {
+        ok: true,
+        grid,
+        stylePairs: app.styles.pairs.length,
+        buttonsUsed: app.buttonsUsed.map((id) => POCKET_PAD[id]),
+        warnings: app.diagnostics,
+        errors: [],
+      };
+      if (!json) {
+        console.log(`${target.padEnd(label)} OK    ${grid}, ${app.styles.pairs.length} style pairs`);
+        for (const warning of app.diagnostics) console.log(`${" ".repeat(label + 1)}warn  ${warning}`);
+      }
     } catch (e) {
       failed = true;
-      console.log(`${target.padEnd(4)} FAIL`);
-      for (const line of String(e instanceof Error ? e.message : e).split("\n"))
-        console.log(`     error ${line}`);
+      const errors = String(e instanceof Error ? e.message : e).split("\n");
+      targets[target] = { ok: false, grid, warnings: [], errors };
+      if (!json) {
+        console.log(`${target.padEnd(label)} FAIL`);
+        for (const line of errors) console.log(`${" ".repeat(label + 1)}error ${line}`);
+      }
     }
+  }
+
+  interface BoardRow {
+    chip: string;
+    target: VaporTargetName;
+    ok: boolean;
+    issues: BoardIssue[];
+  }
+  const boards: Record<string, BoardRow> = {};
+  for (const name of listBoards()) {
+    const board = loadBoard(name);
+    const target: VaporTargetName = "esp32"; // the only board-backed target
+    const app = apps[target];
+    const issues = app
+      ? admitBoard({ buttonsUsed: app.buttonsUsed }, board, VAPOR_TARGETS[target])
+      : [{ code: "VB100", severity: "error" as const, message: `target ${target} failed to compile` }];
+    const ok = issues.every((issue) => issue.severity !== "error");
+    boards[name] = { chip: board.chip, target, ok, issues };
+    if (!json) {
+      console.log(`${name.padEnd(label)} ${ok ? "OK   " : "FAIL "} board (${board.chip})`);
+      for (const issue of issues)
+        console.log(`${" ".repeat(label + 1)}${issue.severity.padEnd(5)} ${issue.code}: ${issue.message}`);
+    }
+  }
+
+  if (json) {
+    console.log(JSON.stringify({ entry, strict, targets, boards }, null, 2));
   }
   process.exit(failed ? 1 : 0);
 }

--- a/vapor/compiler/compile.ts
+++ b/vapor/compiler/compile.ts
@@ -63,6 +63,10 @@ export interface CompiledApp {
   styles: StyleTable;
   /** style diagnostics (errors already thrown; warnings informational) */
   diagnostics: string[];
+  /** Button ids the compiled source statically references (keymap keys and
+   * folded Button.X reads) — the input half of the app's derived demands.
+   * Per target: code behind a false SCREEN fold is never compiled. */
+  buttonsUsed: number[];
 }
 
 export class VaporCompileError extends Error {
@@ -532,6 +536,7 @@ class AppCompiler {
   // `(cond ? mapA : mapB)[b]?.()` — undefined entries are null pointers.
 
   private keymaps: KeymapBinding[] = [];
+  private buttonsUsed = new Set<number>();
 
   private scanKeymap(name: string, init: ts.ObjectLiteralExpression): void {
     const entries = new Map<number, string>();
@@ -819,7 +824,10 @@ class AppCompiler {
           const buttons: Record<string, number> = {
             A: 0, B: 1, Select: 2, Start: 3, Right: 4, Left: 5, Up: 6, Down: 7, R: 8, L: 9,
           };
-          if (e.name.text in buttons) return buttons[e.name.text];
+          if (e.name.text in buttons) {
+            this.buttonsUsed.add(buttons[e.name.text]);
+            return buttons[e.name.text];
+          }
         }
       }
     }
@@ -2083,6 +2091,7 @@ class AppCompiler {
       debugSlots,
       styles: this.styleTable,
       diagnostics: this.styleWarnings,
+      buttonsUsed: [...this.buttonsUsed].sort((a, b) => a - b),
     };
   }
 }

--- a/vapor/compiler/esp32.ts
+++ b/vapor/compiler/esp32.ts
@@ -9,33 +9,12 @@ import { existsSync } from "node:fs";
 import { basename, dirname, join, resolve } from "node:path";
 import { mkdir, unlink } from "node:fs/promises";
 import { homedir } from "node:os";
+import { admitBoard, boardDefinitions, loadBoard, type VaporBoard } from "./boards.ts";
 import { VAPOR_TARGETS, type CompiledApp } from "./compile.ts";
 
 const RUNTIME = resolve(import.meta.dir, "..", "runtime");
 const IDF_VERSION = "v6.0.2";
-const MEOWBIT_DEFINITIONS = [
-  'VP_ESP32_BOARD=\\"meowbit\\"',
-  "VP_LCD_ENABLED=1",
-  "VP_LCD_CONTROLLER=3",
-  "VP_LCD_WIDTH=160",
-  "VP_LCD_HEIGHT=128",
-  "VP_LCD_CELL_W=8",
-  "VP_LCD_CELL_H=7",
-  "VP_LCD_MADCTL=0x60",
-  "VP_LCD_SCLK=18",
-  "VP_LCD_MOSI=23",
-  "VP_LCD_CS=5",
-  "VP_LCD_DC=4",
-  "VP_LCD_RST=-1",
-  "VP_LCD_BL=-1",
-  "VP_BUTTON_COUNT=6",
-  "VP_BUTTON_UP=2",
-  "VP_BUTTON_DOWN=13",
-  "VP_BUTTON_LEFT=27",
-  "VP_BUTTON_RIGHT=35",
-  "VP_BUTTON_A=34",
-  "VP_BUTTON_B=12",
-] as const;
+export const DEFAULT_BOARD = "meowbit";
 
 function cmakeString(value: string): string {
   return `"${value.replaceAll("\\", "/").replaceAll('"', '\\"')}"`;
@@ -136,7 +115,7 @@ export async function runEspIdf(args: string[]): Promise<void> {
   await runIdf(idfPath, idfToolsPath, args);
 }
 
-function mainCmake(debugStateBytes: number, buildId: string): string {
+function mainCmake(debugStateBytes: number, buildId: string, board: VaporBoard): string {
   const target = VAPOR_TARGETS.esp32;
   const sources = [
     join(RUNTIME, "vapor_core.c"),
@@ -150,7 +129,7 @@ function mainCmake(debugStateBytes: number, buildId: string): string {
     `VP_VIEW_CAP=${target.poolCap}`,
     `VP_DEBUG_STATE_BYTES=${debugStateBytes}`,
     `VP_BUILD_ID=\\"${buildId}\\"`,
-    ...MEOWBIT_DEFINITIONS,
+    ...boardDefinitions(board),
   ];
 
   return [
@@ -176,10 +155,12 @@ export interface Esp32BuildResult {
   buildId: string;
 }
 
-/** Identity of the generated app plus every source/config input flashed. */
-export async function esp32BuildId(app: CompiledApp): Promise<string> {
+/** Identity of the generated app plus every source/config input flashed.
+ * The board contributes exactly its derived definitions, so a board file
+ * refactor that keeps the definitions byte-identical keeps the id. */
+export async function esp32BuildId(app: CompiledApp, board: VaporBoard): Promise<string> {
   const hasher = new Bun.CryptoHasher("sha256");
-  hasher.update(`${IDF_VERSION}\n${JSON.stringify(MEOWBIT_DEFINITIONS)}\n${app.c}\n`);
+  hasher.update(`${IDF_VERSION}\n${JSON.stringify(boardDefinitions(board))}\n${app.c}\n`);
   for (const path of [
     join(RUNTIME, "vapor.h"),
     join(RUNTIME, "vapor_core.c"),
@@ -194,13 +175,19 @@ export async function esp32BuildId(app: CompiledApp): Promise<string> {
 export async function buildEsp32Firmware(
   app: CompiledApp,
   outFirmware: string,
+  board: VaporBoard = loadBoard(DEFAULT_BOARD),
 ): Promise<Esp32BuildResult> {
+  const target = VAPOR_TARGETS.esp32;
+  const refusals = admitBoard({ buttonsUsed: [] }, board, target).filter((i) => i.severity === "error");
+  if (refusals.length > 0) {
+    throw new Error(`board ${board.board} cannot host the ${target.width}x${target.height} grid:\n${refusals.map((i) => `${i.code} ${i.message}`).join("\n")}`);
+  }
   const output = resolve(outFirmware);
   const outputDir = dirname(output);
   const projectDir = join(outputDir, "gen-esp32");
   const mainDir = join(projectDir, "main");
   const buildDir = join(projectDir, "build");
-  const buildId = await esp32BuildId(app);
+  const buildId = await esp32BuildId(app, board);
   const debugStateEnd = Math.max(
     1,
     ...app.debugSlots.map((slot) => slot.offset + slot.size),
@@ -213,7 +200,7 @@ export async function buildEsp32Firmware(
 
   await mkdir(mainDir, { recursive: true });
   await Bun.write(join(mainDir, "gen_app.c"), app.c);
-  await Bun.write(join(mainDir, "CMakeLists.txt"), mainCmake(debugStateBytes, buildId));
+  await Bun.write(join(mainDir, "CMakeLists.txt"), mainCmake(debugStateBytes, buildId, board));
   await Bun.write(
     join(projectDir, "CMakeLists.txt"),
     [

--- a/vapor/runtime/esp32/README.md
+++ b/vapor/runtime/esp32/README.md
@@ -13,6 +13,13 @@ ESP32-D0WD and a 160×128 ST7735 panel. The logical Pocket screen is 20×18;
 each character is rasterized into an 8×7 RGB565 cell, leaving one physical
 row above and below the 160×126 content area.
 
+Board profiles are data, not code: pins, panel and pad coverage live in
+[`vapor/boards/meowbit.json`](../../boards/meowbit.json), validated and
+turned into compile definitions by `vapor/compiler/boards.ts`. The build
+and verify commands take `--board <name>` (default `meowbit`). See
+[`vapor/BOARDS.md`](../../BOARDS.md) for the design. The tables below
+describe the MeowBit values.
+
 ## Board profile
 
 | function | GPIO | electrical behavior |

--- a/vapor/scripts/esp32.ts
+++ b/vapor/scripts/esp32.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env bun
 // Build, flash, and verify Pocket Vapor on a USB-connected ESP32 MeowBit.
 //
-//   bun vapor/scripts/esp32.ts flash [--port /dev/cu.usbmodem...]
-//   bun vapor/scripts/esp32.ts verify [--port ...] [--no-flash]
+//   bun vapor/scripts/esp32.ts flash [--port /dev/cu.usbmodem...] [--board meowbit]
+//   bun vapor/scripts/esp32.ts verify [--port ...] [--no-flash] [--board meowbit]
 //
 // `verify` is the physical-device equivalent of parity.test.ts: it boots the
 // real Vue Vapor oracle, replays the shared TodoMVC tape through the native
@@ -14,8 +14,10 @@ import {
 } from "node:fs";
 import { basename, join, resolve } from "node:path";
 import { compileVaporApp, VAPOR_TARGETS } from "../compiler/compile.ts";
+import { loadBoard } from "../compiler/boards.ts";
 import {
   buildEsp32Firmware,
+  DEFAULT_BOARD,
   esp32BuildId,
   resolveEspIdfEnvironment,
   runEspIdf,
@@ -33,6 +35,7 @@ const RECEIPT = join(OUT, "esp32-device-receipt.json");
 const TARGET = VAPOR_TARGETS.esp32;
 const BAUD = 115200;
 const CELLS = TARGET.width * TARGET.height;
+const BOARD = loadBoard(option("--board") ?? DEFAULT_BOARD);
 
 interface GridReceipt {
   header: string;
@@ -266,7 +269,7 @@ async function build(): Promise<{
 }> {
   const source = await Bun.file(ENTRY).text();
   const app = compileVaporApp(ENTRY, source, "VAPOR TODO", "esp32");
-  const firmware = await buildEsp32Firmware(app, FIRMWARE);
+  const firmware = await buildEsp32Firmware(app, FIRMWARE, BOARD);
   return { app, firmware };
 }
 
@@ -318,12 +321,12 @@ async function verify(
     if (handshakeError) throw handshakeError;
     const identity = fields(ready);
     const expected = {
-      board: "meowbit",
-      chip: "esp32",
-      grid: "20x18",
+      board: BOARD.board,
+      chip: BOARD.chip,
+      grid: `${TARGET.width}x${TARGET.height}`,
       lcd: "1",
-      panel: "160x128",
-      cell: "8x7",
+      panel: `${BOARD.lcd.width}x${BOARD.lcd.height}`,
+      cell: `${BOARD.lcd.cell[0]}x${BOARD.lcd.cell[1]}`,
       build: expectedBuildId,
     };
     for (const [key, value] of Object.entries(expected)) {
@@ -380,6 +383,7 @@ async function verify(
         verifiedAt: new Date().toISOString(),
         port,
         baud: BAUD,
+        board: BOARD.board,
         buildId: expectedBuildId,
         firmware: FIRMWARE,
         localFirmwareBytes: firmwareBytes?.byteLength,
@@ -401,7 +405,7 @@ async function verify(
 const command = process.argv[2] ?? "verify";
 if (command !== "flash" && command !== "verify") {
   console.error(
-    "usage: bun vapor/scripts/esp32.ts flash|verify [--port /dev/cu.usbmodem...] [--no-flash]",
+    "usage: bun vapor/scripts/esp32.ts flash|verify [--port /dev/cu.usbmodem...] [--no-flash] [--board meowbit]",
   );
   process.exit(2);
 }
@@ -415,6 +419,6 @@ if (command === "flash" || !process.argv.includes("--no-flash")) {
   await flash(firmware, port);
 }
 if (command === "verify") {
-  const expectedBuildId = firmware?.buildId ?? await esp32BuildId(app);
+  const expectedBuildId = firmware?.buildId ?? await esp32BuildId(app, BOARD);
   await verify(port, app, expectedBuildId);
 }

--- a/vapor/tests/boards.test.ts
+++ b/vapor/tests/boards.test.ts
@@ -1,0 +1,149 @@
+// Board profiles are data with a contract: the loader must refuse malformed
+// or incomplete boards, the derived compile definitions must stay
+// byte-stable (they are the board half of esp32BuildId), and the admission
+// rule must judge demands the way BOARDS.md promises.
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import {
+  admitBoard,
+  boardDefinitions,
+  listBoards,
+  loadBoard,
+  parseBoard,
+  POCKET_PAD,
+  RUNTIME_CHORDS,
+} from "../compiler/boards.ts";
+import { compileVaporApp, VAPOR_TARGETS } from "../compiler/compile.ts";
+import { Button } from "../host/input.ts";
+
+const ENTRY = join(import.meta.dir, "..", "examples", "todo", "todo.tsx");
+
+function meowbitRaw(): any {
+  return {
+    board: "meowbit",
+    title: "Xueersi/KittenBot MeowBit",
+    chip: "esp32",
+    lcd: {
+      controller: "st7735",
+      width: 160,
+      height: 128,
+      cell: [8, 7],
+      madctl: 96,
+      pins: { sclk: 18, mosi: 23, cs: 5, dc: 4, rst: -1, backlight: -1 },
+    },
+    input: {
+      pins: { up: 2, down: 13, left: 27, right: 35, a: 34, b: 12 },
+      chorded: { start: ["a", "b"], select: ["left", "right"], r: ["up", "down"] },
+      absent: ["l"],
+    },
+  };
+}
+
+describe("board registry", () => {
+  test("POCKET_PAD mirrors the Button ids apps compile against", () => {
+    for (const [name, id] of Object.entries(Button) as [string, number][]) {
+      expect(POCKET_PAD[id]).toBe(name.toLowerCase() as (typeof POCKET_PAD)[number]);
+    }
+  });
+
+  test("meowbit is a registered, loadable board", () => {
+    expect(listBoards()).toContain("meowbit");
+    const board = loadBoard("meowbit");
+    expect(board.title).toBe("Xueersi/KittenBot MeowBit");
+    expect(board.input.absent).toEqual(["l"]);
+  });
+
+  test("meowbit derives the exact definitions PR #154 flashed (buildId stability)", () => {
+    // This list is the board half of esp32BuildId. If this test breaks, the
+    // firmware identity of every flashed MeowBit changes with it — that must
+    // be a deliberate act, not a refactor side effect.
+    expect(boardDefinitions(loadBoard("meowbit"))).toEqual([
+      'VP_ESP32_BOARD=\\"meowbit\\"',
+      "VP_LCD_ENABLED=1",
+      "VP_LCD_CONTROLLER=3",
+      "VP_LCD_WIDTH=160",
+      "VP_LCD_HEIGHT=128",
+      "VP_LCD_CELL_W=8",
+      "VP_LCD_CELL_H=7",
+      "VP_LCD_MADCTL=0x60",
+      "VP_LCD_SCLK=18",
+      "VP_LCD_MOSI=23",
+      "VP_LCD_CS=5",
+      "VP_LCD_DC=4",
+      "VP_LCD_RST=-1",
+      "VP_LCD_BL=-1",
+      "VP_BUTTON_COUNT=6",
+      "VP_BUTTON_UP=2",
+      "VP_BUTTON_DOWN=13",
+      "VP_BUTTON_LEFT=27",
+      "VP_BUTTON_RIGHT=35",
+      "VP_BUTTON_A=34",
+      "VP_BUTTON_B=12",
+    ]);
+  });
+
+  test("rejects a chord the runtime does not decode", () => {
+    const raw = meowbitRaw();
+    raw.input.chorded.start = ["a", "up"];
+    expect(() => parseBoard("meowbit", raw)).toThrow(/fixed by vapor_esp32\.c/);
+    delete raw.input.chorded.start;
+    raw.input.chorded.l = RUNTIME_CHORDS.start;
+    expect(() => parseBoard("meowbit", raw)).toThrow(/no chord for "l"/);
+  });
+
+  test("rejects silent pad coverage gaps and double spellings", () => {
+    const gap = meowbitRaw();
+    gap.input.absent = []; // "l" now has no spelling
+    expect(() => parseBoard("meowbit", gap)).toThrow(/"l" must have exactly one spelling.*found 0/);
+
+    const doubled = meowbitRaw();
+    doubled.input.absent = ["l", "start"]; // start is also chorded
+    expect(() => parseBoard("meowbit", doubled)).toThrow(/"start" must have exactly one spelling.*found 2/);
+  });
+
+  test("rejects missing pins, bad chips, and mismatched names", () => {
+    const unwired = meowbitRaw();
+    delete unwired.input.pins.a;
+    expect(() => parseBoard("meowbit", unwired)).toThrow(/input\.pins\.a/);
+
+    const chip = meowbitRaw();
+    chip.chip = "rp2040";
+    expect(() => parseBoard("meowbit", chip)).toThrow(/only board runtime today is "esp32"/);
+
+    expect(() => parseBoard("other-name", meowbitRaw())).toThrow(/"board" must equal the file name/);
+  });
+});
+
+describe("aot admission: derived demands vs board profile", () => {
+  const board = loadBoard("meowbit");
+  const grid = VAPOR_TARGETS.esp32;
+
+  test("todo admits onto meowbit with exactly the three chord warnings", async () => {
+    const source = await Bun.file(ENTRY).text();
+    const app = compileVaporApp(ENTRY, source, "VAPOR TODO", "esp32");
+    expect(app.buttonsUsed).toEqual([0, 1, 2, 3, 4, 5, 6, 7, 8]); // everything but L
+    const issues = admitBoard({ buttonsUsed: app.buttonsUsed }, board, grid);
+    expect(issues.map((issue) => [issue.code, issue.severity])).toEqual([
+      ["VB103", "warn"],
+      ["VB103", "warn"],
+      ["VB103", "warn"],
+    ]);
+  });
+
+  test("a demand for an unmapped button is refused", () => {
+    const issues = admitBoard({ buttonsUsed: [Button.L] }, board, grid);
+    expect(issues).toEqual([
+      {
+        code: "VB102",
+        severity: "error",
+        message: 'app uses "l" but meowbit has no mapping for it',
+      },
+    ]);
+  });
+
+  test("a grid the panel cannot host is refused", () => {
+    const issues = admitBoard({ buttonsUsed: [] }, board, { width: 30, height: 20 });
+    expect(issues.map((issue) => issue.code)).toEqual(["VB101"]);
+  });
+});

--- a/vapor/tests/compiler.test.ts
+++ b/vapor/tests/compiler.test.ts
@@ -2,6 +2,7 @@
 
 import { describe, expect, test } from "bun:test";
 import { join } from "node:path";
+import { loadBoard } from "../compiler/boards.ts";
 import { compileVaporApp, VAPOR_TARGETS, VaporCompileError } from "../compiler/compile.ts";
 import { esp32BuildId } from "../compiler/esp32.ts";
 import { FONT8 } from "../compiler/font.gen.ts";
@@ -87,7 +88,7 @@ describe("pocket vapor compiler", () => {
     expect(compiled.plan).toContain("760 B font + 12 B style data");
   });
 
-  test("esp32 build identity is deterministic and source-sensitive", async () => {
+  test("esp32 build identity is deterministic, source- and board-sensitive", async () => {
     const app = compileVaporApp("esp32.tsx", minimal(""), "ESP32", "esp32");
     const same = compileVaporApp("esp32.tsx", minimal(""), "ESP32", "esp32");
     const changed = compileVaporApp(
@@ -97,10 +98,15 @@ describe("pocket vapor compiler", () => {
       "esp32",
     );
 
-    const id = await esp32BuildId(app);
+    const board = loadBoard("meowbit");
+    const id = await esp32BuildId(app, board);
     expect(id).toMatch(/^[0-9a-f]{16}$/);
-    expect(await esp32BuildId(same)).toBe(id);
-    expect(await esp32BuildId(changed)).not.toBe(id);
+    expect(await esp32BuildId(same, board)).toBe(id);
+    expect(await esp32BuildId(changed, board)).not.toBe(id);
+
+    const rewired = structuredClone(board);
+    rewired.input.pins.b = 14;
+    expect(await esp32BuildId(app, rewired)).not.toBe(id);
   });
 
   test("effect masks subscribe conditional reads on both arms", async () => {


### PR DESCRIPTION
## Summary

Follow-up to #154: the scaling design for the AOT target family, so MCU boards multiply as data files instead of registry entries. Full argument in `vapor/BOARDS.md`.

- **Execution classes in the platform contract** — `EXECUTION_CLASSES` (`guest` / `aot`) in `contracts/spec/platforms.ts`; pocket.json v2 gains optional `execution.classes` (schema regenerated), and the guest resolver consumes it: a manifest that ships no guest artifact is refused with `execution.guestExcluded`.
- **Boards are data** — `MEOWBIT_DEFINITIONS` moves out of the compiler into `vapor/boards/meowbit.json`, loaded and validated by `vapor/compiler/boards.ts`: chords are pinned to the exact pairs the C runtime decodes, and all ten Pocket buttons must have exactly one spelling (direct pin / chord / absent). Adding a device = adding a JSON file.
- **Demands are derived, never authored** — the compiler records the Button ids the source statically references (`CompiledApp.buttonsUsed`, keymap keys + folded `Button.X` reads, per-target under `SCREEN` folds).
- **Admission rule** — `admitBoard(demands, board, grid)`: VB101 grid/panel fit (error), VB102 unmapped button (error), VB103 chord-only reachability (warn — the VS104 of input).
- **`vapor:check` grows board rows and `--json`** — the human matrix now judges every registered board; `--json` emits demands + verdicts as data for a store or CI.
- `flash`/`verify` take `--board <name>` (default `meowbit`); expected receipts derive from board data.

## Firmware identity is provably preserved

The derived `-D` definitions are byte-identical to #154's literal list (locked by a test), so the build id of the flashed, hardware-verified MeowBit firmware is unchanged through the refactor:

- `esp32BuildId` via the new pipeline: `c0645d4c9a9d5d57` — equal to the #154 hardware receipt
- full ESP-IDF build through board data: `dist/vapor/todo.esp32.bin` 151,296 bytes, same as #154
- `vapor:esp32:verify --no-flash` against the already-flashed board remains valid

## Deliberately not built yet (recorded in BOARDS.md)

Per-board grid geometry (second board with a different panel forces it), chord tables as data (needs the C decoder generalized first), and a build service (companion-local compile suffices at this board count).

## Validation

- `bun test vapor/tests/` — 53 pass, 0 fail, 7,313 assertions (incl. 3-console per-press parity)
- `bun test tests/platform-contracts.test.ts tests/cli.test.ts` — 32 pass
- `bun tests/contract.ts` — spec.rs byte-compare green
- `bunx tsc --noEmit -p vapor`
- `bun run vapor:check` and `check --json` on the todo example
- `bun run vapor:esp32` — full firmware build through the board pipeline
- root `tsc --noEmit` failures are pre-existing on main (missing generated `styles.generated.ts`, `pocket-pack.ts`), verified via stash

🤖 Generated with [Claude Code](https://claude.com/claude-code)