### PR TITLE
fix(release): publish @pocketjs/cli from tools/cli after the #149 move

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -108,7 +108,7 @@ jobs:
           fi
 
       - name: Publish @pocketjs/cli
-        working-directory: cli
+        working-directory: tools/cli
         run: |
           name=$(node -p "require('./package.json').name")
           version=$(node -p "require('./package.json').version")


### PR DESCRIPTION
## Summary

Second v0.7.0 release run (29994515146) got past every gate and published `@pocketjs/framework@0.7.0`, then failed at **Publish @pocketjs/cli**: the step's `working-directory: cli` predates #149, which moved the package to `tools/cli/`. One-line fix.

State after the failed run:
- `@pocketjs/framework@0.7.0` — published ✓ (`npm view` confirms)
- `@pocketjs/cli@0.7.0` — not published
- GitHub Release — not created

All publish steps carry already-published/already-exists guards, so retagging `v0.7.0` on the merged head reruns the workflow and completes the two remaining steps without double-publishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)