### PR TITLE
fix(symbian): use E7 physical key input

### DIFF
--- a/hosts/symbian/runtime/main.cpp
+++ b/hosts/symbian/runtime/main.cpp
@@ -1193,6 +1193,7 @@ private:
     bool validViewport(const QSize &viewport) const;
     QRect presentationRect() const;
     QString takeException(JSContext *context);
+    void clearInput();
     void fail(const QString &message);
     void queueViewport(const QSize &viewport);
     void requestSummon();
@@ -1220,7 +1221,9 @@ private:
     QSize pendingViewportSize_;
     QSize windowSize_;
     int buttons_;
+    int pressedButtons_;
     uint32_t nativeKeys_;
+    uint32_t pressedNativeKeys_;
     int currentApp_;
     int pendingApp_;
     int resumeApp_;
@@ -1271,7 +1274,9 @@ PocketJsRuntime::PocketJsRuntime()
           POCKETJS_INITIAL_LOGICAL_HEIGHT
       ),
       buttons_(0),
+      pressedButtons_(0),
       nativeKeys_(0),
+      pressedNativeKeys_(0),
       currentApp_(0),
       pendingApp_(-1),
       resumeApp_(-1),
@@ -1291,6 +1296,9 @@ PocketJsRuntime::PocketJsRuntime()
     setAttribute(Qt::WA_OpaquePaintEvent, true);
     setAttribute(Qt::WA_AcceptTouchEvents, true);
     setAttribute(Qt::WA_AutoOrientation, true);
+    // This surface is a controller, not a Qt text editor. Do not advertise
+    // input-method capabilities; controller identity comes from nativeScanCode.
+    setAttribute(Qt::WA_InputMethodEnabled, false);
     setFocusPolicy(Qt::StrongFocus);
 
     errorLabel_->setAlignment(Qt::AlignCenter);
@@ -1323,6 +1331,15 @@ PocketJsRuntime::~PocketJsRuntime()
         doneCurrent();
     }
     glInitialized_ = false;
+}
+
+void PocketJsRuntime::clearInput()
+{
+    buttons_ = 0;
+    pressedButtons_ = 0;
+    nativeKeys_ = 0;
+    pressedNativeKeys_ = 0;
+    touches_.clear();
 }
 
 void PocketJsRuntime::destroyGuest()
@@ -1362,9 +1379,7 @@ void PocketJsRuntime::destroyGuest()
     resizeViewport_ = JS_UNDEFINED;
     appJavaScript_.clear();
     appPack_.clear();
-    touches_.clear();
-    buttons_ = 0;
-    nativeKeys_ = 0;
+    clearInput();
     frozenShotHandle_ = -1;
 }
 
@@ -1968,9 +1983,7 @@ void PocketJsRuntime::queueViewport(const QSize &viewport)
         windowSize_ = viewport;
         pendingViewportSize_ = viewport;
         hasPendingViewport_ = false;
-        buttons_ = 0;
-        nativeKeys_ = 0;
-        touches_.clear();
+        clearInput();
         update();
         return;
     }
@@ -1989,9 +2002,7 @@ void PocketJsRuntime::queueViewport(const QSize &viewport)
 
     // Coordinates and held keyboard directions belong to the old screen
     // orientation. Never deliver them against the replacement layout.
-    buttons_ = 0;
-    nativeKeys_ = 0;
-    touches_.clear();
+    clearInput();
 }
 
 bool PocketJsRuntime::applyPendingViewport()
@@ -2012,9 +2023,7 @@ bool PocketJsRuntime::applyPendingViewport()
 
     ui_set_viewport(viewport.width(), viewport.height());
     viewportSize_ = viewport;
-    buttons_ = 0;
-    nativeKeys_ = 0;
-    touches_.clear();
+    clearInput();
     if (extension_ != 0 && extension_->resize != 0) {
         extension_->resize(viewport.width(), viewport.height());
     }
@@ -2082,7 +2091,12 @@ void PocketJsRuntime::runFrame()
     QTime perfTimer;
     perfTimer.start();
 #endif
