### PR TITLE
feat(render): add transactional strip rendering

### DIFF
--- a/engine/backends/esp32p4-ppa/README.md
+++ b/engine/backends/esp32p4-ppa/README.md
@@ -47,6 +47,19 @@ renderer drops texture classifications even when DrawList handles stay
 unchanged. Call `Renderer::invalidate_resources()` and explicitly invalidate
 target states only for output-affecting changes performed outside `Ui`.
 
+Hosts that present damage through a separate asynchronous display pipeline can
+split planning from history updates:
+
+- `prepare_damage` computes a plan without mutating the target snapshot;
+- `render_strip` renders one logical damage rectangle into a compact,
+  full-viewport-width RGB565 strip while preserving global sampling phase;
+- `commit_damage` advances history only after every strip is presented;
+- `abort_damage` invalidates a partially updated target so its next plan is a
+  full redraw.
+
+This keeps framebuffer history transactional when a display transfer fails and
+lets two reusable strips overlap CPU rendering with asynchronous presentation.
+
 ## Test
 
 Run the portable renderer and pixel-parity tests on the host:

--- a/engine/backends/esp32p4-ppa/src/lib.rs
+++ b/engine/backends/esp32p4-ppa/src/lib.rs
@@ -18,6 +18,7 @@ use pocketjs_core::damage::{
 };
 use pocketjs_core::raster::{
     coverage_index, linear_sample_coordinates, pack_rgb565, render_scaled_rgb565_over,
+    render_scaled_rgb565_window_over,
 };
 use pocketjs_core::{spec, TexView, Ui};
 
