### PR TITLE
fix(site): deploy the manifest schema at its published URL

### DIFF
--- a/site/build.ts
+++ b/site/build.ts
@@ -304,8 +304,9 @@ async function main() {
 
   // 2. runtime assets
   // Keep the editor-facing URL byte-identical to the schema used by the
-  // validator. The deployed path is POCKET_MANIFEST_SCHEMA_ID.
-  copy(ROOT + "contracts/schema/pocket-2.json", "contracts/schema/pocket-2.json");
+  // validator. The deployed path is POCKET_MANIFEST_SCHEMA_ID —
+  // /schema/pocket-2.json, independent of where the repo keeps the file.
+  copy(ROOT + "contracts/schema/pocket-2.json", "schema/pocket-2.json");
   copy(ROOT + "hosts/web/pocketjs.wasm", "pg/pocketjs.wasm");
   copy(ROOT + "assets/fonts/Inter-Regular.ttf", "pg/fonts/Inter-Regular.ttf");
   copy(ROOT + "assets/fonts/Inter-Bold.ttf", "pg/fonts/Inter-Bold.ttf");


### PR DESCRIPTION
## Summary

`site/build.ts` copied the pocket.json schema to `site/dist/contracts/schema/pocket-2.json`; both `POCKET_MANIFEST_SCHEMA_ID` (`https://pocketjs.dev/schema/pocket-2.json`) and release.yml's gate (`cmp contracts/schema/pocket-2.json site/dist/schema/pocket-2.json`) expect `site/dist/schema/`. The #149 restructure updated the copy's destination together with its source, so the published schema URL has been 404 since then — and the v0.7.0 release run failed at the schema gate (run 29993721790) before any publish step ran.

One-line fix: copy to `schema/pocket-2.json`, matching the promise in the adjacent comment.

## Validation

- `bun run site:build && cmp contracts/schema/pocket-2.json site/dist/schema/pocket-2.json` — byte-identical
- no stray `site/dist/contracts/` remains

After merge: retag `v0.7.0` on the new main head to rerun the release (nothing was published by the failed run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)