-    int frameButtons = buttons_;
+    // Preserve a quick press+release for one host frame. S60 can deliver both
+    // events between two 30 Hz samples even though the core advances at 60 Hz.
+    int frameButtons = buttons_ | pressedButtons_;
+    const uint32_t frameNativeKeys = nativeKeys_ | pressedNativeKeys_;
+    pressedButtons_ = 0;
+    pressedNativeKeys_ = 0;
     if (apps_.size() > 1 && currentApp_ != 0) {
         const bool selectPressed =
             (frameButtons & kButtonSelect) != 0;
@@ -2097,7 +2111,7 @@ void PocketJsRuntime::runFrame()
             context_,
             static_cast<uint32_t>(frameButtons),
             static_cast<uint32_t>(kAnalogCenter),
-            nativeKeys_
+            frameNativeKeys
         ) == 0) {
         fail("PocketJS native extension frame failed.");
         return;
@@ -2340,7 +2354,10 @@ bool PocketJsRuntime::event(QEvent *event)
 
 void PocketJsRuntime::keyPressEvent(QKeyEvent *event)
 {
-    const int key = pocketjsSymbianNormalizeKey(event->key());
+    const int key = pocketjsSymbianControlKey(
+        event->key(),
+        event->nativeScanCode()
+    );
     const int button = buttonForKey(key);
     const uint32_t nativeKey = nativeKeyForKey(key);
     if (button != 0 || nativeKey != 0) {
@@ -2348,8 +2365,12 @@ void PocketJsRuntime::keyPressEvent(QKeyEvent *event)
             event->accept();
             return;
         }
-        if (button != 0) buttons_ |= button;
+        if (button != 0) {
+            buttons_ |= button;
+            pressedButtons_ |= button;
+        }
         nativeKeys_ |= nativeKey;
+        pressedNativeKeys_ |= nativeKey;
         event->accept();
         return;
     }
@@ -2358,7 +2379,10 @@ void PocketJsRuntime::keyPressEvent(QKeyEvent *event)
 
 void PocketJsRuntime::keyReleaseEvent(QKeyEvent *event)
 {
-    const int key = pocketjsSymbianNormalizeKey(event->key());
+    const int key = pocketjsSymbianControlKey(
+        event->key(),
+        event->nativeScanCode()
+    );
     const int button = buttonForKey(key);
     const uint32_t nativeKey = nativeKeyForKey(key);
     if (button != 0 || nativeKey != 0) {
@@ -2376,9 +2400,7 @@ void PocketJsRuntime::keyReleaseEvent(QKeyEvent *event)
 
 void PocketJsRuntime::focusOutEvent(QFocusEvent *event)
 {
-    buttons_ = 0;
-    nativeKeys_ = 0;
-    touches_.clear();
+    clearInput();
     QGLWidget::focusOutEvent(event);
 }
 

--- a/hosts/symbian/runtime/pocketjs_symbian_keys.h
+++ b/hosts/symbian/runtime/pocketjs_symbian_keys.h
@@ -11,23 +11,39 @@
     (((key) >= 'a' && (key) <= 'z') ? ((key) - ('a' - 'A')) : (key))
 
 /*
- * Symbian exposes physical A-Z keys as their uppercase ASCII scan codes.
- * Prefer that stable identity for controller input: the FEP may translate the
- * logical key into the number or symbol printed above an E7 keyboard key.
- * Synthetic/non-Symbian events have no usable letter scan code and retain the
- * normalized logical-key fallback.
+ * The E7/RM-626 keyboard matrix exposes its Q-P row through scan codes 1-0;
+ * the same physical keys produce Q-P normally and those digits through Fn.
+ * Its remaining letter keys use A-Z scan codes. Resolve that target-specific
+ * physical layout before the FEP-dependent logical key, but never reinterpret
+ * a logical digit when native scan information is absent.
  */
 #define POCKETJS_SYMBIAN_IS_PHYSICAL_LETTER_SCAN_CODE(key) \
     ((key) >= 'A' && (key) <= 'Z')
 
-#define POCKETJS_SYMBIAN_CONTROL_KEY(key, nativeScanCode) \
-    (POCKETJS_SYMBIAN_IS_PHYSICAL_LETTER_SCAN_CODE(nativeScanCode) \
-        ? (nativeScanCode) \
-        : POCKETJS_SYMBIAN_NORMALIZED_ASCII_KEY(key))
-
 static inline int pocketjsSymbianNormalizeKey(int key)
 {
     return POCKETJS_SYMBIAN_NORMALIZED_ASCII_KEY(key);
+}
+
+static inline int pocketjsSymbianE7PhysicalKey(unsigned int nativeScanCode)
+{
+    switch (nativeScanCode) {
+    case '1': return 'Q';
+    case '2': return 'W';
+    case '3': return 'E';
+    case '4': return 'R';
+    case '5': return 'T';
+    case '6': return 'Y';
+    case '7': return 'U';
+    case '8': return 'I';
+    case '9': return 'O';
+    case '0': return 'P';
+    default: break;
+    }
+    if (POCKETJS_SYMBIAN_IS_PHYSICAL_LETTER_SCAN_CODE(nativeScanCode)) {
+        return (int)nativeScanCode;
+    }
+    return 0;
 }
 
 static inline int pocketjsSymbianControlKey(
@@ -35,7 +51,11 @@ static inline int pocketjsSymbianControlKey(
     unsigned int nativeScanCode
 )
 {
-    return POCKETJS_SYMBIAN_CONTROL_KEY(key, nativeScanCode);
+    const int physicalKey =
+        pocketjsSymbianE7PhysicalKey(nativeScanCode);
+    return physicalKey != 0
+        ? physicalKey
+        : pocketjsSymbianNormalizeKey(key);
 }
 
 #endif

--- a/hosts/symbian/runtime/pocketjs_symbian_keys.h
+++ b/hosts/symbian/runtime/pocketjs_symbian_keys.h
@@ -10,9 +10,32 @@
 #define POCKETJS_SYMBIAN_NORMALIZED_ASCII_KEY(key) \
     (((key) >= 'a' && (key) <= 'z') ? ((key) - ('a' - 'A')) : (key))
 
+/*
+ * Symbian exposes physical A-Z keys as their uppercase ASCII scan codes.
+ * Prefer that stable identity for controller input: the FEP may translate the
+ * logical key into the number or symbol printed above an E7 keyboard key.
+ * Synthetic/non-Symbian events have no usable letter scan code and retain the
+ * normalized logical-key fallback.
+ */
+#define POCKETJS_SYMBIAN_IS_PHYSICAL_LETTER_SCAN_CODE(key) \
+    ((key) >= 'A' && (key) <= 'Z')
+
+#define POCKETJS_SYMBIAN_CONTROL_KEY(key, nativeScanCode) \
+    (POCKETJS_SYMBIAN_IS_PHYSICAL_LETTER_SCAN_CODE(nativeScanCode) \
+        ? (nativeScanCode) \
+        : POCKETJS_SYMBIAN_NORMALIZED_ASCII_KEY(key))
+
 static inline int pocketjsSymbianNormalizeKey(int key)
 {
     return POCKETJS_SYMBIAN_NORMALIZED_ASCII_KEY(key);
+}
+
+static inline int pocketjsSymbianControlKey(
+    int key,
+    unsigned int nativeScanCode
+)
+{
+    return POCKETJS_SYMBIAN_CONTROL_KEY(key, nativeScanCode);
 }
 
 #endif

--- a/tests/fixtures/symbian-key-normalization-test.c
+++ b/tests/fixtures/symbian-key-normalization-test.c
@@ -16,31 +16,32 @@
 #error Qt special keys must remain unchanged
 #endif
 
-#if POCKETJS_SYMBIAN_CONTROL_KEY('1', 'W') != 'W'
-#error physical W must win over its translated secondary glyph
-#endif
-
-#if POCKETJS_SYMBIAN_CONTROL_KEY('d', 'D') != 'D'
-#error physical D must remain a controller letter
-#endif
-
-#if POCKETJS_SYMBIAN_CONTROL_KEY('r', 0) != 'R'
-#error events without a scan code must retain the logical fallback
-#endif
-
-#if POCKETJS_SYMBIAN_CONTROL_KEY(0x01000013, 0x0000000e) != 0x01000013
-#error non-letter scan codes must not replace Qt special keys
-#endif
-
-#if POCKETJS_SYMBIAN_CONTROL_KEY(0x01000013, 0x61) != 0x01000013
-#error Symbian F2 scan code must not be mistaken for lowercase A
-#endif
-
-#if POCKETJS_SYMBIAN_CONTROL_KEY(0x01000013, 0x79) != 0x01000013
-#error Symbian comma scan code must not be mistaken for lowercase Y
-#endif
-
 int main(void)
 {
-    return pocketjsSymbianControlKey('4', 'R') == 'R' ? 0 : 1;
+    static const char scans[] = {
+        '1', '2', '3', '4', '5', '6', '7', '8', '9', '0'
+    };
+    static const char controls[] = {
+        'Q', 'W', 'E', 'R', 'T', 'Y', 'U', 'I', 'O', 'P'
+    };
+    unsigned int index;
+
+    for (index = 0; index < sizeof(scans) / sizeof(scans[0]); ++index) {
+        if (pocketjsSymbianControlKey(
+                scans[index],
+                (unsigned int)scans[index]
+            ) != controls[index]) {
+            return 10 + (int)index;
+        }
+    }
+    if (pocketjsSymbianControlKey('d', 'D') != 'D') return 21;
+    if (pocketjsSymbianControlKey('r', 0) != 'R') return 22;
+    if (pocketjsSymbianControlKey(0x01000013, 0x0000000e) !=
+        0x01000013) return 23;
+    if (pocketjsSymbianControlKey(0x01000013, 0x61) !=
+        0x01000013) return 24;
+    if (pocketjsSymbianControlKey(0x01000013, 0x79) !=
+        0x01000013) return 25;
+    if (pocketjsSymbianControlKey('2', 0) != '2') return 26;
+    return 0;
 }

--- a/tests/fixtures/symbian-key-normalization-test.c
+++ b/tests/fixtures/symbian-key-normalization-test.c
@@ -16,7 +16,31 @@
 #error Qt special keys must remain unchanged
 #endif
 
+#if POCKETJS_SYMBIAN_CONTROL_KEY('1', 'W') != 'W'
+#error physical W must win over its translated secondary glyph
+#endif
+
+#if POCKETJS_SYMBIAN_CONTROL_KEY('d', 'D') != 'D'
+#error physical D must remain a controller letter
+#endif
+
+#if POCKETJS_SYMBIAN_CONTROL_KEY('r', 0) != 'R'
+#error events without a scan code must retain the logical fallback
+#endif
+
+#if POCKETJS_SYMBIAN_CONTROL_KEY(0x01000013, 0x0000000e) != 0x01000013
+#error non-letter scan codes must not replace Qt special keys
+#endif
+
+#if POCKETJS_SYMBIAN_CONTROL_KEY(0x01000013, 0x61) != 0x01000013
+#error Symbian F2 scan code must not be mistaken for lowercase A
+#endif
+
+#if POCKETJS_SYMBIAN_CONTROL_KEY(0x01000013, 0x79) != 0x01000013
+#error Symbian comma scan code must not be mistaken for lowercase Y
+#endif
+
 int main(void)
 {
-    return pocketjsSymbianNormalizeKey('d') == 'D' ? 0 : 1;
+    return pocketjsSymbianControlKey('4', 'R') == 'R' ? 0 : 1;
 }

--- a/tests/symbian-runtime.test.ts
+++ b/tests/symbian-runtime.test.ts
@@ -36,19 +36,43 @@ describe("experimental Nokia E7 runtime profile", () => {
       "cc is required to validate the Symbian key mapper",
     ).toBeTruthy();
     if (!compiler) return;
-    const compiled = Bun.spawnSync([
-      compiler,
-      "-std=c11",
-      "-Wall",
-      "-Wextra",
-      "-Werror",
-      "-fsyntax-only",
-      join(
-        repository,
-        "tests/fixtures/symbian-key-normalization-test.c",
-      ),
-    ], { cwd: repository });
-    expect(compiled.exitCode, compiled.stderr.toString()).toBe(0);
+    const root = mkdtempSync(join(tmpdir(), "pocketjs-e7-key-map-"));
+    try {
+      const executable = join(root, "symbian-key-map-test");
+      const compiled = Bun.spawnSync([
+        compiler,
+        "-std=c11",
+        "-Wall",
+        "-Wextra",
+        "-Werror",
+        join(
+          repository,
+          "tests/fixtures/symbian-key-normalization-test.c",
+        ),
+        "-o",
+        executable,
+      ], { cwd: repository });
+      expect(compiled.exitCode, compiled.stderr.toString()).toBe(0);
+
+      // Managed macOS hosts can attach provenance to a freshly linked
+      // temporary executable and hold its first launch beyond Bun's timeout.
+      // This file is built above from the committed hermetic fixture.
+      if (process.platform === "darwin") {
+        const xattr = Bun.which("xattr");
+        if (xattr) {
+          Bun.spawnSync([
+            xattr,
+            "-d",
+            "com.apple.provenance",
+            executable,
+          ]);
+        }
+      }
+      const ran = Bun.spawnSync([executable], { cwd: repository });
+      expect(ran.exitCode, ran.stderr.toString()).toBe(0);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("serializes the shared launcher source tree across targets", async () => {

--- a/tests/symbian-runtime.test.ts
+++ b/tests/symbian-runtime.test.ts
@@ -29,11 +29,11 @@ import { validateAndResolveBuildPlan } from "../framework/src/manifest/resolve.t
 const repository = new URL("..", import.meta.url).pathname;
 
 describe("experimental Nokia E7 runtime profile", () => {
-  test("normalizes unshifted S60 letter keysyms without changing special keys", () => {
+  test("maps the E7 scan matrix without changing unrelated keys", () => {
     const compiler = Bun.which("cc");
     expect(
       compiler,
-      "cc is required to validate the Symbian key normalizer",
+      "cc is required to validate the Symbian key mapper",
     ).toBeTruthy();
     if (!compiler) return;
     const compiled = Bun.spawnSync([
@@ -474,7 +474,21 @@ describe("experimental Nokia E7 runtime profile", () => {
       "((key) >= 'a' && (key) <= 'z') ? ((key) - ('a' - 'A')) : (key)",
     );
     expect(keyHeader).toContain("pocketjsSymbianNormalizeKey");
-    expect(keyHeader).toContain("POCKETJS_SYMBIAN_CONTROL_KEY");
+    expect(keyHeader).toContain("pocketjsSymbianE7PhysicalKey");
+    for (const [scan, control] of [
+      ["1", "Q"],
+      ["2", "W"],
+      ["3", "E"],
+      ["4", "R"],
+      ["5", "T"],
+      ["6", "Y"],
+      ["7", "U"],
+      ["8", "I"],
+      ["9", "O"],
+      ["0", "P"],
+    ]) {
+      expect(keyHeader).toContain(`case '${scan}': return '${control}';`);
+    }
     expect(keyHeader).toContain("pocketjsSymbianControlKey");
     expect(runtime).toContain("setAttribute(Qt::WA_AutoOrientation, true)");
     expect(runtime).toContain(

--- a/tests/symbian-runtime.test.ts
+++ b/tests/symbian-runtime.test.ts
@@ -457,15 +457,29 @@ describe("experimental Nokia E7 runtime profile", () => {
     expect(runtime).toContain("POCKETJS_SYMBIAN_KEY_MOVE_FORWARD");
     expect(runtime).toContain("POCKETJS_SYMBIAN_KEY_LOOK_LEFT");
     expect(runtime).toContain("POCKETJS_SYMBIAN_KEY_RELOAD");
-    expect(runtime.match(/pocketjsSymbianNormalizeKey\(event->key\(\)\)/g))
+    expect(runtime.match(/pocketjsSymbianControlKey\(/g))
       .toHaveLength(2);
+    expect(runtime.match(/event->nativeScanCode\(\)/g)).toHaveLength(2);
     expect(runtime).toContain("nativeKeys_ |= nativeKey");
     expect(runtime).toContain("nativeKeys_ &= ~nativeKey");
+    expect(runtime).toContain("pressedNativeKeys_ |= nativeKey");
+    expect(runtime).toContain(
+      "const uint32_t frameNativeKeys = nativeKeys_ | pressedNativeKeys_;",
+    );
+    expect(runtime).toContain("int frameButtons = buttons_ | pressedButtons_;");
+    expect(runtime).toContain("void PocketJsRuntime::clearInput()");
+    expect(runtime).toContain("pressedButtons_ = 0;");
+    expect(runtime).toContain("pressedNativeKeys_ = 0;");
     expect(keyHeader).toContain(
       "((key) >= 'a' && (key) <= 'z') ? ((key) - ('a' - 'A')) : (key)",
     );
     expect(keyHeader).toContain("pocketjsSymbianNormalizeKey");
+    expect(keyHeader).toContain("POCKETJS_SYMBIAN_CONTROL_KEY");
+    expect(keyHeader).toContain("pocketjsSymbianControlKey");
     expect(runtime).toContain("setAttribute(Qt::WA_AutoOrientation, true)");
+    expect(runtime).toContain(
+      "setAttribute(Qt::WA_InputMethodEnabled, false)",
+    );
     expect(runtime).not.toContain("WA_LockLandscapeOrientation");
     expect(runtime).toContain('"__pocketResizeViewport"');
     expect(runtime).toContain("queueViewport(event->size())");


### PR DESCRIPTION
## Summary
- resolve controller letters from stable Symbian physical scan codes
- map the Nokia E7/RM-626 shared 1-0 scan row to its Q-P controller letters
- latch fast press/release pulses for one 30 Hz host frame
- clear held and latched input across viewport, guest, and focus boundaries
- explicitly keep the controller surface out of Qt text-input mode

## Root cause
The E7 physical Q-P row reports native scan codes 1-0 because those keys produce digits through Fn. Qt logical key values are FEP-dependent, so W and R could arrive as 2 and 4 while A, S, and D used alphabetic scans. The host now resolves the complete target-specific physical matrix first and falls back to the logical key only when no recognized native scan is available.

## Validation
- bun run test: passed
- bunx tsc --noEmit: passed
- C++98 key-helper compile check: passed
- compiled and executed hermetic E7 key-matrix fixture: passed
- independent Qt 4.7/S60 review: no P0-P2 findings
- Nokia E7 hardware acceptance through OpenStrike: W/A/S/D movement, R reload, Enter fire, map selection, and view controls all passed