@@ -160,12 +161,16 @@ pub struct RenderStats {
 /// Core damage snapshot describing the pixels stored in one framebuffer.
 pub type RenderTargetState = DamageTracker<MAX_DAMAGE_REGIONS>;
 
+/// Damage plan produced for one persistent render target.
+pub type RenderDamagePlan = DamagePlan<MAX_DAMAGE_REGIONS>;
+
 /// Persistent DrawList renderer. The A8 plane and fallback word buffer are
 /// reused across frames.
 pub struct Renderer {
     config: RendererConfig,
     mask_storage: Vec<u128>,
     mask_offset: usize,
+    mask_capacity: usize,
     mask_len: usize,
     fallback_words: Vec<u32>,
     alpha_texture_cache: Vec<(i32, bool)>,
@@ -181,6 +186,7 @@ impl Renderer {
             config,
             mask_storage: Vec::new(),
             mask_offset: 0,
+            mask_capacity: 0,
             mask_len: 0,
             fallback_words: Vec::with_capacity(16),
             alpha_texture_cache: Vec::new(),
@@ -224,6 +230,41 @@ impl Renderer {
         self.render_damage(ui, words, destination, width, height, &damage, true, ppa)
     }
 
+    /// Compute damage against the DrawList last committed to `target`.
+    ///
+    /// This does not mutate `target`. Call [`commit_damage`](Self::commit_damage)
+    /// only after every corresponding output update has completed successfully,
+    /// or [`abort_damage`](Self::abort_damage) after a failed/partial update.
+    pub fn prepare_damage(
+        &mut self,
+        target: &RenderTargetState,
+        ui: &Ui,
+        words: &[u32],
+    ) -> Option<RenderDamagePlan> {
+        self.sync_resources(ui);
+        let damage_target = self.damage_target(ui)?;
+        target
+            .prepare(ui, words, damage_target)
+            .ok()?
+            .with_policy(DamagePolicy::new(FULL_REDRAW_PERCENT))
+            .ok()
+    }
+
+    /// Record a successfully presented DrawList in one persistent target.
+    pub fn commit_damage(&self, target: &mut RenderTargetState, ui: &Ui, words: &[u32]) -> bool {
+        let Some(damage_target) = self.damage_target(ui) else {
+            target.invalidate();
+            return false;
+        };
+        target.commit(ui, words, damage_target);
+        true
+    }
+
+    /// Invalidate a persistent target after an aborted or partial update.
+    pub fn abort_damage(&self, target: &mut RenderTargetState) {
+        target.invalidate();
+    }
+
     /// Repaint only pixels whose DrawList operations differ from the snapshot
     /// stored in `target`.
     ///
@@ -242,15 +283,8 @@ impl Renderer {
         height: u32,
         ppa: &mut O,
     ) -> Option<RenderStats> {
-        self.sync_resources(ui);
         self.target_screen(ui, destination, width, height)?;
-        let damage_target =
-            DamageTarget::new(width, height, self.config.scale, DAMAGE_TARGET_SIGNATURE);
-        let damage = target
-            .prepare(ui, words, damage_target)
-            .ok()?
-            .with_policy(DamagePolicy::new(FULL_REDRAW_PERCENT))
-            .ok()?;
+        let damage = self.prepare_damage(target, ui, words)?;
         let full_redraw = damage.is_full_redraw();
 
         let result = self.render_damage(
@@ -264,11 +298,108 @@ impl Renderer {
             ppa,
         );
         if result.is_some() {
-            target.commit(ui, words, damage_target);
+            if !self.commit_damage(target, ui, words) {
+                return None;
+            }
         } else {
-            target.invalidate();
+            self.abort_damage(target);
         }
         result
+    }
+
+    /// Render one global logical dirty rectangle into a tightly packed
+    /// full-width horizontal strip.
+    ///
+    /// `region.y..region.y + region.h` defines both the strip's global vertical
+    /// interval and its height. The backing buffer is
+    /// `viewport_width * region.h` pixels at `config.scale`; pixels outside
+    /// `region.x..region.x + region.w` are left untouched. DrawList geometry and
+    /// sampling remain in global viewport coordinates while all PPA surfaces
+    /// and mask offsets are translated to strip-local coordinates.
+    pub fn render_strip<O: PpaOps>(
+        &mut self,
+        ui: &Ui,
+        words: &[u32],
+        destination: &mut [u16],
+        region: Rect,
+        ppa: &mut O,
+    ) -> Option<RenderStats> {
+        self.sync_resources(ui);
+        if region.is_empty() {
+            return None;
+        }
+        let (viewport_w, viewport_h) = ui.viewport();
+        let logical_width = viewport_w as u32;
+        let logical_height = viewport_h as u32;
+        let x1 = region.x.checked_add(region.w)?;
+        let y1 = region.y.checked_add(region.h)?;
+        if logical_width == 0 || logical_height == 0 || x1 > logical_width || y1 > logical_height {
+            return None;
+        }
+
+        let scale = self.config.scale;
+        let width = logical_width.checked_mul(scale)?;
+        let height = region.h.checked_mul(scale)?;
+        if destination.len() != width as usize * height as usize {
+            return None;
+        }
+
+        let surface = Clip {
+            x0: 0,
+            y0: region.y as i32,
+            x1: logical_width as i32,
+            y1: y1 as i32,
+        };
+        let clip = Clip {
+            x0: region.x as i32,
+            y0: region.y as i32,
+            x1: x1 as i32,
+            y1: y1 as i32,
+        };
+        let local = local_physical_rect(clip, surface, scale);
+        let mut stats = RenderStats {
+            damage_regions: 1,
+            damage_pixels: region.area().saturating_mul(scale).saturating_mul(scale),
+            damage_bounds: physical_rect(clip, scale),
+            ..RenderStats::default()
+        };
+
+        self.ensure_mask(destination.len());
+        if local.area() >= self.config.min_fill_pixels
+            && ppa.fill_rgb565(destination, width, height, local, 0)
+        {
+            stats.ppa_fills += 1;
+        } else {
+            fill_rgb565_rect(destination, width, local, 0);
+        }
+        self.render_region(
+            ui,
+            words,
+            destination,
+            width,
+            height,
+            surface,
+            clip,
+            ppa,
+            &mut stats,
+        )?;
+        Some(stats)
+    }
+
+    fn damage_target(&self, ui: &Ui) -> Option<DamageTarget> {
+        let scale = self.config.scale;
+        let (viewport_w, viewport_h) = ui.viewport();
+        let width = (viewport_w as u32).checked_mul(scale)?;
+        let height = (viewport_h as u32).checked_mul(scale)?;
+        if width == 0 || height == 0 {
+            return None;
+        }
+        Some(DamageTarget::new(
+            width,
+            height,
+            scale,
+            DAMAGE_TARGET_SIGNATURE,
+        ))
     }
 
     fn target_screen(&self, ui: &Ui, destination: &[u16], width: u32, height: u32) -> Option<Clip> {
@@ -301,6 +432,12 @@ impl Renderer {
         ppa: &mut O,
     ) -> Option<RenderStats> {
         let scale = self.config.scale;
+        let surface = Clip {
+            x0: 0,
+            y0: 0,
+            x1: (width / scale) as i32,
+            y1: (height / scale) as i32,
+        };
         let mut stats = RenderStats {
             damage_regions: damage.region_count() as u32,
             damage_pixels: damage
@@ -318,7 +455,7 @@ impl Renderer {
 
         self.ensure_mask(destination.len());
         for &region in damage.regions() {
-            let physical = physical_rect(region, scale);
+            let physical = local_physical_rect(region, surface, scale);
             if physical.area() >= self.config.min_fill_pixels
                 && ppa.fill_rgb565(destination, width, height, physical, 0)
             {
@@ -332,6 +469,7 @@ impl Renderer {
                 destination,
                 width,
                 height,
+                surface,
                 region,
                 ppa,
                 &mut stats,
@@ -348,6 +486,7 @@ impl Renderer {
         destination: &mut [u16],
         width: u32,
         height: u32,
+        surface: Clip,
         screen: Clip,
         ppa: &mut O,
         stats: &mut RenderStats,
@@ -366,13 +505,14 @@ impl Renderer {
                             destination,
                             width,
                             height,
+                            surface,
                             rect,
                             words[i + 3],
                             ppa,
                             stats,
                         )
                     {
-                        self.software_op(ui, destination, clip, op, stats);
+                        self.software_op(ui, destination, surface, clip, op, stats);
                     }
                     i += 4;
                 }
@@ -381,7 +521,7 @@ impl Renderer {
                         .intersect(clip)
                         .is_empty()
                     {
-                        self.software_op(ui, destination, clip, &words[i..i + 6], stats);
+                        self.software_op(ui, destination, surface, clip, &words[i..i + 6], stats);
                     }
                     i += 6;
                 }
@@ -393,9 +533,19 @@ impl Renderer {
                     }
                     let op = &words[i..next];
                     if !glyph_run_bounds(ui, op, clip).is_empty()
-                        && !self.try_glyph_run(ui, destination, width, height, clip, op, ppa, stats)
+                        && !self.try_glyph_run(
+                            ui,
+                            destination,
+                            width,
+                            height,
+                            surface,
+                            clip,
+                            op,
+                            ppa,
+                            stats,
+                        )
                     {
-                        self.software_op(ui, destination, clip, op, stats);
+                        self.software_op(ui, destination, surface, clip, op, stats);
                     }
                     i = next;
                 }
@@ -414,6 +564,7 @@ impl Renderer {
                         destination,
                         width,
                         height,
+                        surface,
                         clip,
                         ppa,
                         stats,
@@ -421,7 +572,7 @@ impl Renderer {
                     if let Some(next) = next {
                         i = next;
                     } else {
-                        self.software_op(ui, destination, clip, &words[i..i + 9], stats);
+                        self.software_op(ui, destination, surface, clip, &words[i..i + 9], stats);
                         i += 9;
                     }
                 }
@@ -446,14 +597,14 @@ impl Renderer {
                 spec::draw_op::TRI if i + 7 <= words.len() => {
                     if !triangle_bounds([words[i + 1], words[i + 2], words[i + 3]], clip).is_empty()
                     {
-                        self.software_op(ui, destination, clip, &words[i..i + 7], stats);
+                        self.software_op(ui, destination, surface, clip, &words[i..i + 7], stats);
                     }
                     i += 7;
                 }
                 spec::draw_op::TEX_TRI if i + 12 <= words.len() => {
                     if !triangle_bounds([words[i + 2], words[i + 5], words[i + 8]], clip).is_empty()
                     {
-                        self.software_op(ui, destination, clip, &words[i..i + 12], stats);
+                        self.software_op(ui, destination, surface, clip, &words[i..i + 12], stats);
                     }
                     i += 12;
                 }
@@ -468,6 +619,7 @@ impl Renderer {
         destination: &mut [u16],
         width: u32,
         height: u32,
+        surface: Clip,
         logical: Clip,
         color: u32,
         ppa: &mut O,
@@ -477,7 +629,7 @@ impl Renderer {
         if a == 0 {
             return true;
         }
-        let rect = physical_rect(logical, self.config.scale);
+        let rect = local_physical_rect(logical, surface, self.config.scale);
         if a == 255 && rect.area() >= self.config.min_fill_pixels {
             if ppa.fill_rgb565(destination, width, height, rect, pack_rgb565(r, g, b)) {
                 stats.ppa_fills += 1;
@@ -509,6 +661,7 @@ impl Renderer {
         destination: &mut [u16],
         width: u32,
         height: u32,
+        surface: Clip,
         clip: Clip,
         op: &[u32],
         ppa: &mut O,
@@ -540,7 +693,8 @@ impl Renderer {
             }
         }
         bounds = bounds.intersect(clip);
-        let rect = physical_rect(bounds, self.config.scale);
+        let global_rect = physical_rect(bounds, self.config.scale);
+        let rect = local_physical_rect(bounds, surface, self.config.scale);
         if rect.is_empty() || rect.area() < self.config.min_blend_pixels {
             return false;
         }
@@ -557,17 +711,19 @@ impl Renderer {
                 continue;
             }
             let rows = atlas.glyph_rows(gid);
-            let x0 = (gx * scale).max(rect.x as i32);
-            let y0 = (gy * scale).max(rect.y as i32);
-            let x1 = ((gx + cell_w) * scale).min((rect.x + rect.w) as i32);
-            let y1 = ((gy + cell_h) * scale).min((rect.y + rect.h) as i32);
+            let x0 = (gx * scale).max(global_rect.x as i32);
+            let y0 = (gy * scale).max(global_rect.y as i32);
+            let x1 = ((gx + cell_w) * scale).min((global_rect.x + global_rect.w) as i32);
+            let y1 = ((gy + cell_h) * scale).min((global_rect.y + global_rect.h) as i32);
             for py in y0..y1 {
                 let sy = coverage_index(py - gy * scale, scale, density, coverage_h);
                 let row = &rows[sy * bpr..];
                 for px in x0..x1 {
                     let sx = coverage_index(px - gx * scale, scale, density, coverage_w);
+                    let local_x = px - surface.x0 * scale;
+                    let local_y = py - surface.y0 * scale;
                     composite_mask(
-                        &mut mask[py as usize * width as usize + px as usize],
+                        &mut mask[local_y as usize * width as usize + local_x as usize],
                         ((row[sx] as u32 * a + 127) / 255) as u8,
                     );
                 }
@@ -598,6 +754,7 @@ impl Renderer {
         destination: &mut [u16],
         width: u32,
         height: u32,
+        surface: Clip,
         clip: Clip,
         ppa: &mut O,
         stats: &mut RenderStats,
@@ -608,7 +765,7 @@ impl Renderer {
 
         if view.psm == spec::psm::PSM_5650 {
             let logical = logical_rect(op[2], op[3]).intersect(clip);
-            let destination_rect = physical_rect(logical, self.config.scale);
+            let destination_rect = local_physical_rect(logical, surface, self.config.scale);
             if destination_rect.area() >= self.config.min_srm_pixels {
                 let (source_rect, mirror_x, mirror_y) = texture_source_rect(&view, op, logical)?;
                 let one_to_one =
@@ -656,7 +813,7 @@ impl Renderer {
         if a == 0 {
             return Some(end);
         }
-        let rect = physical_rect(bounds, self.config.scale);
+        let rect = local_physical_rect(bounds, surface, self.config.scale);
         if rect.is_empty() || rect.area() < self.config.min_blend_pixels {
             return None;
         }
@@ -668,6 +825,7 @@ impl Renderer {
             alpha_quad_into_mask(
                 &view,
                 &words[cursor..cursor + 9],
+                surface,
                 clip,
                 scale,
                 mask,
@@ -696,6 +854,7 @@ impl Renderer {
         &mut self,
         ui: &Ui,
         destination: &mut [u16],
+        surface: Clip,
         clip: Clip,
         op: &[u32],
         stats: &mut RenderStats,
@@ -709,19 +868,38 @@ impl Renderer {
         self.fallback_words
             .push(pack_wh(clip.x1 - clip.x0, clip.y1 - clip.y0));
         self.fallback_words.extend_from_slice(op);
-        render_scaled_rgb565_over(ui, &self.fallback_words, destination, self.config.scale);
+        let full_screen = {
+            let (viewport_w, viewport_h) = ui.viewport();
+            Clip {
+                x0: 0,
+                y0: 0,
+                x1: viewport_w as i32,
+                y1: viewport_h as i32,
+            }
+        };
+        if surface == full_screen {
+            render_scaled_rgb565_over(ui, &self.fallback_words, destination, self.config.scale);
+        } else {
+            render_scaled_rgb565_window_over(
+                ui,
+                &self.fallback_words,
+                destination,
+                self.config.scale,
+                surface,
+            );
+        }
         stats.software_ops += 1;
         stats.software_words += op.len() as u32;
     }
 
     fn ensure_mask(&mut self, len: usize) {
-        if self.mask_len >= len {
-            return;
+        if self.mask_capacity < len {
+            let bytes = len + MASK_ALIGNMENT - 1;
+            self.mask_storage = alloc::vec![0u128; bytes.div_ceil(16)];
+            let base = self.mask_storage.as_ptr() as usize;
+            self.mask_offset = (MASK_ALIGNMENT - base % MASK_ALIGNMENT) % MASK_ALIGNMENT;
+            self.mask_capacity = len;
         }
-        let bytes = len + MASK_ALIGNMENT - 1;
-        self.mask_storage = alloc::vec![0u128; bytes.div_ceil(16)];
-        let base = self.mask_storage.as_ptr() as usize;
-        self.mask_offset = (MASK_ALIGNMENT - base % MASK_ALIGNMENT) % MASK_ALIGNMENT;
         self.mask_len = len;
     }
 
@@ -825,6 +1003,20 @@ fn physical_rect(clip: Clip, scale: u32) -> Rect {
     Rect {
         x: clip.x0 as u32 * scale,
         y: clip.y0 as u32 * scale,
+        w: (clip.x1 - clip.x0) as u32 * scale,
+        h: (clip.y1 - clip.y0) as u32 * scale,
+    }
+}
+
+#[inline]
+fn local_physical_rect(clip: Clip, surface: Clip, scale: u32) -> Rect {
+    let clip = clip.intersect(surface);
+    if clip.is_empty() {
+        return Rect::default();
+    }
+    Rect {
+        x: (clip.x0 - surface.x0) as u32 * scale,
+        y: (clip.y0 - surface.y0) as u32 * scale,
         w: (clip.x1 - clip.x0) as u32 * scale,
         h: (clip.y1 - clip.y0) as u32 * scale,
     }
@@ -1001,6 +1193,7 @@ fn sample_alpha(view: &TexView<'_>, u: f32, v: f32) -> u8 {
 fn alpha_quad_into_mask(
     view: &TexView<'_>,
     op: &[u32],
+    surface: Clip,
     clip: Clip,
     scale: u32,
     mask: &mut [u8],
@@ -1025,8 +1218,10 @@ fn alpha_quad_into_mask(
             let u =
                 u0 + (u1 - u0) * ((px as i32 - x * scale_i) as f32 + 0.5) / (w * scale_i) as f32;
             let alpha = (sample_alpha(view, u, v) as u32 * global_alpha as u32 + 127) / 255;
+            let local_x = px as i32 - surface.x0 * scale_i;
+            let local_y = py as i32 - surface.y0 * scale_i;
             composite_mask(
-                &mut mask[py as usize * stride as usize + px as usize],
+                &mut mask[local_y as usize * stride as usize + local_x as usize],
                 alpha as u8,
             );
         }
@@ -1046,6 +1241,11 @@ mod tests {
         last_mask_max: u8,
         last_mask: Vec<u8>,
         last_global_alpha: u8,
+        last_surface_width: u32,
+        last_surface_height: u32,
+        last_fill_rect: Rect,
+        last_blend_rect: Rect,
+        last_mask_len: usize,
         last_source_rect: Rect,
         last_destination_rect: Rect,
         last_transform: SrmTransform,
@@ -1056,11 +1256,14 @@ mod tests {
             &mut self,
             destination: &mut [u16],
             width: u32,
-            _height: u32,
+            height: u32,
             rect: Rect,
             color: u16,
         ) -> bool {
             self.fills += 1;
+            self.last_surface_width = width;
+            self.last_surface_height = height;
+            self.last_fill_rect = rect;
             for y in rect.y..rect.y + rect.h {
                 let start = y as usize * width as usize + rect.x as usize;
                 destination[start..start + rect.w as usize].fill(color);
@@ -1072,13 +1275,17 @@ mod tests {
             &mut self,
             destination: &mut [u16],
             width: u32,
-            _height: u32,
+            height: u32,
             mask: &[u8],
             rect: Rect,
             color: [u8; 3],
             global_alpha: u8,
         ) -> bool {
             self.blends += 1;
+            self.last_surface_width = width;
+            self.last_surface_height = height;
+            self.last_blend_rect = rect;
+            self.last_mask_len = mask.len();
             self.last_mask_max = mask.iter().copied().max().unwrap_or(0);
             self.last_mask.clear();
             self.last_mask.extend_from_slice(mask);
@@ -1207,6 +1414,158 @@ mod tests {
         let mut output = vec![0u16; width * height];
         pocketjs_core::raster::render_scaled_rgb565(ui, words, &mut output, 1);
         output
+    }
+
+    #[test]
+    fn compact_strip_matches_the_same_window_of_a_full_render() {
+        let mut ui = Ui::new();
+        ui.set_viewport(16.0, 10.0);
+        let words = [
+            spec::draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(16, 10),
+            0xff20_1008,
+            spec::draw_op::GRAD_RECT,
+            xy_word(2, 2),
+            wh_word(12, 6),
+            0xff00_0040,
+            0xffc0_8000,
+            spec::GradDir::ToRight as u32,
+            spec::draw_op::RECT,
+            xy_word(5, 3),
+            wh_word(5, 5),
+            0x8000_ff00,
+        ];
+        let region = Rect {
+            x: 3,
+            y: 4,
+            w: 9,
+            h: 3,
+        };
+        let untouched = 0x5aa5;
+        let mut strip = vec![untouched; 16 * region.h as usize];
+        let mut ppa = MockPpa::default();
+        let stats = renderer()
+            .render_strip(&ui, &words, &mut strip, region, &mut ppa)
+            .unwrap();
+        let full = full_reference(&ui, &words, 16, 10);
+
+        assert_eq!(stats.damage_bounds, region);
+        assert!(
+            stats.software_ops > 0,
+            "gradient must exercise window fallback"
+        );
+        for local_y in 0..region.h as usize {
+            let global_y = region.y as usize + local_y;
+            for x in 0..16usize {
+                let actual = strip[local_y * 16 + x];
+                if x >= region.x as usize && x < (region.x + region.w) as usize {
+                    assert_eq!(actual, full[global_y * 16 + x], "pixel ({x},{global_y})");
+                } else {
+                    assert_eq!(actual, untouched, "strip write escaped dirty x range");
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn strip_ppa_rects_and_masks_are_local_and_mask_length_tracks_each_strip() {
+        let mut ui = Ui::new();
+        ui.set_viewport(16.0, 10.0);
+        let words = [
+            spec::draw_op::RECT,
+            xy_word(4, 5),
+            wh_word(3, 2),
+            0x8000_00ff,
+        ];
+        let mut renderer = renderer();
+
+        let mut large = vec![0u16; 16 * 4];
+        let mut large_ppa = MockPpa::default();
+        renderer
+            .render_strip(
+                &ui,
+                &words,
+                &mut large,
+                Rect {
+                    x: 4,
+                    y: 3,
+                    w: 3,
+                    h: 4,
+                },
+                &mut large_ppa,
+            )
+            .unwrap();
+        assert_eq!(large_ppa.last_mask_len, 16 * 4);
+
+        let mut small = vec![0u16; 16 * 2];
+        let mut small_ppa = MockPpa::default();
+        renderer
+            .render_strip(
+                &ui,
+                &words,
+                &mut small,
+                Rect {
+                    x: 4,
+                    y: 5,
+                    w: 3,
+                    h: 2,
+                },
+                &mut small_ppa,
+            )
+            .unwrap();
+        assert_eq!(small_ppa.last_surface_width, 16);
+        assert_eq!(small_ppa.last_surface_height, 2);
+        assert_eq!(
+            small_ppa.last_blend_rect,
+            Rect {
+                x: 4,
+                y: 0,
+                w: 3,
+                h: 2,
+            }
+        );
+        assert_eq!(small_ppa.last_mask_len, 16 * 2);
+    }
+
+    #[test]
+    fn split_damage_transactions_track_two_native_targets_independently() {
+        let mut ui = Ui::new();
+        ui.set_viewport(24.0, 8.0);
+        let frame = |x: i16, color: u32| {
+            vec![
+                spec::draw_op::RECT,
+                xy_word(0, 0),
+                wh_word(24, 8),
+                0xff10_0804,
+                spec::draw_op::RECT,
+                xy_word(x, 2),
+                wh_word(3, 3),
+                color,
+            ]
+        };
+        let first = frame(1, 0xff00_00ff);
+        let second = frame(5, 0xff00_ff00);
+        let third = frame(9, 0xffff_0000);
+        let mut states = [RenderTargetState::new(), RenderTargetState::new()];
+        let mut renderer = renderer();
+
+        assert!(renderer
+            .prepare_damage(&states[0], &ui, &first)
+            .unwrap()
+            .is_full_redraw());
+        assert!(renderer.commit_damage(&mut states[0], &ui, &first));
+        assert!(renderer
+            .prepare_damage(&states[1], &ui, &second)
+            .unwrap()
+            .is_full_redraw());
+        assert!(renderer.commit_damage(&mut states[1], &ui, &second));
+
+        let target_zero = renderer.prepare_damage(&states[0], &ui, &third).unwrap();
+        assert!(!target_zero.is_full_redraw());
+        assert!(!target_zero.is_empty());
+        let target_one_unchanged = renderer.prepare_damage(&states[1], &ui, &second).unwrap();
+        assert!(target_one_unchanged.is_empty());
     }
 
     #[test]

--- a/engine/backends/esp32p4-ppa/tests/strip_parity.rs
+++ b/engine/backends/esp32p4-ppa/tests/strip_parity.rs
@@ -1,0 +1,499 @@
+//! Strip-vs-full parity: `render_strip` must produce, for any horizontal
+//! band, exactly the bytes a full render puts in that band — the invariant
+//! transactional display hosts rely on when they reassemble a frame from
+//! reusable strips.
+//!
+//! The matrix covers every DrawList op family (RECT, GRAD_RECT both axes,
+//! SCISSOR, TRI, TEX_QUAD 8888, TEX_TRI, GLYPH_RUN, SRM-eligible 5650
+//! TEX_QUAD), all-software fallback via a declining PPA, SRM-through-PPA
+//! strip locality and band splits, scale 2, per-row strips, offset windows,
+//! and repeat determinism across mask reallocation.
+
+use pocketjs_core::raster::render_scaled_rgb565;
+use pocketjs_core::{spec, Ui};
+use pocketjs_esp32p4_ppa::{PpaOps, Rect, Renderer, RendererConfig, SrmTransform};
+
+fn xy_word(x: i16, y: i16) -> u32 {
+    x as u16 as u32 | ((y as u16 as u32) << 16)
+}
+
+fn wh_word(w: u16, h: u16) -> u32 {
+    w as u32 | ((h as u32) << 16)
+}
+
+/// Declines every op: forces the renderer through the software window
+/// fallback (`render_scaled_rgb565_window_over`) for every op family.
+struct NoPpa;
+
+impl PpaOps for NoPpa {
+    fn fill_rgb565(&mut self, _: &mut [u16], _: u32, _: u32, _: Rect, _: u16) -> bool {
+        false
+    }
+    fn blend_a8_rgb565(
+        &mut self,
+        _: &mut [u16],
+        _: u32,
+        _: u32,
+        _: &[u8],
+        _: Rect,
+        _: [u8; 3],
+        _: u8,
+    ) -> bool {
+        false
+    }
+    fn srm_psm5650_to_rgb565(
+        &mut self,
+        _: &mut [u16],
+        _: u32,
+        _: u32,
+        _: &[u8],
+        _: u32,
+        _: u32,
+        _: Rect,
+        _: Rect,
+        _: SrmTransform,
+    ) -> bool {
+        false
+    }
+}
+
+/// Accepts only one-to-one SRM copies (software emulation, mirroring the
+/// crate's MockPpa), declines fills/blends — probes SRM strip locality.
+#[derive(Default)]
+struct SrmOnlyPpa {
+    srm_calls: u32,
+    last_destination_rect: Rect,
+}
+
+impl PpaOps for SrmOnlyPpa {
+    fn fill_rgb565(&mut self, _: &mut [u16], _: u32, _: u32, _: Rect, _: u16) -> bool {
+        false
+    }
+    fn blend_a8_rgb565(
+        &mut self,
+        _: &mut [u16],
+        _: u32,
+        _: u32,
+        _: &[u8],
+        _: Rect,
+        _: [u8; 3],
+        _: u8,
+    ) -> bool {
+        false
+    }
+    fn srm_psm5650_to_rgb565(
+        &mut self,
+        destination: &mut [u16],
+        width: u32,
+        _height: u32,
+        source: &[u8],
+        source_width: u32,
+        _source_height: u32,
+        source_rect: Rect,
+        destination_rect: Rect,
+        transform: SrmTransform,
+    ) -> bool {
+        if transform.mirror_x
+            || transform.mirror_y
+            || source_rect.w != destination_rect.w
+            || source_rect.h != destination_rect.h
+        {
+            return false;
+        }
+        self.srm_calls += 1;
+        self.last_destination_rect = destination_rect;
+        for dy in 0..destination_rect.h {
+            let sy = source_rect.y + dy;
+            for dx in 0..destination_rect.w {
+                let sx = source_rect.x + dx;
+                let source_index = (sy * source_width + sx) as usize * 2;
+                let psm5650 = u16::from_le_bytes([source[source_index], source[source_index + 1]]);
+                let rgb565 =
+                    ((psm5650 & 0x001f) << 11) | (psm5650 & 0x07e0) | ((psm5650 & 0xf800) >> 11);
+                let destination_index = (destination_rect.y + dy) as usize * width as usize
+                    + (destination_rect.x + dx) as usize;
+                destination[destination_index] = rgb565;
+            }
+        }
+        true
+    }
+}
+
+fn density_two_font() -> Vec<u8> {
+    let coverage = [
+        0, 16, 32, 48, 64, 80, 96, 112, 128, 144, 160, 176, 192, 208, 224, 255,
+    ];
+    let mut atlas = Vec::new();
+    atlas.extend_from_slice(&spec::font_atlas::MAGIC.to_le_bytes());
+    atlas.extend_from_slice(&spec::font_atlas::VERSION.to_le_bytes());
+    atlas.extend_from_slice(&1u16.to_le_bytes());
+    atlas.extend_from_slice(&[2, 2, 2, 2, 0, 0, 2, 0]);
+    atlas.extend_from_slice(&65u32.to_le_bytes());
+    atlas.extend_from_slice(&0u16.to_le_bytes());
+    atlas.extend_from_slice(&[2, 0]);
+    atlas.extend_from_slice(&coverage);
+    atlas
+}
+
+fn renderer(scale: u32) -> Renderer {
+    Renderer::new(RendererConfig {
+        scale,
+        min_fill_pixels: 1,
+        min_blend_pixels: 1,
+        min_srm_pixels: 1,
+    })
+    .unwrap()
+}
+
+/// A 16x10 frame touching every op family, with ops deliberately crossing
+/// horizontal strip boundaries so sampling phase matters.
+fn full_matrix_scene() -> (Ui, Vec<u32>) {
+    let mut ui = Ui::new_with_raster_density(2);
+    ui.set_viewport(16.0, 10.0);
+    assert!(ui.load_font_atlas(&density_two_font()));
+
+    let rgba_pixels: Vec<u8> = (0..16u32)
+        .flat_map(|value| {
+            [
+                (value * 16) as u8,
+                255 - (value * 16) as u8,
+                (value * 7) as u8,
+                255,
+            ]
+        })
+        .collect();
+    let tex_rgba = ui.upload_texture(&rgba_pixels, 4, 4, spec::psm::PSM_8888);
+    assert!(tex_rgba >= 0);
+
+    let psm5650_pixels: Vec<u8> = (0..16u32)
+        .flat_map(|value| ((value * 4093) as u16).to_le_bytes())
+        .collect();
+    let tex_5650 = ui.upload_texture(&psm5650_pixels, 4, 4, spec::psm::PSM_5650);
+    assert!(tex_5650 >= 0);
+
+    let words = vec![
+        // opaque background rect
+        spec::draw_op::RECT,
+        xy_word(0, 0),
+        wh_word(16, 10),
+        0xff20_1008,
+        // translucent horizontal gradient over everything
+        spec::draw_op::GRAD_RECT,
+        xy_word(0, 0),
+        wh_word(16, 10),
+        0x8000_0040,
+        0x80c0_8000,
+        spec::GradDir::ToRight as u32,
+        // opaque vertical gradient column (fill_opaque rows in the window target)
+        spec::draw_op::GRAD_RECT,
+        xy_word(12, 0),
+        wh_word(4, 10),
+        0xff00_2010,
+        0xffff_f0c0,
+        spec::GradDir::ToBottom as u32,
+        // scissored translucent gouraud triangle crossing all strip bands
+        spec::draw_op::SCISSOR,
+        xy_word(1, 1),
+        wh_word(14, 8),
+        spec::draw_op::TRI,
+        xy_word(2, 1),
+        xy_word(14, 9),
+        xy_word(2, 9),
+        0x80ff_0000,
+        0x8000_ff00,
+        0x8000_00ff,
+        spec::draw_op::SCISSOR_POP,
+        // RGBA texture quad straddling band 0/1
+        spec::draw_op::TEX_QUAD,
+        tex_rgba as u32,
+        xy_word(4, 2),
+        wh_word(4, 4),
+        0.0f32.to_bits(),
+        0.0f32.to_bits(),
+        1.0f32.to_bits(),
+        1.0f32.to_bits(),
+        0xffff_ffff,
+        // modulated translucent textured triangle straddling band 1/2
+        spec::draw_op::TEX_TRI,
+        tex_rgba as u32,
+        xy_word(8, 3),
+        0.0f32.to_bits(),
+        0.0f32.to_bits(),
+        xy_word(15, 3),
+        1.0f32.to_bits(),
+        0.0f32.to_bits(),
+        xy_word(8, 9),
+        0.0f32.to_bits(),
+        1.0f32.to_bits(),
+        0x80ff_ffff,
+        // glyphs in band 0 and band 2
+        spec::draw_op::GLYPH_RUN,
+        1 << 16,
+        0xff00_ffcc,
+        xy_word(3, 0),
+        0,
+        spec::draw_op::GLYPH_RUN,
+        1 << 16,
+        0xffff_4080,
+        xy_word(9, 7),
+        0,
+        // SRM-eligible opaque one-to-one 5650 quad straddling band 1/2
+        spec::draw_op::TEX_QUAD,
+        tex_5650 as u32,
+        xy_word(0, 6),
+        wh_word(4, 4),
+        0.0f32.to_bits(),
+        0.0f32.to_bits(),
+        1.0f32.to_bits(),
+        1.0f32.to_bits(),
+        0xffff_ffff,
+    ];
+    (ui, words)
+}
+
+fn full_reference(ui: &Ui, words: &[u32], width: usize, height: usize, scale: u32) -> Vec<u16> {
+    let mut output = vec![0u16; width * height * (scale * scale) as usize];
+    render_scaled_rgb565(ui, words, &mut output, scale);
+    output
+}
+
+fn assemble_strips<O: PpaOps>(
+    renderer: &mut Renderer,
+    ui: &Ui,
+    words: &[u32],
+    width: usize,
+    bands: &[(u32, u32)],
+    scale: u32,
+    ppa: &mut O,
+) -> Vec<u16> {
+    let physical_width = width * scale as usize;
+    let total_rows: u32 = bands.iter().map(|&(_, h)| h).sum();
+    let base_row = bands.iter().map(|&(y, _)| y).min().unwrap_or(0);
+    let mut output = vec![0u16; physical_width * (total_rows * scale) as usize];
+    for &(y, h) in bands {
+        let mut strip = vec![0u16; physical_width * (h * scale) as usize];
+        let region = Rect {
+            x: 0,
+            y,
+            w: width as u32,
+            h,
+        };
+        renderer
+            .render_strip(ui, words, &mut strip, region, ppa)
+            .unwrap_or_else(|| panic!("strip y={y} h={h} failed"));
+        let dst = ((y - base_row) * scale) as usize * physical_width;
+        output[dst..dst + strip.len()].copy_from_slice(&strip);
+    }
+    output
+}
+
+#[test]
+fn uneven_strip_tiling_reassembles_the_full_frame_for_every_op_family() {
+    let (ui, words) = full_matrix_scene();
+    let full = full_reference(&ui, &words, 16, 10, 1);
+    let mut renderer = renderer(1);
+    let tiled = assemble_strips(
+        &mut renderer,
+        &ui,
+        &words,
+        16,
+        &[(0, 3), (3, 4), (7, 3)],
+        1,
+        &mut NoPpa,
+    );
+    assert_eq!(
+        tiled, full,
+        "3-band tiling must be byte-identical to a full render"
+    );
+}
+
+#[test]
+fn one_pixel_row_strips_reassemble_the_full_frame() {
+    let (ui, words) = full_matrix_scene();
+    let full = full_reference(&ui, &words, 16, 10, 1);
+    let mut renderer = renderer(1);
+    let bands: Vec<(u32, u32)> = (0..10).map(|y| (y, 1)).collect();
+    let tiled = assemble_strips(&mut renderer, &ui, &words, 16, &bands, 1, &mut NoPpa);
+    assert_eq!(
+        tiled, full,
+        "1px strips must be byte-identical to a full render"
+    );
+}
+
+#[test]
+fn scale_two_strip_tiling_reassembles_the_full_frame() {
+    let (ui, words) = full_matrix_scene();
+    let full = full_reference(&ui, &words, 16, 10, 2);
+    let mut renderer = renderer(2);
+    let tiled = assemble_strips(
+        &mut renderer,
+        &ui,
+        &words,
+        16,
+        &[(0, 4), (4, 3), (7, 3)],
+        2,
+        &mut NoPpa,
+    );
+    assert_eq!(
+        tiled, full,
+        "scale-2 tiling must be byte-identical to a full render"
+    );
+}
+
+#[test]
+fn offset_window_matches_full_interior_and_leaves_exterior_untouched() {
+    let (ui, words) = full_matrix_scene();
+    let full = full_reference(&ui, &words, 16, 10, 1);
+    let mut renderer = renderer(1);
+    let region = Rect {
+        x: 2,
+        y: 1,
+        w: 11,
+        h: 5,
+    };
+    let untouched = 0x5aa5u16;
+    let mut strip = vec![untouched; 16 * region.h as usize];
+    renderer
+        .render_strip(&ui, &words, &mut strip, region, &mut NoPpa)
+        .unwrap();
+    for local_y in 0..region.h as usize {
+        let global_y = region.y as usize + local_y;
+        for x in 0..16usize {
+            let actual = strip[local_y * 16 + x];
+            if x >= region.x as usize && x < (region.x + region.w) as usize {
+                assert_eq!(actual, full[global_y * 16 + x], "pixel ({x},{global_y})");
+            } else {
+                assert_eq!(
+                    actual, untouched,
+                    "write escaped dirty x at ({x},{global_y})"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn rendering_the_same_strip_twice_is_byte_identical_despite_mask_churn() {
+    let (ui, words) = full_matrix_scene();
+    let mut renderer = renderer(1);
+    let region = Rect {
+        x: 0,
+        y: 3,
+        w: 16,
+        h: 4,
+    };
+    let render_once = |renderer: &mut Renderer| {
+        let mut strip = vec![0u16; 16 * 4];
+        renderer
+            .render_strip(&ui, &words, &mut strip, region, &mut NoPpa)
+            .unwrap();
+        strip
+    };
+    let first = render_once(&mut renderer);
+    // churn the mask allocation with a taller and a 1px strip in between
+    let mut tall = vec![0u16; 16 * 9];
+    renderer
+        .render_strip(
+            &ui,
+            &words,
+            &mut tall,
+            Rect {
+                x: 0,
+                y: 0,
+                w: 16,
+                h: 9,
+            },
+            &mut NoPpa,
+        )
+        .unwrap();
+    let mut thin = vec![0u16; 16];
+    renderer
+        .render_strip(
+            &ui,
+            &words,
+            &mut thin,
+            Rect {
+                x: 0,
+                y: 9,
+                w: 16,
+                h: 1,
+            },
+            &mut NoPpa,
+        )
+        .unwrap();
+    let second = render_once(&mut renderer);
+    assert_eq!(
+        first, second,
+        "strip renders must be reproducible across mask churn"
+    );
+}
+
+#[test]
+fn srm_through_ppa_lands_in_strip_local_coordinates_and_matches_software() {
+    let (ui, words) = full_matrix_scene();
+    let full = full_reference(&ui, &words, 16, 10, 1);
+    let mut renderer = renderer(1);
+    let mut ppa = SrmOnlyPpa::default();
+    // band y=6..10 contains the whole one-to-one 5650 quad (0,6)-(4,10)
+    let region = Rect {
+        x: 0,
+        y: 6,
+        w: 16,
+        h: 4,
+    };
+    let mut strip = vec![0u16; 16 * 4];
+    renderer
+        .render_strip(&ui, &words, &mut strip, region, &mut ppa)
+        .unwrap();
+    assert!(ppa.srm_calls >= 1, "SRM path must engage for the 5650 quad");
+    assert_eq!(
+        ppa.last_destination_rect,
+        Rect {
+            x: 0,
+            y: 0,
+            w: 4,
+            h: 4
+        },
+        "SRM destination must be strip-local"
+    );
+    for local_y in 0..4usize {
+        let global_y = 6 + local_y;
+        for x in 0..16usize {
+            assert_eq!(
+                strip[local_y * 16 + x],
+                full[global_y * 16 + x],
+                "pixel ({x},{global_y})"
+            );
+        }
+    }
+}
+
+#[test]
+fn split_srm_band_boundary_matches_software() {
+    // Split the 5650 quad across two strips (y=6..8 and y=8..10): the SRM
+    // source rect must advance with the band, not restart at the texture top.
+    let (ui, words) = full_matrix_scene();
+    let full = full_reference(&ui, &words, 16, 10, 1);
+    let mut renderer = renderer(1);
+    let mut ppa = SrmOnlyPpa::default();
+    let tiled = assemble_strips(
+        &mut renderer,
+        &ui,
+        &words,
+        16,
+        &[(6, 2), (8, 2)],
+        1,
+        &mut ppa,
+    );
+    assert!(ppa.srm_calls >= 2, "both half-bands must engage SRM");
+    for local_y in 0..4usize {
+        let global_y = 6 + local_y;
+        for x in 0..16usize {
+            assert_eq!(
+                tiled[local_y * 16 + x],
+                full[global_y * 16 + x],
+                "pixel ({x},{global_y})"
+            );
+        }
+    }
+}

--- a/engine/core/src/lib.rs
+++ b/engine/core/src/lib.rs
@@ -1087,6 +1087,13 @@ impl Ui {
         &self.draw_list
     }
 
+    /// Return the DrawList most recently produced by [`draw`](Self::draw)
+    /// without rebuilding it. Transactional render hosts use this to replay
+    /// several dirty strips from one stable frame snapshot.
+    pub fn current_draw_list(&self) -> &DrawList {
+        &self.draw_list
+    }
+
     /// Resize the logical viewport (root node + layout bounds + draw clip).
     /// Defaults to the PSP's 480x272; desktop hosts call this with their
     /// surface size. Values are clamped to the DrawList's i16 coordinate

--- a/engine/core/src/raster.rs
+++ b/engine/core/src/raster.rs
@@ -221,6 +221,24 @@ fn unpack_rgb565(pixel: u16) -> (u32, u32, u32) {
     )
 }
 
+/// Blend one straight-alpha RGB888 source pixel over an RGB565 pixel. Shared
+/// by the full-frame and compact-window targets so a strip render stays
+/// bit-identical to the same window of a full render by construction.
+#[inline]
+fn blend_rgb565_pixel(pixel: &mut u16, r: u32, g: u32, b: u32, a: u32) {
+    if a >= 255 {
+        *pixel = pack_rgb565(r, g, b);
+        return;
+    }
+    if a == 0 {
+        return;
+    }
+    let (dr, dg, db) = unpack_rgb565(*pixel);
+    let ia = 255 - a;
+    let mix = |s: u32, d: u32| (s * a + d * ia + 127) / 255;
+    *pixel = pack_rgb565(mix(r, dr), mix(g, dg), mix(b, db));
+}
+
 impl RenderTarget for Rgb565Target<'_> {
     #[inline]
     fn pixel_len(&self) -> usize {
@@ -229,17 +247,7 @@ impl RenderTarget for Rgb565Target<'_> {
 
     #[inline]
     fn blend(&mut self, offset: usize, r: u32, g: u32, b: u32, a: u32) {
-        if a >= 255 {
-            self.pixels[offset] = pack_rgb565(r, g, b);
-            return;
-        }
-        if a == 0 {
-            return;
-        }
-        let (dr, dg, db) = unpack_rgb565(self.pixels[offset]);
-        let ia = 255 - a;
-        let mix = |s: u32, d: u32| (s * a + d * ia + 127) / 255;
-        self.pixels[offset] = pack_rgb565(mix(r, dr), mix(g, dg), mix(b, db));
+        blend_rgb565_pixel(&mut self.pixels[offset], r, g, b, a);
     }
 
     #[inline]
@@ -276,17 +284,7 @@ impl RenderTarget for Rgb565WindowTarget<'_> {
     #[inline]
     fn blend(&mut self, offset: usize, r: u32, g: u32, b: u32, a: u32) {
         let offset = self.local_offset(offset);
-        if a >= 255 {
-            self.pixels[offset] = pack_rgb565(r, g, b);
-            return;
-        }
-        if a == 0 {
-            return;
-        }
-        let (dr, dg, db) = unpack_rgb565(self.pixels[offset]);
-        let ia = 255 - a;
-        let mix = |s: u32, d: u32| (s * a + d * ia + 127) / 255;
-        self.pixels[offset] = pack_rgb565(mix(r, dr), mix(g, dg), mix(b, db));
+        blend_rgb565_pixel(&mut self.pixels[offset], r, g, b, a);
     }
 
     #[inline]

--- a/engine/core/src/raster.rs
+++ b/engine/core/src/raster.rs
@@ -190,6 +190,20 @@ struct Rgb565Target<'a> {
     pixels: &'a mut [u16],
 }
 
+/// A tightly packed RGB565 window whose pixels retain their coordinates in the
+/// full viewport. The rasterizer continues to produce full-surface linear
+/// offsets so gradient, glyph, texture, and triangle sampling keep their global
+/// phase; this adapter maps those offsets into the compact backing slice.
+struct Rgb565WindowTarget<'a> {
+    pixels: &'a mut [u16],
+    full_stride: usize,
+    full_pixel_len: usize,
+    origin_x: usize,
+    origin_y: usize,
+    width: usize,
+    height: usize,
+}
+
 #[inline]
 pub const fn pack_rgb565(r: u32, g: u32, b: u32) -> u16 {
     (((r & 0xf8) << 8) | ((g & 0xfc) << 3) | (b >> 3)) as u16
@@ -231,6 +245,59 @@ impl RenderTarget for Rgb565Target<'_> {
     #[inline]
     fn fill_opaque(&mut self, start: usize, len: usize, r: u32, g: u32, b: u32) {
         self.pixels[start..start + len].fill(pack_rgb565(r, g, b));
+    }
+}
+
+impl Rgb565WindowTarget<'_> {
+    #[inline]
+    fn local_offset(&self, full_offset: usize) -> usize {
+        let y = full_offset / self.full_stride;
+        let x = full_offset % self.full_stride;
+        assert!(
+            x >= self.origin_x
+                && x < self.origin_x + self.width
+                && y >= self.origin_y
+                && y < self.origin_y + self.height,
+            "raster write escaped the compact RGB565 window"
+        );
+        (y - self.origin_y) * self.width + (x - self.origin_x)
+    }
+}
+
+impl RenderTarget for Rgb565WindowTarget<'_> {
+    #[inline]
+    fn pixel_len(&self) -> usize {
+        // This is the virtual target length used by full-viewport coordinate
+        // calculations. The actual compact slice is validated by the window
+        // entry point below.
+        self.full_pixel_len
+    }
+
+    #[inline]
+    fn blend(&mut self, offset: usize, r: u32, g: u32, b: u32, a: u32) {
+        let offset = self.local_offset(offset);
+        if a >= 255 {
+            self.pixels[offset] = pack_rgb565(r, g, b);
+            return;
+        }
+        if a == 0 {
+            return;
+        }
+        let (dr, dg, db) = unpack_rgb565(self.pixels[offset]);
+        let ia = 255 - a;
+        let mix = |s: u32, d: u32| (s * a + d * ia + 127) / 255;
+        self.pixels[offset] = pack_rgb565(mix(r, dr), mix(g, dg), mix(b, db));
+    }
+
+    #[inline]
+    fn fill_opaque(&mut self, start: usize, len: usize, r: u32, g: u32, b: u32) {
+        let full_x = start % self.full_stride;
+        let local = self.local_offset(start);
+        assert!(
+            len <= self.origin_x + self.width - full_x,
+            "raster span crossed a compact RGB565 window row"
+        );
+        self.pixels[local..local + len].fill(pack_rgb565(r, g, b));
     }
 }
 
@@ -311,6 +378,62 @@ pub fn render_scaled_rgb565(ui: &Ui, words: &[u32], fb: &mut [u16], scale: u32) 
 pub fn render_scaled_rgb565_over(ui: &Ui, words: &[u32], fb: &mut [u16], scale: u32) {
     let mut target = Rgb565Target { pixels: fb };
     render_scaled_impl(ui, words, &mut target, scale, false);
+}
+
+/// Execute DrawList words over a tightly packed RGB565 sub-window without
+/// clearing it.
+///
+/// `window` is expressed in global logical viewport coordinates with half-open
+/// bounds. `fb` must contain exactly
+/// `(window.width * scale) * (window.height * scale)` pixels. Raster sampling
+/// remains anchored to the full viewport; only storage is translated to the
+/// compact window. Hardware backends use this for ordered software fallback
+/// while rendering a dirty strip.
+pub fn render_scaled_rgb565_window_over(
+    ui: &Ui,
+    words: &[u32],
+    fb: &mut [u16],
+    scale: u32,
+    window: DamageRect,
+) {
+    assert!(
+        (1..=MAX_RENDER_SCALE).contains(&scale),
+        "render scale must be 1 through 4"
+    );
+    let scale_i = scale as i32;
+    let (viewport_w, viewport_h) = ui.viewport();
+    let logical_screen = DamageRect::new(0, 0, viewport_w as i32, viewport_h as i32);
+    assert!(
+        !window.is_empty() && window.intersect(logical_screen) == window,
+        "compact RGB565 window must be non-empty and inside the viewport"
+    );
+
+    let full_width = logical_screen.x1 * scale_i;
+    let full_height = logical_screen.y1 * scale_i;
+    let physical = Clip {
+        x0: window.x0 * scale_i,
+        y0: window.y0 * scale_i,
+        x1: window.x1 * scale_i,
+        y1: window.y1 * scale_i,
+    };
+    let width = (physical.x1 - physical.x0) as usize;
+    let height = (physical.y1 - physical.y0) as usize;
+    assert_eq!(
+        fb.len(),
+        width * height,
+        "compact RGB565 window has the wrong pixel length"
+    );
+
+    let mut target = Rgb565WindowTarget {
+        pixels: fb,
+        full_stride: full_width as usize,
+        full_pixel_len: full_width as usize * full_height as usize,
+        origin_x: physical.x0 as usize,
+        origin_y: physical.y0 as usize,
+        width,
+        height,
+    };
+    render_scaled_clipped(ui, words, &mut target, full_width, scale_i, physical);
 }
 
 /// Clear and repaint only the supplied logical damage rectangles into an


### PR DESCRIPTION
## What changed

- add a compact RGB565 window target that preserves full-viewport raster coordinates
- expose the last built DrawList for stable multi-strip replay
- expose split `prepare_damage`, `commit_damage`, and `abort_damage` operations on the ESP32-P4 PPA renderer
- add `render_strip` for full-viewport-width, tightly packed dirty strips
- translate PPA rectangles, A8 masks, texture destinations, and software fallback writes into strip-local storage
- retain allocation capacity while allowing the active A8 mask length to shrink with each strip

## Why

Asynchronous display hosts must render and submit several reusable strips before they can advance a persistent framebuffer's damage history. Coupling history updates to `render_incremental` cannot represent a failed or partially submitted display transaction.

The split API keeps history unchanged until presentation succeeds, invalidates it on abort, and preserves global gradient, glyph, texture, and triangle sampling when software fallback writes into a compact strip.

## Impact

Existing full-frame and incremental callers are unchanged. The new API is backend-neutral and keeps board/display ownership outside PocketJS Core.

## Validation

- `cargo test --locked --manifest-path engine/core/Cargo.toml --features std` — 100 passed
- `cargo test --locked --manifest-path engine/backends/esp32p4-ppa/Cargo.toml --features std` — 20 passed
- `cargo check --locked --manifest-path engine/backends/esp32p4-ppa/Cargo.toml --features esp-idf`
- `git diff --check`
