### PR TITLE
feat(site): rebuild the landing page around impossible devices

### DIFF
--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -1,8 +1,10 @@
 /* ==========================================================================
-   PocketJS — "Bare Metal Modern Web" landing page
+   PocketJS — "Build modern apps for impossible devices" landing page
    Direction: Docs navy with brushed metal accents. All classes are .lp-* scoped.
    The hero plays the baked demo wall (site/bake-demo-wall.ts) as a full-bleed
-   background and mounts the demand-rendered Pocket Stage below its CTA.
+   background and mounts the demand-rendered Pocket Stage below its CTA. The
+   page then walks the platform story: proof strip → execution classes →
+   target selector → .pocket → device taxonomy → showcase → porting contract.
    ========================================================================== */
 
 @font-face {
@@ -22,6 +24,7 @@
 }
 
 html, body { margin: 0; background: #05070d; }
+html { scroll-behavior: smooth; }
 
 .lp, .lp *, .lp *::before, .lp *::after { box-sizing: border-box; }
 
@@ -83,7 +86,7 @@ html, body { margin: 0; background: #05070d; }
   z-index: 1;
 }
 
-.lp h1, .lp h2, .lp h3, .lp h4, .lp p, .lp ul, .lp figure, .lp pre { margin: 0; }
+.lp h1, .lp h2, .lp h3, .lp h4, .lp p, .lp ul, .lp dl, .lp dd, .lp figure, .lp pre { margin: 0; }
 .lp a { color: inherit; }
 .lp img, .lp svg { display: block; }
 
@@ -253,24 +256,7 @@ a.lp-btn--primary:hover {
 .lp-nav__discord svg { width: 18px; height: 18px; }
 .lp-nav__x { display: inline-flex; align-items: center; }
 .lp-nav__x svg { width: 16px; height: 16px; }
-/* 3D entry: an accent-tinted link so it stands out among the nav items, but
-   with no filled box until it's the current page (see .is-on). */
-.lp-nav__3d {
-  display: inline-flex; align-items: center; gap: 0.4rem;
-  color: #a9e7ff;
-  background: transparent;
-  border: 1px solid transparent;
-}
-.lp-nav__3d svg { width: 16px; height: 16px; }
-.lp-nav__3d:hover { color: #e4f5ff; background: linear-gradient(180deg, rgba(56, 152, 224, 0.16), rgba(56, 152, 224, 0.06)); border-color: rgba(120, 190, 240, 0.32); }
-.lp-nav__3d.is-on {
-  color: #e4f5ff;
-  background: linear-gradient(180deg, rgba(56, 152, 224, 0.28), rgba(56, 152, 224, 0.12));
-  border-color: rgba(150, 210, 250, 0.55);
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-}
 @media (max-width: 480px) {
-  .lp-nav__ghlabel { display: none; }
   .lp-nav__optional { display: none; }
   .lp-nav__link { padding: 0.5rem 0.32rem; font-size: 12px; }
 }
@@ -354,8 +340,8 @@ a.lp-btn--primary:hover {
   margin-top: 1.5rem;
   font-weight: 800;
   letter-spacing: -0.035em;
-  line-height: 0.96;
-  font-size: clamp(2.9rem, 9.6vw, 6.4rem);
+  line-height: 1.02;
+  font-size: clamp(2.45rem, 7.4vw, 5.3rem);
   color: var(--ink);
 }
 .lp-h1 .lp-grad {
@@ -364,12 +350,11 @@ a.lp-btn--primary:hover {
 }
 .lp-sub {
   margin: 1.6rem auto 0;
-  max-width: 650px;
-  font-size: clamp(1.05rem, 2.3vw, 1.32rem);
+  max-width: 680px;
+  font-size: clamp(1.05rem, 2.3vw, 1.3rem);
   line-height: 1.55;
   color: var(--ink-2);
 }
-.lp-hl { color: var(--ink); font-weight: 600; }
 .lp-hero__cta {
   display: flex;
   flex-wrap: wrap;
@@ -467,58 +452,61 @@ a.lp-btn--primary:hover {
   .lp-stage__viewport { height: clamp(245px, 65vw, 330px); }
   .lp-stage__credit { margin-left: 0; }
 }
-/* ---- Showcase cases (OpenStrike / Pocket Figma) ---------------------------- */
-.lp-case {
+
+/* ---- Proof strip ----------------------------------------------------------
+   Five seconds of "this actually happened": six clickable field results in a
+   band that reads like a wire ticker, each linking to its story. */
+.lp-proofstrip {
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line);
+  background: linear-gradient(180deg, rgba(15, 22, 38, 0.45), rgba(9, 12, 20, 0.3));
+}
+.lp-proofstrip__row {
+  list-style: none;
+  margin: 0;
+  padding: 0;
   display: grid;
-  gap: clamp(1.5rem, 4vw, 3.2rem);
-  align-items: center;
-  margin-top: clamp(2.4rem, 5.5vw, 4rem);
+  grid-template-columns: repeat(6, 1fr);
 }
-@media (min-width: 940px) {
-  .lp-case { grid-template-columns: 1.08fr 0.92fr; }
-  .lp-case--flip .lp-case__media { order: 2; }
+.lp-proofstrip__row li { min-width: 0; }
+.lp-proofstrip__row li + li { border-left: 1px solid var(--line); }
+.lp-fact {
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+  height: 100%;
+  padding: 1.15rem 1.1rem 1.2rem;
+  text-decoration: none;
+  transition: background 0.22s ease;
 }
-.lp-case__media {
-  display: block;
-  border-radius: 18px;
-  overflow: hidden;
-  border: 1px solid var(--line-2);
-  background: #04060c;
-  box-shadow:
-    inset 0 1px 0 rgba(255, 255, 255, 0.05),
-    0 36px 72px -36px rgba(0, 0, 0, 0.9);
-}
-.lp-case__media img {
-  display: block;
-  width: 100%;
-  height: auto;
-  transform: scale(1.001);
-  transition: transform 0.35s ease;
-}
-.lp-case__media:hover img { transform: scale(1.02); }
-.lp-case__media:focus-visible { outline: 2px solid var(--sky); outline-offset: 3px; }
-.lp-case__title {
-  margin: 0 0 0.8rem;
-  font-size: clamp(1.55rem, 3.2vw, 2.1rem);
-  line-height: 1.12;
-  letter-spacing: -0.015em;
+.lp-fact:hover { background: rgba(20, 29, 49, 0.55); }
+.lp-fact b {
+  font-size: 0.94rem;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
   color: var(--ink);
 }
-.lp-case__copy p { margin: 0; color: var(--ink-2); line-height: 1.7; }
-.lp-case__links {
-  display: flex;
-  align-items: center;
-  flex-wrap: wrap;
-  gap: 1.1rem;
-  margin-top: 1.5rem;
-}
-.lp-case__src {
-  font: 500 13px/1 var(--mono);
+.lp-fact span {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  line-height: 1.45;
+  letter-spacing: 0.01em;
   color: var(--muted);
-  text-decoration: none;
-  border-bottom: 1px solid transparent;
 }
-.lp-case__src:hover { color: var(--ink); border-bottom-color: var(--muted); }
+.lp-fact:hover span { color: var(--ink-2); }
+@media (max-width: 1080px) {
+  .lp-proofstrip__row { grid-template-columns: repeat(3, 1fr); }
+  .lp-proofstrip__row li:nth-child(4) { border-left: 0; }
+  .lp-proofstrip__row li:nth-child(n + 4) { border-top: 1px solid var(--line); }
+}
+@media (max-width: 640px) {
+  .lp-proofstrip__row { grid-template-columns: repeat(2, 1fr); }
+  .lp-proofstrip__row li { border-left: 0; }
+  .lp-proofstrip__row li:nth-child(even) { border-left: 1px solid var(--line); }
+  .lp-proofstrip__row li:nth-child(n + 3) { border-top: 1px solid var(--line); }
+}
+
 /* ---- Section scaffolding -------------------------------------------------- */
 .lp-section { padding: clamp(4.5rem, 10vw, 8rem) 0; }
 .lp-kicker {
@@ -527,7 +515,8 @@ a.lp-btn--primary:hover {
   font-weight: 600;
   color: #a9b7cb;
 }
-.lp-secthead { max-width: 680px; margin: 0 auto; text-align: center; }
+.lp-secthead { max-width: 720px; margin: 0 auto; text-align: center; }
+.lp-secthead--wide { max-width: 880px; }
 .lp-secthead .lp-kicker { display: block; margin-bottom: 0.9rem; }
 .lp-h2 {
   font-weight: 800;
@@ -542,46 +531,256 @@ a.lp-btn--primary:hover {
   line-height: 1.55;
   color: var(--ink-2);
 }
+.lp-mono {
+  font-family: var(--mono);
+  font-size: 0.85em;
+  color: var(--sky);
+  background: rgba(20, 29, 49, 0.78);
+  border: 1px solid rgba(43, 58, 85, 0.92);
+  padding: 0.08em 0.4em;
+  border-radius: 6px;
+  white-space: nowrap;
+}
 
-/* ---- Hardware section ----------------------------------------------------- */
-.lp-hardware {
-  border-top: 1px solid var(--line);
+/* ---- Execution classes -----------------------------------------------------
+   The page's central claim: one authoring model, two ways down to silicon. */
+.lp-exec {
   background:
     radial-gradient(38% 50% at 0% 8%, rgba(96, 165, 250, 0.06), transparent 70%),
-    radial-gradient(36% 48% at 100% 14%, rgba(34, 211, 238, 0.035), transparent 72%),
-    linear-gradient(180deg, rgba(20, 29, 49, 0.2), transparent);
+    radial-gradient(36% 48% at 100% 14%, rgba(34, 211, 238, 0.035), transparent 72%);
 }
-.lp-tools__label {
-  text-align: center;
-  font-size: 0.95rem;
+.lp-exec__grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: clamp(2.4rem, 5vw, 3.6rem);
+}
+@media (min-width: 880px) { .lp-exec__grid { grid-template-columns: 1fr 1fr; } }
+.lp-exec__card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: clamp(1.5rem, 3vw, 2.1rem);
+  border-radius: 18px;
+  border: 1px solid transparent;
+  background:
+    linear-gradient(180deg, rgba(15, 22, 38, 0.92), rgba(9, 12, 20, 0.88)) padding-box,
+    linear-gradient(165deg, rgba(96, 165, 250, 0.34), rgba(43, 58, 85, 0.5) 42%, rgba(34, 211, 238, 0.16)) border-box;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 22px 50px -32px rgba(0, 0, 0, 0.9);
+}
+.lp-exec__card--aot {
+  background:
+    linear-gradient(180deg, rgba(15, 22, 38, 0.92), rgba(9, 12, 20, 0.88)) padding-box,
+    linear-gradient(165deg, rgba(157, 229, 199, 0.36), rgba(43, 58, 85, 0.5) 42%, rgba(96, 165, 250, 0.16)) border-box;
+}
+.lp-exec__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+}
+.lp-exec__head h3 {
+  font-size: clamp(1.3rem, 2.4vw, 1.6rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+.lp-exec__badge {
+  font: 700 11px/1 var(--mono);
+  letter-spacing: 0.04em;
+  color: var(--sky);
+  padding: 0.42rem 0.6rem;
+  border-radius: 8px;
+  border: 1px solid rgba(96, 165, 250, 0.32);
+  background: rgba(20, 29, 49, 0.7);
+}
+.lp-exec__card--aot .lp-exec__badge {
+  color: var(--mint);
+  border-color: rgba(157, 229, 199, 0.32);
+}
+.lp-exec__tag {
+  margin-top: 0.45rem;
+  font-size: 1.02rem;
   font-weight: 600;
+  color: var(--ink-2);
+}
+.lp-exec__list {
+  list-style: none;
+  padding: 0;
+  margin: 1.25rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+.lp-exec__list li {
+  position: relative;
+  padding-left: 1.35rem;
+  font-size: 0.95rem;
+  line-height: 1.55;
+  color: var(--ink-2);
+}
+.lp-exec__list li::before {
+  content: "";
+  position: absolute;
+  left: 0.15rem;
+  top: 0.58em;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--sky);
+  box-shadow: 0 0 8px rgba(96, 165, 250, 0.5);
+}
+.lp-exec__card--aot .lp-exec__list li::before {
+  background: var(--mint);
+  box-shadow: 0 0 8px rgba(157, 229, 199, 0.55);
+}
+.lp-exec__for {
+  margin-top: 1.4rem;
+  padding-top: 1.05rem;
+  border-top: 1px solid var(--line);
+  font-size: 0.86rem;
+  line-height: 1.6;
+  color: var(--ink-2);
+}
+.lp-exec__for span {
+  display: block;
+  font: 600 10.5px/1 var(--mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.4rem;
+}
+.lp-exec__note {
+  margin: clamp(1.6rem, 3vw, 2.2rem) auto 0;
+  max-width: 720px;
+  text-align: center;
+  font-size: 0.92rem;
+  line-height: 1.65;
   color: var(--muted);
 }
+.lp-exec__note a { color: var(--ink-2); text-underline-offset: 3px; }
+.lp-exec__note a:hover { color: var(--ink); }
+
+/* ---- Target selector -------------------------------------------------------
+   Same component on the left, pick the machine on the right. Panels are static
+   HTML; home.js only toggles [hidden]. */
+.lp-targets { border-top: 1px solid var(--line); }
 .lp-tools__row {
   display: flex;
   flex-wrap: wrap;
   align-items: center;
   justify-content: center;
   gap: clamp(1rem, 3vw, 2.1rem);
-  margin-top: clamp(2rem, 4vw, 2.8rem);
+  margin-top: clamp(1.8rem, 3.6vw, 2.6rem);
 }
 .lp-tool {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  font-weight: 600;
-  font-size: clamp(1rem, 2vw, 1.18rem);
-  color: var(--ink);
   opacity: 0.86;
   transition: opacity 0.2s ease;
 }
 .lp-tool:hover { opacity: 1; }
 .lp-tool svg {
   flex: none;
-  width: clamp(42px, 5vw, 58px);
+  width: clamp(38px, 4.6vw, 52px);
   height: auto;
-  max-height: 54px;
+  max-height: 50px;
 }
+.lp-targets__grid {
+  display: grid;
+  gap: 1rem;
+  align-items: stretch;
+  margin-top: clamp(2rem, 4.5vw, 3rem);
+}
+@media (min-width: 980px) { .lp-targets__grid { grid-template-columns: 1.08fr 0.92fr; } }
+.lp-tgt {
+  display: flex;
+  flex-direction: column;
+  border-radius: 16px;
+  border: 1px solid var(--line-2);
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.5), rgba(9, 12, 20, 0.92)),
+    #090c14;
+  box-shadow: 0 46px 90px -46px rgba(3, 9, 20, 0.94);
+  overflow: hidden;
+}
+.lp-tgt__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding: 0.85rem 1rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(20, 29, 49, 0.5);
+}
+.lp-tgt__chip {
+  appearance: none;
+  border: 1px solid var(--line-2);
+  border-radius: 999px;
+  padding: 0.44rem 0.78rem;
+  background: rgba(5, 7, 13, 0.5);
+  color: var(--ink-2);
+  font: 600 12.5px/1 var(--font);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
+}
+.lp-tgt__chip:hover { color: var(--ink); border-color: rgba(96, 165, 250, 0.4); }
+.lp-tgt__chip.is-active {
+  color: #04060b;
+  font-weight: 700;
+  border-color: rgba(226, 232, 240, 0.5);
+  background: var(--metal-lite);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.55), inset 0 -6px 10px rgba(20, 37, 64, 0.12);
+}
+.lp-tgt__chip:focus-visible { outline: 2px solid var(--sky); outline-offset: 2px; }
+.lp-tgt__panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 1.1rem;
+  padding: 1.3rem 1.4rem 1.35rem;
+}
+.lp-tgt__panel[hidden] { display: none; }
+.lp-tgt__specs {
+  display: flex;
+  flex-direction: column;
+  gap: 0.72rem;
+}
+.lp-tgt__specs > div {
+  display: grid;
+  grid-template-columns: 92px 1fr;
+  gap: 0.9rem;
+  align-items: baseline;
+}
+.lp-tgt__specs dt {
+  font: 600 10.5px/1.6 var(--mono);
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.lp-tgt__specs dd {
+  font-size: 0.93rem;
+  line-height: 1.55;
+  color: var(--ink-2);
+}
+.lp-tgt__link {
+  margin-top: auto;
+  align-self: flex-start;
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--ink-2);
+  text-decoration: none;
+  border-bottom: 1px solid var(--line-2);
+  padding-bottom: 0.1rem;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+.lp-tgt__link:hover { color: var(--ink); border-color: var(--muted); }
+@media (max-width: 560px) {
+  .lp-tgt__specs > div { grid-template-columns: 1fr; gap: 0.1rem; }
+}
+
+/* three-up "what compiles into what" mini cards, shared with the sys grid */
 .lp-proof-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
@@ -607,162 +806,404 @@ a.lp-btn--primary:hover {
   font-size: 0.94rem;
   line-height: 1.6;
 }
+.lp-proof a { color: var(--ink-2); text-underline-offset: 3px; }
+.lp-proof a:hover { color: var(--ink); }
 
-/* ---- Bento grid (features + tooling + targets) ---------------------------- */
-.vb-bento { border-top: 1px solid var(--line); }
-.vb-grid {
+/* ---- .pocket package -------------------------------------------------------
+   Ship the application, not the port. */
+.lp-pkg { border-top: 1px solid var(--line); }
+.lp-pkg__split {
+  display: grid;
+  gap: clamp(2rem, 5vw, 3.5rem);
+  align-items: center;
+}
+@media (min-width: 940px) { .lp-pkg__split { grid-template-columns: 0.95fr 1.05fr; } }
+.lp-pkg__copy .lp-kicker { display: block; margin-bottom: 0.9rem; }
+.lp-pkg__copy .lp-h2 { font-size: clamp(1.75rem, 4vw, 2.6rem); }
+.lp-pkg__copy p {
+  margin-top: 1.1rem;
+  font-size: 1.02rem;
+  line-height: 1.65;
+  color: var(--ink-2);
+}
+.lp-pkg__copy em { font-style: normal; font-weight: 700; color: var(--ink); }
+.lp-pkg__verbs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 1.6rem;
+}
+.lp-pkg__verbs .lp-mono { font-size: 12px; padding: 0.4em 0.7em; }
+.lp-pkg__tree {
+  border-radius: 16px;
+  border: 1px solid var(--line-2);
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.62), rgba(9, 12, 20, 0.94)),
+    #090c14;
+  overflow: hidden;
+  box-shadow: 0 46px 90px -46px rgba(3, 9, 20, 0.94);
+}
+.lp-pkg__tree-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.78rem 1.05rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(20, 29, 49, 0.72);
+}
+.lp-pkg__pre {
+  padding: 1.3rem 1.4rem;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 13px;
+  line-height: 1.9;
+  color: #8b99ad;
+}
+.lp-pkg__pre code { font: inherit; white-space: pre; }
+.lp-pkg__pre b { color: var(--ink); font-weight: 700; }
+.lp-pkg__pre i { font-style: normal; color: var(--sky); }
+.lp-pkg__cap {
+  padding: 0 1.4rem 1.2rem;
+  font-size: 0.85rem;
+  line-height: 1.55;
+  color: var(--muted);
+}
+
+/* system-software grid under the package split */
+.lp-sys { margin-top: clamp(3.4rem, 7vw, 5rem); }
+.lp-sys__head { max-width: 640px; }
+.lp-sys__head h3 {
+  font-size: clamp(1.3rem, 2.6vw, 1.7rem);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+  color: var(--ink);
+}
+.lp-sys__head p { margin-top: 0.55rem; color: var(--ink-2); font-size: 0.98rem; line-height: 1.6; }
+.lp-sys__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+  gap: 1rem;
+  margin-top: 1.6rem;
+}
+
+/* ---- Device taxonomy -------------------------------------------------------
+   "Impossible" classified by constraint, not by nostalgia. */
+.lp-imposs {
+  border-top: 1px solid var(--line);
+  background:
+    radial-gradient(40% 55% at 100% 0%, rgba(96, 165, 250, 0.05), transparent 70%),
+    radial-gradient(34% 46% at 0% 20%, rgba(34, 211, 238, 0.035), transparent 72%);
+}
+.lp-imposs__grid {
   display: grid;
   grid-template-columns: repeat(6, 1fr);
-  gap: 0.9rem;
+  gap: 1rem;
   margin-top: clamp(2.4rem, 5vw, 3.6rem);
 }
-.vb-tile {
-  position: relative;
+.lp-imp {
   grid-column: span 2;
+  display: flex;
+  flex-direction: column;
   padding: 1.5rem 1.5rem 1.6rem;
   border-radius: 18px;
   border: 1px solid transparent;
   background:
     linear-gradient(180deg, rgba(15, 22, 38, 0.92), rgba(9, 12, 20, 0.88)) padding-box,
-    linear-gradient(165deg, rgba(96, 165, 250, 0.34), rgba(43, 58, 85, 0.5) 42%, rgba(34, 211, 238, 0.16)) border-box;
+    linear-gradient(165deg, rgba(96, 165, 250, 0.3), rgba(43, 58, 85, 0.5) 42%, rgba(34, 211, 238, 0.14)) border-box;
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 22px 50px -32px rgba(0, 0, 0, 0.9);
   transition: transform 0.28s ease, box-shadow 0.28s ease;
 }
-.vb-tile:hover {
+.lp-imp:hover {
   transform: translateY(-3px);
   box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 30px 60px -30px rgba(0, 0, 0, 0.95);
 }
-.vb-tile h3 { font-size: 1.06rem; letter-spacing: -0.01em; color: var(--ink); }
-.vb-tile p { margin-top: 0.55rem; color: var(--muted); font-size: 0.92rem; line-height: 1.62; }
-
-.vb-tile--hero { grid-column: span 4; grid-row: span 2; padding: 2rem 2rem 1.8rem; }
-.vb-tile--half { grid-column: span 3; }
-.vb-tile--hero h3 { font-size: clamp(1.35rem, 2.6vw, 1.7rem); }
-.vb-tile--hero > p { color: var(--ink-2); font-size: 1rem; max-width: 56ch; }
-
-/* input-tape visual in the hero tile */
-.vb-tape {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-  margin-top: 1.5rem;
-  padding: 1rem 1.1rem;
-  border-radius: 12px;
-  border: 1px solid var(--line-2);
-  background: rgba(5, 7, 13, 0.6);
+.lp-imp:nth-child(4), .lp-imp:nth-child(5), .lp-imp:nth-child(6) { grid-column: span 3; }
+.lp-imp h3 {
+  font-size: 1.12rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  color: var(--ink);
 }
-.vb-tape__label, .vb-tape__frame {
-  font: 600 10.5px/1.5 var(--mono);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
+.lp-imp > p {
+  margin-top: 0.5rem;
+  font-size: 0.92rem;
+  line-height: 1.6;
   color: var(--muted);
-  white-space: nowrap;
 }
-.vb-tape__frame b { color: var(--mint); letter-spacing: 0.04em; }
-.vb-tape__eq { color: var(--sky); font-size: 1.1rem; }
-.vb-tape__strip { display: flex; gap: 3px; flex: 1; min-width: 0; overflow: hidden; }
-.vb-tape__strip i {
-  flex: 1 0 8px;
-  height: 26px;
-  border-radius: 2px;
-  background: rgba(43, 58, 85, 0.65);
+.lp-imp.lp-imp--legend {
+  grid-column: 1 / -1;
+  flex-direction: row;
+  align-items: center;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 0.9rem 1.6rem;
+  background:
+    linear-gradient(180deg, rgba(9, 12, 20, 0.6), rgba(9, 12, 20, 0.4)) padding-box,
+    linear-gradient(165deg, rgba(43, 58, 85, 0.5), rgba(43, 58, 85, 0.3)) border-box;
+  box-shadow: none;
 }
-.vb-tape__strip i.dn { background: rgba(96, 165, 250, 0.55); }
-.vb-tape__strip i.on {
-  background: var(--mint);
-  box-shadow: 0 0 12px rgba(157, 229, 199, 0.5);
-  animation: vb-tick 1.6s steps(2) infinite;
-}
-@keyframes vb-tick { 50% { opacity: 0.45; } }
-.vb-meta { margin-top: 1.1rem; font-size: 0.86rem; color: var(--muted); font-style: italic; }
-
-/* targets tile */
-.vb-tile--wide { grid-column: span 6; }
-.vb-targets__head { display: flex; align-items: baseline; gap: 1.4rem; flex-wrap: wrap; }
-.vb-targets__head p { margin-top: 0; max-width: 56ch; }
-.vb-chips {
+.lp-imp--legend:hover { transform: none; }
+.lp-imp--legend p { margin-top: 0; font-size: 0.88rem; color: var(--muted); line-height: 1.6; flex: 1 1 320px; }
+.lp-imp--legend a { color: var(--ink-2); text-underline-offset: 3px; }
+.lp-imp--legend a:hover { color: var(--ink); }
+.lp-chips {
   display: flex;
   flex-wrap: wrap;
-  gap: 0.55rem;
-  margin: 1.2rem 0 0;
+  gap: 0.5rem;
+  margin: 1.05rem 0 0;
   padding: 0;
   list-style: none;
 }
-.vb-chips li {
+.lp-chips li {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  font-size: 0.88rem;
+  font-size: 0.85rem;
   font-weight: 600;
   color: var(--ink-2);
-  padding: 0.52rem 0.85rem;
+  padding: 0.48rem 0.8rem;
   border-radius: 999px;
   border: 1px solid var(--line-2);
   background: rgba(5, 7, 13, 0.55);
 }
-.vb-chips b, .vb-legend b {
+.lp-chips b, .vb-legend b {
   width: 7px;
   height: 7px;
   border-radius: 999px;
   background: var(--steel-4);
 }
-.vb-chips li.is-live b, .vb-legend b.is-live { background: var(--mint); box-shadow: 0 0 8px rgba(157, 229, 199, 0.55); }
-.vb-chips li.is-wip b, .vb-legend b.is-wip { background: var(--sky); box-shadow: 0 0 8px rgba(96, 165, 250, 0.5); }
-.vb-chips li.is-live { border-color: rgba(157, 229, 199, 0.32); }
+.lp-chips li.is-live b, .vb-legend b.is-live { background: var(--mint); box-shadow: 0 0 8px rgba(157, 229, 199, 0.55); }
+.lp-chips li.is-wip b, .vb-legend b.is-wip { background: var(--sky); box-shadow: 0 0 8px rgba(96, 165, 250, 0.5); }
+.lp-chips li.is-live { border-color: rgba(157, 229, 199, 0.32); }
 .vb-legend {
   display: flex;
+  flex-wrap: wrap;
   gap: 1.2rem;
-  margin-top: 1.1rem;
   font: 500 11px/1 var(--mono);
   color: var(--muted);
 }
 .vb-legend span { display: inline-flex; align-items: center; gap: 0.45rem; }
-
 @media (max-width: 920px) {
-  .vb-grid { grid-template-columns: repeat(2, 1fr); }
-  .vb-tile, .vb-tile--hero, .vb-tile--half, .vb-tile--wide { grid-column: span 2; grid-row: auto; }
+  .lp-imposs__grid { grid-template-columns: 1fr 1fr; }
+  .lp-imp, .lp-imp:nth-child(4), .lp-imp:nth-child(5), .lp-imp:nth-child(6) { grid-column: span 1; }
+  .lp-imp.lp-imp--legend, .lp-imposs__grid .lp-imp--legend:nth-child(6) { grid-column: 1 / -1; }
+}
+@media (max-width: 620px) {
+  .lp-imposs__grid { grid-template-columns: 1fr; }
 }
 
-/* ---- Split (code) section ------------------------------------------------- */
-.lp-split {
+/* ---- Showcase — six proof apps -------------------------------------------- */
+.lp-showcase { border-top: 1px solid var(--line); }
+.lp-apps {
   display: grid;
-  gap: clamp(2rem, 5vw, 3.5rem);
-  align-items: center;
+  gap: 1.1rem;
+  margin-top: clamp(2.4rem, 5vw, 3.6rem);
 }
-@media (min-width: 940px) { .lp-split { grid-template-columns: 0.92fr 1.08fr; } }
-.lp-split__copy .lp-kicker { display: block; margin-bottom: 0.9rem; }
-.lp-split__copy .lp-h2 { font-size: clamp(1.75rem, 4vw, 2.6rem); }
-.lp-split__copy p { margin-top: 1.1rem; font-size: 1.02rem; line-height: 1.6; color: var(--ink-2); }
-.lp-mono {
-  font-family: var(--mono);
-  font-size: 0.85em;
-  color: var(--sky);
-  background: rgba(20, 29, 49, 0.78);
-  border: 1px solid rgba(43, 58, 85, 0.92);
-  padding: 0.08em 0.4em;
-  border-radius: 6px;
-  white-space: nowrap;
-}
-.lp-checklist {
-  list-style: none;
-  padding: 0;
-  margin-top: 1.6rem;
+@media (min-width: 720px) { .lp-apps { grid-template-columns: 1fr 1fr; } }
+@media (min-width: 1080px) { .lp-apps { grid-template-columns: 1fr 1fr 1fr; } }
+.lp-app {
   display: flex;
   flex-direction: column;
-  gap: 0.95rem;
+  border-radius: 18px;
+  border: 1px solid var(--line-2);
+  background:
+    linear-gradient(180deg, rgba(15, 22, 38, 0.7), rgba(9, 12, 20, 0.92)),
+    var(--bg-2);
+  overflow: hidden;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 26px 56px -36px rgba(0, 0, 0, 0.92);
+  transition: transform 0.28s ease, box-shadow 0.28s ease, border-color 0.28s ease;
 }
-.lp-checklist li {
+.lp-app:hover {
+  transform: translateY(-3px);
+  border-color: rgba(96, 165, 250, 0.34);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06), 0 34px 66px -34px rgba(0, 0, 0, 0.96);
+}
+.lp-app__media {
+  display: block;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  background: #04060c;
+  border-bottom: 1px solid var(--line);
+}
+.lp-app__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scale(1.001);
+  transition: transform 0.35s ease;
+}
+.lp-app__media:hover img { transform: scale(1.03); }
+.lp-app__media:focus-visible { outline: 2px solid var(--sky); outline-offset: -2px; }
+.lp-app__body {
   display: flex;
-  gap: 0.7rem;
-  font-size: 0.95rem;
+  flex-direction: column;
+  flex: 1;
+  padding: 1.2rem 1.3rem 1.3rem;
+}
+.lp-app__body h3 {
+  font-size: 1.14rem;
+  font-weight: 800;
+  letter-spacing: -0.015em;
+  color: var(--ink);
+}
+.lp-app__proves {
+  margin-top: 0.4rem;
+  font: 600 10.5px/1.5 var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--mint);
+}
+.lp-app__body > p:not(.lp-app__proves) {
+  margin-top: 0.65rem;
+  font-size: 0.92rem;
+  line-height: 1.62;
+  color: var(--ink-2);
+}
+.lp-app__links {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.8rem;
+  flex-wrap: wrap;
+  margin-top: auto;
+  padding-top: 1.05rem;
+}
+.lp-app__links a {
+  font-size: 0.88rem;
+  font-weight: 600;
+  color: var(--ink-2);
+  text-decoration: none;
+  border-bottom: 1px solid var(--line-2);
+  padding-bottom: 0.08rem;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+.lp-app__links a:hover { color: var(--ink); border-color: var(--muted); }
+.lp-app__links .lp-app__src {
+  font: 500 12px/1.4 var(--mono);
+  color: var(--muted);
+  border-bottom-color: transparent;
+}
+.lp-app__links .lp-app__src:hover { color: var(--ink); border-bottom-color: var(--muted); }
+
+/* ---- Porting contract + workflow ------------------------------------------ */
+.lp-port { border-top: 1px solid var(--line); }
+.lp-port__grid {
+  display: grid;
+  gap: 1rem;
+  margin-top: clamp(2.4rem, 5vw, 3.6rem);
+}
+@media (min-width: 980px) {
+  .lp-port__grid { grid-template-columns: 0.75fr 1fr 1.35fr; align-items: stretch; }
+}
+.lp-port__card {
+  padding: 1.5rem 1.5rem 1.6rem;
+  border-radius: 18px;
+  border: 1px solid var(--line);
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.58), rgba(7, 10, 17, 0.9)),
+    var(--bg-2);
+}
+.lp-port__card--pocket {
+  border: 1px solid transparent;
+  background:
+    linear-gradient(180deg, rgba(15, 22, 38, 0.92), rgba(9, 12, 20, 0.88)) padding-box,
+    linear-gradient(165deg, rgba(96, 165, 250, 0.34), rgba(43, 58, 85, 0.5) 42%, rgba(157, 229, 199, 0.2)) border-box;
+}
+.lp-port__card h3 {
+  font: 600 11px/1.5 var(--mono);
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 0.95rem;
+}
+.lp-port__card--pocket h3 { color: var(--mint); }
+.lp-port__list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.62rem;
+}
+.lp-port__list li {
+  position: relative;
+  padding-left: 1.2rem;
+  font-size: 0.94rem;
   line-height: 1.5;
   color: var(--ink-2);
 }
-.lp-checklist svg { flex: none; margin-top: 0.15rem; color: #cbd5e1; }
-.lp-split__copy .lp-btn { margin-top: 1.9rem; }
+.lp-port__list li::before {
+  content: "";
+  position: absolute;
+  left: 0.1rem;
+  top: 0.56em;
+  width: 5px;
+  height: 5px;
+  border-radius: 999px;
+  background: var(--steel-3);
+}
+.lp-port__card--pocket .lp-port__list li::before {
+  background: var(--mint);
+  box-shadow: 0 0 7px rgba(157, 229, 199, 0.5);
+}
+.lp-port__side { display: flex; flex-direction: column; gap: 1rem; min-width: 0; }
+.lp-term {
+  border-radius: 16px;
+  border: 1px solid var(--line-2);
+  background:
+    linear-gradient(180deg, rgba(20, 29, 49, 0.62), rgba(9, 12, 20, 0.94)),
+    #090c14;
+  overflow: hidden;
+  box-shadow: 0 40px 80px -44px rgba(3, 9, 20, 0.94);
+}
+.lp-term__bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.78rem 1.05rem;
+  border-bottom: 1px solid var(--line);
+  background: rgba(20, 29, 49, 0.72);
+}
+.lp-term__pre {
+  padding: 1.2rem 1.3rem;
+  overflow-x: auto;
+  font-family: var(--mono);
+  font-size: 12.8px;
+  line-height: 1.95;
+  color: #cbd5e1;
+}
+.lp-term__pre code { font: inherit; white-space: pre; }
+.lp-term__ps { color: var(--mint); }
+.lp-term__c { color: #566780; }
+.lp-port__note {
+  font-size: 0.92rem;
+  line-height: 1.65;
+  color: var(--muted);
+}
+.lp-port__note a { color: var(--ink-2); text-underline-offset: 3px; }
+.lp-port__note a:hover { color: var(--ink); }
+.lp-port__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: auto;
+}
+.lp-port__links a {
+  font-size: 0.86rem;
+  font-weight: 600;
+  color: var(--ink-2);
+  text-decoration: none;
+  padding: 0.5rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid var(--line-2);
+  background: rgba(5, 7, 13, 0.5);
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+.lp-port__links a:hover { color: var(--ink); border-color: rgba(96, 165, 250, 0.44); }
 
-/* ---- Code card ------------------------------------------------------------ */
+/* ---- Codecard (shared by the target selector) ------------------------------ */
 .lp-codecard {
+  display: flex;
+  flex-direction: column;
   border-radius: 16px;
   border: 1px solid var(--line-2);
   background:
@@ -786,11 +1227,6 @@ a.lp-btn--primary:hover {
   font-family: var(--mono);
   font-size: 12px;
   color: var(--muted);
-}
-.lp-shot {
-  display: block;
-  width: 100%;
-  height: auto;
 }
 .lp-code-tabs {
   display: inline-flex;
@@ -824,7 +1260,7 @@ a.lp-btn--primary:hover {
   padding: 1.3rem 1.4rem;
   overflow-x: auto;
   font-family: var(--mono);
-  font-size: 13.5px;
+  font-size: 13px;
   line-height: 1.75;
   color: #cbd5e1;
   -webkit-text-size-adjust: 100%;
@@ -906,7 +1342,7 @@ a.lp-btn--primary:hover {
 .lp-footer__brand .lp-brand { font-size: 16px; }
 .lp-footer__brand p {
   margin-top: 0.95rem;
-  max-width: 32ch;
+  max-width: 34ch;
   font-size: 0.9rem;
   line-height: 1.55;
   color: var(--muted);
@@ -933,7 +1369,6 @@ a.lp-btn--primary:hover {
   font-size: 0.8rem;
 }
 .lp-footer__bar--end { justify-content: flex-end; }
-.lp-footer__bar:not(.lp-footer__bar--end) span:first-child { font-family: var(--mono); letter-spacing: 0.02em; }
 
 /* ---- Scroll-reveal (progressive enhancement; visible by default) ---------- */
 @supports (animation-timeline: view()) {
@@ -952,4 +1387,5 @@ a.lp-btn--primary:hover {
 
 @media (prefers-reduced-motion: reduce) {
   .lp * { animation: none !important; transition: none !important; }
+  html { scroll-behavior: auto; }
 }

--- a/site/assets/home.js
+++ b/site/assets/home.js
@@ -1,23 +1,26 @@
 // site/assets/home.js — homepage behaviors. The background remains a cheap
 // baked demo wall; the live Pocket Stage below the CTA is code-split and boots
-// only when it approaches the viewport.
+// only when it approaches the viewport. Tab groups (framework tabs on the code
+// card, target chips on the selector) are static HTML — JS only toggles state.
 
-function setupCodeTabs() {
-  const tabs = [...document.querySelectorAll("[data-code-tab]")];
+function setupTabs(tabAttr, panelAttr) {
+  const tabs = [...document.querySelectorAll(`[data-${tabAttr}]`)];
   if (tabs.length === 0) return;
-  const panels = [...document.querySelectorAll("[data-code-panel]")];
+  const panels = [...document.querySelectorAll(`[data-${panelAttr}]`)];
+  const key = tabAttr.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
+  const panelKey = panelAttr.replace(/-([a-z])/g, (_, c) => c.toUpperCase());
   const select = (name) => {
     for (const tab of tabs) {
-      const active = tab.dataset.codeTab === name;
+      const active = tab.dataset[key] === name;
       tab.classList.toggle("is-active", active);
       tab.setAttribute("aria-selected", active ? "true" : "false");
     }
     for (const panel of panels) {
-      panel.hidden = panel.dataset.codePanel !== name;
+      panel.hidden = panel.dataset[panelKey] !== name;
     }
   };
   for (const tab of tabs) {
-    tab.addEventListener("click", () => select(tab.dataset.codeTab));
+    tab.addEventListener("click", () => select(tab.dataset[key]));
   }
 }
 
@@ -71,6 +74,7 @@ function setupPocketStage() {
   io.observe(root);
 }
 
-setupCodeTabs();
+setupTabs("code-tab", "code-panel");
+setupTabs("tgt-tab", "tgt-panel");
 setupDemoWall();
 setupPocketStage();

--- a/site/build.ts
+++ b/site/build.ts
@@ -427,7 +427,21 @@ function renderHome(): string {
     url: SITE_URL,
     codeRepository: "https://github.com/pocket-stack/pocketjs",
     programmingLanguage: ["TypeScript", "JavaScript", "Rust"],
-    runtimePlatform: ["Sony PSP", "Sony PS Vita", "PPSSPP", "Vita3K", "WebAssembly", "Bun"],
+    runtimePlatform: [
+      "Sony PSP",
+      "Sony PS Vita",
+      "Nokia E7 (Symbian)",
+      "PocketBook",
+      "ESP32",
+      "Game Boy Advance",
+      "Game Boy",
+      "NES",
+      "macOS",
+      "PPSSPP",
+      "Vita3K",
+      "WebAssembly",
+      "Bun",
+    ],
   });
   return `<!doctype html>
 <html lang="en">
@@ -446,7 +460,7 @@ function renderHome(): string {
 <meta property="og:image" content="${OG_IMAGE_URL}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
-<meta property="og:image:alt" content="PocketJS — Bare Metal Modern Web">
+<meta property="og:image:alt" content="PocketJS — Build Modern Apps for Impossible Devices">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="${SITE_TITLE}">
 <meta name="twitter:description" content="${HOME_DESC}">

--- a/site/home.html
+++ b/site/home.html
@@ -49,20 +49,22 @@
           Symbian Wanted a Frame Function: PocketJS on a Nokia E7
           <span class="lp-eyebrow__arw" aria-hidden="true">&rarr;</span>
         </a>
-        <h1 class="lp-h1">Bare Metal<span class="lp-grad">Modern Web</span></h1>
+        <h1 class="lp-h1">Build modern apps<span class="lp-grad">for impossible devices.</span></h1>
         <p class="lp-sub">
-          High-performance JSX UI outside the browser, with native rendering,
-          standard Vue Vapor and Solid support, a Tailwind design system, and
-          60 FPS animation under an 8 MB memory budget.
+          Write Vue, Solid and TypeScript once &mdash; run it on game consoles,
+          e-readers, abandoned smartphones and microcontrollers. A tiny
+          JavaScript guest where it fits; the framework compiled away where it
+          doesn&rsquo;t.
         </p>
         <div class="lp-hero__cta">
           <a class="lp-btn lp-btn--primary" href="/docs/getting-started/">Get started</a>
+          <a class="lp-btn lp-btn--ghost" href="#devices">Explore the devices</a>
           <a class="lp-btn lp-btn--ghost" href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">
             Star on GitHub
             <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 4.7 18 5 18 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
           </a>
         </div>
-        <figure class="lp-stage" data-pocket-stage>
+        <figure class="lp-stage" id="stage" data-pocket-stage>
           <div class="lp-stage__viewport" data-stage-viewport>
             <canvas class="lp-stage__canvas" data-stage-canvas aria-label="Interactive 3D PSP running the Pocket Launcher. Drag to rotate, swipe sideways with two fingers to turn, and click the device controls — SELECT summons the app switcher."></canvas>
             <canvas class="lp-stage__screen" data-stage-screen aria-hidden="true"></canvas>
@@ -82,13 +84,73 @@
       </div>
     </section>
 
-    <!-- 8MB RAM -->
-    <section class="lp-section lp-hardware">
+    <!-- PROOF STRIP — five seconds to establish this is not a concept project. -->
+    <section class="lp-proofstrip" aria-label="Shipped results">
+      <div class="lp-container">
+        <ul class="lp-proofstrip__row">
+          <li><a class="lp-fact" href="/blog/pocket-vapor/"><b>Vue on a Game&nbsp;Boy</b><span>no JS engine, no GC, no malloc</span></a></li>
+          <li><a class="lp-fact" href="/blog/pocket-youtube/"><b>YouTube on a PSP</b><span>the network is a USB cable</span></a></li>
+          <li><a class="lp-fact" href="/blog/pocket-figma/"><b>Figma at 333&nbsp;MHz</b><span>14,430 nodes, streamed in tiles</span></a></li>
+          <li><a class="lp-fact" href="/blog/pocketjs-on-symbian/"><b>Modern UI on Symbian</b><span>a 2011 phone, a 2026 stack</span></a></li>
+          <li><a class="lp-fact" href="/blog/shipping-openstrike/"><b>60&nbsp;FPS 3D on 2004 silicon</b><span>BSP worlds under a Solid HUD</span></a></li>
+          <li><a class="lp-fact" href="/blog/pocket-character/"><b>Desktop widgets, no Electron</b><span>118&nbsp;MB where Electron needs 2.2&nbsp;GB</span></a></li>
+        </ul>
+      </div>
+    </section>
+
+    <!-- EXECUTION CLASSES — the central abstraction: one app model, two ways down. -->
+    <section class="lp-section lp-exec">
       <div class="lp-container">
         <div class="lp-secthead lp-reveal">
-          <span class="lp-kicker">Familiar tools, constrained hardware</span>
-          <h2 class="lp-h2">Tailwind, flexbox, Solid and Vue Vapor under 8MB RAM.</h2>
-          <p class="lp-lead">PocketJS keeps the authoring model modern while moving the expensive work to build time and to a tiny Rust core. The result is a real interface stack that can run smoothly on a Sony PSP.</p>
+          <span class="lp-kicker">One app model, two execution classes</span>
+          <h2 class="lp-h2">Choose how low you need&nbsp;to&nbsp;go.</h2>
+          <p class="lp-lead">Some devices can host a tiny JavaScript engine. Some can&rsquo;t host a heap. PocketJS treats that as a build decision, not a rewrite.</p>
+        </div>
+        <div class="lp-exec__grid lp-reveal">
+          <article class="lp-exec__card">
+            <div class="lp-exec__head">
+              <h3>Pocket Guest</h3>
+              <span class="lp-exec__badge">execution:&nbsp;guest</span>
+            </div>
+            <p class="lp-exec__tag">Keep JavaScript dynamic.</p>
+            <ul class="lp-exec__list">
+              <li>Solid and Vue Vapor with their real reactivity, running on QuickJS</li>
+              <li>A native Rust core owns layout, text, animation and damage tracking</li>
+              <li>Hot-swappable app logic &mdash; replace the bundle, keep the device</li>
+              <li>Time-travel DevTools over USB to real hardware</li>
+            </ul>
+            <p class="lp-exec__for"><span>Runs on</span> PSP &middot; PS&nbsp;Vita &middot; Nokia&nbsp;E7 &middot; PocketBook &middot; ESP32&#8209;P4 &middot; macOS &middot; browser</p>
+          </article>
+          <article class="lp-exec__card lp-exec__card--aot">
+            <div class="lp-exec__head">
+              <h3>Pocket Vapor</h3>
+              <span class="lp-exec__badge">execution:&nbsp;aot</span>
+            </div>
+            <p class="lp-exec__tag">Compile the runtime away.</p>
+            <ul class="lp-exec__list">
+              <li>The Vue authoring model &mdash; <span class="lp-mono">ref</span>, <span class="lp-mono">computed</span>, JSX, list rendering</li>
+              <li>Reactivity becomes compile-time dirty-bit graphs</li>
+              <li>No JavaScript engine, no GC, no allocator on the device</li>
+              <li>Verified frame-by-frame against real Vue on the same inputs</li>
+            </ul>
+            <p class="lp-exec__for"><span>Runs on</span> Game&nbsp;Boy Advance &middot; Game&nbsp;Boy &middot; NES &middot; ESP32 microcontrollers</p>
+          </article>
+        </div>
+        <p class="lp-exec__note lp-reveal">
+          The manifest declares what an app needs; every target profile declares which execution
+          classes and capabilities it admits. Admission is checked before anything ships &mdash;
+          not discovered on the device. <a href="/docs/platform-contracts/">Platform contracts &rarr;</a>
+        </p>
+      </div>
+    </section>
+
+    <!-- CODE + TARGET SELECTOR — same component, pick the machine underneath it. -->
+    <section class="lp-section lp-targets">
+      <div class="lp-container">
+        <div class="lp-secthead lp-reveal">
+          <span class="lp-kicker">Familiar code, native machinery</span>
+          <h2 class="lp-h2">Write the app you already know how to write.</h2>
+          <p class="lp-lead">Components, signals, Tailwind classes. Then pick the machine underneath.</p>
         </div>
         <div class="lp-tools__row lp-reveal" aria-label="PocketJS frontend stack">
           <span class="lp-tool" aria-label="Solid">
@@ -123,47 +185,9 @@
             <svg width="27" height="27" viewBox="0 0 32 32" aria-hidden="true"><rect width="32" height="32" rx="5" fill="#3178c6"/><text x="16.5" y="22.5" font-family="Inter, ui-sans-serif, system-ui, sans-serif" font-size="14" font-weight="700" fill="#fff" text-anchor="middle">TS</text></svg>
           </span>
         </div>
-        <div class="lp-proof-grid">
-          <div class="lp-proof lp-reveal">
-            <h3>Flexbox is native</h3>
-            <p>Layout runs in the Rust core through taffy, so a familiar <span class="lp-mono">flex-col gap-4</span> interface lays out deterministically on PSP, browser and Bun.</p>
-          </div>
-          <div class="lp-proof lp-reveal">
-            <h3>Tailwind compiles away</h3>
-            <p>Class literals become compact style records at build time. There is no CSS parser, stylesheet cascade or utility runtime on the device.</p>
-          </div>
-          <div class="lp-proof lp-reveal">
-            <h3>Text is still sharp</h3>
-            <p>Inter glyphs are baked into coverage atlases and rendered with sub-pixel positioning, so tiny PSP screens still get readable UI text.</p>
-          </div>
-        </div>
-      </div>
-    </section>
 
-    <!-- CODE SAMPLE -->
-    <section class="lp-section" style="padding-top: clamp(2rem, 5vw, 3.5rem);">
-      <div class="lp-container">
-        <div class="lp-split">
-          <div class="lp-split__copy lp-reveal">
-            <span class="lp-kicker">Business logic stays intact</span>
-            <h2 class="lp-h2">Native framework imports on a tiny machine.</h2>
-            <p>Write Solid or Vue Vapor components with their own reactivity APIs, run them on QuickJS, and let PocketJS handle the native pixels.</p>
-            <ul class="lp-checklist">
-              <li>
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m20 6-11 11-5-5"/></svg>
-                <span><span class="lp-mono">focusable</span> and <span class="lp-mono">onPress</span> map to PSP controls.</span>
-              </li>
-              <li>
-                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m20 6-11 11-5-5"/></svg>
-                <span><span class="lp-mono">focus:</span> variants and packed assets become native data in the <span class="lp-mono">.pak</span>.</span>
-              </li>
-            </ul>
-            <a class="lp-btn lp-btn--primary" href="/playground/">
-              Open the playground
-              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
-            </a>
-          </div>
-          <div class="lp-codecard lp-reveal">
+        <div class="lp-targets__grid lp-reveal">
+          <div class="lp-codecard">
             <div class="lp-codecard__bar">
               <span class="lp-dot" aria-hidden="true"></span><span class="lp-dot" aria-hidden="true"></span><span class="lp-dot" aria-hidden="true"></span>
               <span class="lp-codecard__name">Counter.tsx</span>
@@ -201,149 +225,383 @@
   );
 }</code></pre>
           </div>
+
+          <div class="lp-tgt" data-tgt>
+            <div class="lp-tgt__chips" role="tablist" aria-label="Build target">
+              <button class="lp-tgt__chip is-active" type="button" role="tab" id="lp-tgt-tab-browser" aria-selected="true" aria-controls="lp-tgt-browser" data-tgt-tab="browser">Browser</button>
+              <button class="lp-tgt__chip" type="button" role="tab" id="lp-tgt-tab-psp" aria-selected="false" aria-controls="lp-tgt-psp" data-tgt-tab="psp">Sony PSP</button>
+              <button class="lp-tgt__chip" type="button" role="tab" id="lp-tgt-tab-vita" aria-selected="false" aria-controls="lp-tgt-vita" data-tgt-tab="vita">PS Vita</button>
+              <button class="lp-tgt__chip" type="button" role="tab" id="lp-tgt-tab-e7" aria-selected="false" aria-controls="lp-tgt-e7" data-tgt-tab="e7">Nokia E7</button>
+              <button class="lp-tgt__chip" type="button" role="tab" id="lp-tgt-tab-pb" aria-selected="false" aria-controls="lp-tgt-pb" data-tgt-tab="pb">PocketBook</button>
+              <button class="lp-tgt__chip" type="button" role="tab" id="lp-tgt-tab-esp" aria-selected="false" aria-controls="lp-tgt-esp" data-tgt-tab="esp">ESP32&#8209;P4</button>
+              <button class="lp-tgt__chip" type="button" role="tab" id="lp-tgt-tab-gb" aria-selected="false" aria-controls="lp-tgt-gb" data-tgt-tab="gb">Game Boy</button>
+            </div>
+
+            <div class="lp-tgt__panel" id="lp-tgt-browser" role="tabpanel" aria-labelledby="lp-tgt-tab-browser" data-tgt-panel="browser">
+              <dl class="lp-tgt__specs">
+                <div><dt>Execution</dt><dd>the same Rust core, compiled to WebAssembly</dd></div>
+                <div><dt>Display</dt><dd>any viewport, density-aware</dd></div>
+                <div><dt>Rendering</dt><dd>identical framebuffers to the devices &mdash; goldens run here</dd></div>
+                <div><dt>Input</dt><dd>mouse, keyboard, gamepad</dd></div>
+                <div><dt>Ships as</dt><dd>a URL &mdash; no install, no toolchain</dd></div>
+              </dl>
+              <a class="lp-tgt__link" href="/playground/">Run this counter in the playground &rarr;</a>
+            </div>
+            <div class="lp-tgt__panel" id="lp-tgt-psp" role="tabpanel" aria-labelledby="lp-tgt-tab-psp" data-tgt-panel="psp" hidden>
+              <dl class="lp-tgt__specs">
+                <div><dt>Execution</dt><dd>QuickJS guest &middot; 333&nbsp;MHz MIPS &middot; 8&nbsp;MB UI budget</dd></div>
+                <div><dt>Display</dt><dd>480 &times; 272 at 60&nbsp;FPS</dd></div>
+                <div><dt>Rendering</dt><dd>sceGu draw lists, baked glyph atlases</dd></div>
+                <div><dt>Input</dt><dd>D-pad focus, buttons, analog nub</dd></div>
+                <div><dt>Ships as</dt><dd><span class="lp-mono">EBOOT.PBP</span> on a Memory Stick</dd></div>
+              </dl>
+              <a class="lp-tgt__link" href="/blog/introducing-pocketjs/">How PocketJS started here &rarr;</a>
+            </div>
+            <div class="lp-tgt__panel" id="lp-tgt-vita" role="tabpanel" aria-labelledby="lp-tgt-tab-vita" data-tgt-panel="vita" hidden>
+              <dl class="lp-tgt__specs">
+                <div><dt>Execution</dt><dd>QuickJS guest &mdash; the same bundle as the PSP</dd></div>
+                <div><dt>Display</dt><dd>960 &times; 544 native, 2&times; raster density</dd></div>
+                <div><dt>Rendering</dt><dd>one codebase, twice the pixels &mdash; zero forks</dd></div>
+                <div><dt>Input</dt><dd>touch, buttons, dual analog</dd></div>
+                <div><dt>Ships as</dt><dd>a <span class="lp-mono">.vpk</span> with LiveArea art</dd></div>
+              </dl>
+              <a class="lp-tgt__link" href="/blog/pocketjs-on-ps-vita/">Twice the pixels, zero forks &rarr;</a>
+            </div>
+            <div class="lp-tgt__panel" id="lp-tgt-e7" role="tabpanel" aria-labelledby="lp-tgt-tab-e7" data-tgt-panel="e7" hidden>
+              <dl class="lp-tgt__specs">
+                <div><dt>Execution</dt><dd>QuickJS guest on a Symbian C++ host</dd></div>
+                <div><dt>Display</dt><dd>640 &times; 360 AMOLED, live portrait &#8646; landscape</dd></div>
+                <div><dt>Rendering</dt><dd>native viewport resize &mdash; the app relays out, no letterbox</dd></div>
+                <div><dt>Input</dt><dd>touch + the slide-out QWERTY</dd></div>
+                <div><dt>Ships as</dt><dd>a <span class="lp-mono">.sis</span>, deployed over CODA USB</dd></div>
+              </dl>
+              <a class="lp-tgt__link" href="/blog/pocketjs-on-symbian/">Symbian wanted a frame function &rarr;</a>
+            </div>
+            <div class="lp-tgt__panel" id="lp-tgt-pb" role="tabpanel" aria-labelledby="lp-tgt-tab-pb" data-tgt-panel="pb" hidden>
+              <dl class="lp-tgt__specs">
+                <div><dt>Execution</dt><dd>QuickJS guest on the inkview host</dd></div>
+                <div><dt>Display</dt><dd>e-ink &mdash; a screen that fights every frame</dd></div>
+                <div><dt>Rendering</dt><dd>16 &times; 16 tile diffs choose partial, dynamic or full refresh</dd></div>
+                <div><dt>Input</dt><dd>page-turn buttons + touch</dd></div>
+                <div><dt>Ships as</dt><dd>a PocketBook application</dd></div>
+              </dl>
+              <a class="lp-tgt__link" href="/docs/platform-contracts/">The contract that admits e-ink &rarr;</a>
+            </div>
+            <div class="lp-tgt__panel" id="lp-tgt-esp" role="tabpanel" aria-labelledby="lp-tgt-tab-esp" data-tgt-panel="esp" hidden>
+              <dl class="lp-tgt__specs">
+                <div><dt>Execution</dt><dd>embedded guest &mdash; no OS underneath</dd></div>
+                <div><dt>Display</dt><dd>RGB565 panel</dd></div>
+                <div><dt>Rendering</dt><dd>incremental damage strips, PPA-accelerated blits</dd></div>
+                <div><dt>Input</dt><dd>touch</dd></div>
+                <div><dt>Ships as</dt><dd>flashed firmware</dd></div>
+              </dl>
+              <a class="lp-tgt__link" href="/changelog/">Fresh from the changelog &rarr;</a>
+            </div>
+            <div class="lp-tgt__panel" id="lp-tgt-gb" role="tabpanel" aria-labelledby="lp-tgt-tab-gb" data-tgt-panel="gb" hidden>
+              <dl class="lp-tgt__specs">
+                <div><dt>Execution</dt><dd>Pocket Vapor AOT &mdash; no JS engine on the device</dd></div>
+                <div><dt>Display</dt><dd>160 &times; 144, four shades of green</dd></div>
+                <div><dt>Rendering</dt><dd>reactivity compiled to console-native tile layers</dd></div>
+                <div><dt>Input</dt><dd>D-pad and two buttons</dd></div>
+                <div><dt>Ships as</dt><dd>a <span class="lp-mono">.gb</span> cart &mdash; the same source also builds <span class="lp-mono">.gba</span> and <span class="lp-mono">.nes</span></dd></div>
+              </dl>
+              <a class="lp-tgt__link" href="/blog/pocket-vapor/">Vue, compiled all the way down &rarr;</a>
+            </div>
+          </div>
+        </div>
+
+        <div class="lp-proof-grid">
+          <div class="lp-proof lp-reveal">
+            <h3>Layout becomes native flexbox</h3>
+            <p>taffy lays out in the Rust core &mdash; a familiar <span class="lp-mono">flex-col gap-4</span> lands on identical pixels on every target, provable in goldens.</p>
+          </div>
+          <div class="lp-proof lp-reveal">
+            <h3>Tailwind becomes style data</h3>
+            <p>Class literals compile to compact numeric records. No CSS parser, no cascade, no utility runtime ships to the device.</p>
+          </div>
+          <div class="lp-proof lp-reveal">
+            <h3>Reactivity becomes what fits</h3>
+            <p>A tiny QuickJS guest where there&rsquo;s room for one; compiled dirty-bit state machinery where there isn&rsquo;t.</p>
+          </div>
         </div>
       </div>
     </section>
 
-    <!-- SHOWCASE -->
+    <!-- .POCKET — the platform story: ship the application, not the port. -->
+    <section class="lp-section lp-pkg">
+      <div class="lp-container">
+        <div class="lp-pkg__split">
+          <div class="lp-pkg__copy lp-reveal">
+            <span class="lp-kicker">One app. Every target. One package.</span>
+            <h2 class="lp-h2">Ship the application,<br />not the port.</h2>
+            <p>A <span class="lp-mono">.pocket</span> file describes what the app <em>is</em> and what it <em>needs</em> &mdash; identity, capabilities, build plan, payloads. Each device decides how it should run: which viewport, which presentation, which execution class. If a target can&rsquo;t honor the contract, it says so before launch, not after.</p>
+            <div class="lp-pkg__verbs" aria-label="Package toolchain verbs">
+              <span class="lp-mono">build --all-targets</span>
+              <span class="lp-mono">inspect</span>
+              <span class="lp-mono">verify</span>
+              <span class="lp-mono">thin</span>
+            </div>
+          </div>
+          <div class="lp-pkg__tree lp-reveal" aria-label="Anatomy of a .pocket package">
+            <div class="lp-pkg__tree-bar">
+              <span class="lp-dot" aria-hidden="true"></span><span class="lp-dot" aria-hidden="true"></span><span class="lp-dot" aria-hidden="true"></span>
+              <span class="lp-codecard__name">my-app.pocket</span>
+            </div>
+            <pre class="lp-pkg__pre"><code><b>my-app.pocket</b>
+├─ <i>identity</i>       app id, version, entry
+├─ <i>capabilities</i>   input.touch · display.viewport.live · …
+├─ <i>build plan</i>     how every target gets produced
+├─ <i>payloads</i>       guest bundle · AOT program
+└─ <i>assets</i>         style packs · fonts · tiles</code></pre>
+            <p class="lp-pkg__cap">One deterministic file. Every target re-verifies the plan before launch.</p>
+          </div>
+        </div>
+
+        <div class="lp-sys lp-reveal">
+          <div class="lp-sys__head">
+            <h3>System software, built into the runtime</h3>
+            <p>Not just rectangles on unusual screens &mdash; the pieces apps need to become an ecosystem.</p>
+          </div>
+          <div class="lp-sys__grid">
+            <article class="lp-proof">
+              <h3>App launcher</h3>
+              <p>A Cover Flow deck that cold-boots, freezes and switches whole apps &mdash; running live in the PSP at the top of this page.</p>
+            </article>
+            <article class="lp-proof">
+              <h3>Capability contracts</h3>
+              <p>A registry of real, tested hosts. Apps declare needs; targets admit or refuse them at build time.</p>
+            </article>
+            <article class="lp-proof">
+              <h3>Input &amp; OSK</h3>
+              <p>D-pad focus, touch, analog, a virtual cursor &mdash; and a system keyboard any app summons with one call.</p>
+            </article>
+            <article class="lp-proof">
+              <h3>Host services</h3>
+              <p>USB companions bring what the device lacks: yt-dlp on a Mac becomes YouTube on a PSP.</p>
+            </article>
+            <article class="lp-proof">
+              <h3>Time-travel DevTools</h3>
+              <p>Every session records itself. Step to any frame, inspect the native tree &mdash; over USB to real hardware.</p>
+            </article>
+            <article class="lp-proof">
+              <h3>Deterministic core</h3>
+              <p>A virtual clock makes every frame a pure function of the input tape. Goldens compare framebuffers byte for byte. <a href="/blog/ui-runtime-that-cant-flake/">The UI runtime that can&rsquo;t flake &rarr;</a></p>
+            </article>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- DEVICE TAXONOMY — impossible, classified by constraint rather than by nostalgia. -->
+    <section class="lp-section lp-imposs" id="devices">
+      <div class="lp-container">
+        <div class="lp-secthead lp-reveal">
+          <span class="lp-kicker">Where it runs</span>
+          <h2 class="lp-h2">Built for every kind of impossible.</h2>
+          <p class="lp-lead">Impossible doesn&rsquo;t mean old. It means no browser, no modern OS, no JS engine, no continuous refresh &mdash; or no vendor left to care.</p>
+        </div>
+        <div class="lp-imposs__grid">
+          <article class="lp-imp lp-reveal">
+            <h3>Retro consoles</h3>
+            <p>No OS to lean on, and 333&nbsp;MHz is the fast one.</p>
+            <ul class="lp-chips">
+              <li class="is-live"><b></b>Sony PSP</li>
+              <li class="is-live"><b></b>PS Vita</li>
+              <li class="is-live"><b></b>Game Boy Advance</li>
+              <li class="is-live"><b></b>Game Boy</li>
+              <li class="is-live"><b></b>NES</li>
+              <li><b></b>Nintendo 3DS</li>
+            </ul>
+          </article>
+          <article class="lp-imp lp-reveal">
+            <h3>Abandoned smartphones</h3>
+            <p>The vendor moved on. The hardware didn&rsquo;t.</p>
+            <ul class="lp-chips">
+              <li class="is-live"><b></b>Nokia E7 &middot; Symbian</li>
+              <li><b></b>MeeGo</li>
+              <li><b></b>BlackBerry</li>
+              <li><b></b>Windows Phone</li>
+            </ul>
+          </article>
+          <article class="lp-imp lp-reveal">
+            <h3>E-ink surfaces</h3>
+            <p>A screen that fights every frame &mdash; so the runtime picks partial, dynamic or full refresh per update.</p>
+            <ul class="lp-chips">
+              <li class="is-live"><b></b>PocketBook</li>
+              <li><b></b>Kindle</li>
+            </ul>
+          </article>
+          <article class="lp-imp lp-reveal">
+            <h3>Microcontrollers</h3>
+            <p>Kilobytes, not gigabytes. Sometimes no allocator at all.</p>
+            <ul class="lp-chips">
+              <li class="is-live"><b></b>ESP32 MeowBit</li>
+              <li class="is-live"><b></b>ESP32&#8209;P4</li>
+              <li><b></b>M5Stack Tab5</li>
+            </ul>
+          </article>
+          <article class="lp-imp lp-reveal">
+            <h3>Native desktop surfaces</h3>
+            <p>Modern machines that deserve better than a bundled browser per app.</p>
+            <ul class="lp-chips">
+              <li class="is-live"><b></b>macOS widgets</li>
+              <li class="is-live"><b></b>Transparent windows</li>
+              <li class="is-wip"><b></b>iOS</li>
+            </ul>
+          </article>
+          <div class="lp-imp lp-imp--legend lp-reveal">
+            <div class="vb-legend"><span><b class="is-live"></b>shipping</span><span><b class="is-wip"></b>in progress</span><span><b></b>planned</span></div>
+            <p>Every &ldquo;shipping&rdquo; chip is a real, tested host in the registry &mdash; not a roadmap slide. <a href="/docs/platform-contracts/">See the target profiles &rarr;</a></p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <!-- SHOWCASE — six kinds of proof, not three PSP demos. -->
     <section class="lp-section lp-showcase">
       <div class="lp-container">
         <div class="lp-secthead lp-reveal">
-          <span class="lp-kicker">The proof is shipping software</span>
-          <h2 class="lp-h2">Built with PocketJS.</h2>
-          <p class="lp-lead">Complete open-source apps running on real handhelds — not tech demos.</p>
+          <span class="lp-kicker">Real software, not rendering demos</span>
+          <h2 class="lp-h2">The proof is what it can carry.</h2>
+          <p class="lp-lead">Complete open-source apps, each shipped to stress a different part of the platform.</p>
         </div>
-
-        <article class="lp-case lp-reveal">
-          <a class="lp-case__media" href="/blog/shipping-openstrike/" aria-label="Read the OpenStrike story">
-            <img src="/assets/blog/openstrike-psp-dust2.png" alt="OpenStrike on de_dust2: sunlit BSP geometry, crates and arches, with the Solid HUD showing 100 HP and 30/90 ammo." loading="lazy" />
-          </a>
-          <div class="lp-case__copy">
-            <h3 class="lp-case__title">OpenStrike</h3>
-            <p>A Counter-Strike-shaped FPS that plays the classic GoldSrc-era maps — BSP world, lightmaps, bots, recoil, round flow. The HUD is a Solid app; the round rules and weapon tables are TypeScript. It holds a locked 60&nbsp;FPS on a 333&nbsp;MHz PSP and ships as one file you drop on a Memory Stick.</p>
-            <div class="lp-case__links">
-              <a class="lp-btn lp-btn--ghost" href="/blog/shipping-openstrike/">
-                Read the story
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
-              </a>
-              <a class="lp-case__src" href="https://github.com/pocket-stack/open-strike" target="_blank" rel="noreferrer">pocket-stack/open-strike</a>
+        <div class="lp-apps">
+          <article class="lp-app lp-reveal">
+            <a class="lp-app__media" href="#stage" aria-label="Jump to the live Pocket Launcher in the 3D PSP above">
+              <img src="/assets/blog/symbian-e7-launcher.png" alt="The Pocket Launcher Cover Flow deck on a Nokia E7's landscape AMOLED screen." loading="lazy" />
+            </a>
+            <div class="lp-app__body">
+              <h3>Pocket Launcher</h3>
+              <p class="lp-app__proves">Proves: multi-app lifecycle &amp; system UI</p>
+              <p>A Cover Flow deck that boots, freezes and switches whole apps &mdash; on PSP and on a 2011 Nokia. It&rsquo;s running live in the 3D PSP at the top of this page.</p>
+              <div class="lp-app__links">
+                <a href="#stage">Try it above &uarr;</a>
+                <a class="lp-app__src" href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">pocket-stack/pocketjs</a>
+              </div>
             </div>
-          </div>
-        </article>
-
-        <article class="lp-case lp-case--flip lp-reveal">
-          <a class="lp-case__media" href="/blog/pocket-figma/" aria-label="Read the Pocket Figma story">
-            <img src="/assets/blog/figma-psp-cover-zoom.png" alt="Pocket Figma on a PSP at 59% zoom: the Paper Wireframe Kit cover with hand-drawn lettering, and the viewer HUD along the bottom." loading="lazy" />
-          </a>
-          <div class="lp-case__copy">
-            <h3 class="lp-case__title">Pocket Figma</h3>
-            <p>A real Figma Community file, open on a PSP: the Paper Wireframe Kit — 14,430 nodes, 2,293 component instances, a canvas 26,000 pixels wide. The cooker bakes it into streaming tiles, so the device never parses the file. Pan with the analog nub, zoom with the shoulders — and the same bundle runs at native 960&times;544 on PS Vita.</p>
-            <div class="lp-case__links">
-              <a class="lp-btn lp-btn--ghost" href="/blog/pocket-figma/">
-                Read the story
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
-              </a>
-              <a class="lp-case__src" href="https://github.com/pocket-stack/pocket-figma" target="_blank" rel="noreferrer">pocket-stack/pocket-figma</a>
+          </article>
+          <article class="lp-app lp-reveal">
+            <a class="lp-app__media" href="/blog/shipping-openstrike/" aria-label="Read the OpenStrike story">
+              <img src="/assets/blog/openstrike-psp-dust2.png" alt="OpenStrike on de_dust2: sunlit BSP geometry with the Solid HUD showing 100 HP and 30/90 ammo." loading="lazy" />
+            </a>
+            <div class="lp-app__body">
+              <h3>OpenStrike</h3>
+              <p class="lp-app__proves">Proves: 3D worlds &amp; the JS/native split</p>
+              <p>A Counter-Strike-shaped FPS on the classic GoldSrc-era maps &mdash; BSP, lightmaps, bots, recoil &mdash; at a locked 60&nbsp;FPS on a 333&nbsp;MHz PSP. The HUD is a Solid app.</p>
+              <div class="lp-app__links">
+                <a href="/blog/shipping-openstrike/">Read the story &rarr;</a>
+                <a class="lp-app__src" href="https://github.com/pocket-stack/open-strike" target="_blank" rel="noreferrer">pocket-stack/open-strike</a>
+              </div>
             </div>
-          </div>
-        </article>
-
-        <article class="lp-case lp-reveal">
-          <a class="lp-case__media" href="/blog/pocket-youtube/" aria-label="Read the Pocket YouTube story">
-            <img src="/assets/blog/pocket-youtube-paused.png" alt="Pocket YouTube on a PSP: a video paused under a centered pause badge, with the title bar, red progress bar and playback hints of the player HUD." loading="lazy" />
-          </a>
-          <div class="lp-case__copy">
-            <h3 class="lp-case__title">Pocket YouTube</h3>
-            <p>YouTube on a PSP, where the network is a USB cable: a Mac companion runs yt-dlp and ffmpeg, and the handheld plays a ring buffer that happens to be a file. Search with the system keyboard, browse rows with CJK titles the device could never typeset, and watch at 12&nbsp;fps with 44.1&nbsp;kHz audio — pause, seek and all — while the UI never drops from 60&nbsp;FPS.</p>
-            <div class="lp-case__links">
-              <a class="lp-btn lp-btn--ghost" href="/blog/pocket-youtube/">
-                Read the story
-                <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M5 12h14M13 6l6 6-6 6"/></svg>
-              </a>
-              <a class="lp-case__src" href="https://github.com/pocket-stack/pocket-youtube" target="_blank" rel="noreferrer">pocket-stack/pocket-youtube</a>
+          </article>
+          <article class="lp-app lp-reveal">
+            <a class="lp-app__media" href="/blog/pocket-figma/" aria-label="Read the Pocket Figma story">
+              <img src="/assets/blog/figma-psp-cover-zoom.png" alt="Pocket Figma on a PSP at 59% zoom: the Paper Wireframe Kit cover with the viewer HUD along the bottom." loading="lazy" />
+            </a>
+            <div class="lp-app__body">
+              <h3>Pocket Figma</h3>
+              <p class="lp-app__proves">Proves: big documents &amp; streamed assets</p>
+              <p>A real Figma Community file &mdash; 14,430 nodes, a canvas 26,000 pixels wide &mdash; baked into streaming tiles the device pans and zooms without ever parsing the file.</p>
+              <div class="lp-app__links">
+                <a href="/blog/pocket-figma/">Read the story &rarr;</a>
+                <a class="lp-app__src" href="https://github.com/pocket-stack/pocket-figma" target="_blank" rel="noreferrer">pocket-stack/pocket-figma</a>
+              </div>
             </div>
-          </div>
-        </article>
+          </article>
+          <article class="lp-app lp-reveal">
+            <a class="lp-app__media" href="/blog/pocket-youtube/" aria-label="Read the Pocket YouTube story">
+              <img src="/assets/blog/pocket-youtube-paused.png" alt="Pocket YouTube on a PSP: a paused video under the player HUD's title bar and red progress bar." loading="lazy" />
+            </a>
+            <div class="lp-app__body">
+              <h3>Pocket YouTube</h3>
+              <p class="lp-app__proves">Proves: host services, video, audio &amp; OSK</p>
+              <p>YouTube on a PSP where the network is a USB cable: a Mac companion runs yt-dlp and ffmpeg, the handheld plays the stream &mdash; search, seek, CJK titles and all.</p>
+              <div class="lp-app__links">
+                <a href="/blog/pocket-youtube/">Read the story &rarr;</a>
+                <a class="lp-app__src" href="https://github.com/pocket-stack/pocket-youtube" target="_blank" rel="noreferrer">pocket-stack/pocket-youtube</a>
+              </div>
+            </div>
+          </article>
+          <article class="lp-app lp-reveal">
+            <a class="lp-app__media" href="/blog/pocket-character/" aria-label="Read the Pocket Character story">
+              <img src="/assets/blog/pocket-character-activity.jpg" alt="Pocket Character's VRM digital human in a transparent macOS widget window, next to Activity Monitor showing a single light process." loading="lazy" />
+            </a>
+            <div class="lp-app__body">
+              <h3>Pocket Character</h3>
+              <p class="lp-app__proves">Proves: it also replaces heavy desktop runtimes</p>
+              <p>A VRM digital human in a transparent always-on-top window &mdash; one native process, 118&nbsp;MB and ~4% of a core, where the Electron stage needs 2.2&nbsp;GB and 44%.</p>
+              <div class="lp-app__links">
+                <a href="/blog/pocket-character/">Read the story &rarr;</a>
+                <a class="lp-app__src" href="https://github.com/pocket-stack/pocket-character" target="_blank" rel="noreferrer">pocket-stack/pocket-character</a>
+              </div>
+            </div>
+          </article>
+          <article class="lp-app lp-reveal">
+            <a class="lp-app__media" href="/blog/pocket-vapor/" aria-label="Read the Pocket Vapor story">
+              <img src="/assets/blog/pocket-vapor-promo-poster.jpg" alt="The same Vue todo app running side by side on Game Boy Advance, Game Boy and NES." loading="lazy" />
+            </a>
+            <div class="lp-app__body">
+              <h3>Pocket Vapor Todo</h3>
+              <p class="lp-app__proves">Proves: it reaches machines with no interpreter</p>
+              <p>One Vue module &mdash; <span class="lp-mono">ref</span>, <span class="lp-mono">computed</span>, list rendering &mdash; compiled into GBA, Game Boy and NES carts, verified frame-by-frame against real Vue on the same inputs.</p>
+              <div class="lp-app__links">
+                <a href="/blog/pocket-vapor/">Read the story &rarr;</a>
+                <a class="lp-app__src" href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">pocket-stack/pocketjs</a>
+              </div>
+            </div>
+          </article>
+        </div>
       </div>
     </section>
 
-    <!-- FEATURES + TOOLING + TARGETS: one bento grid -->
-    <section class="lp-section vb-bento">
+    <!-- PORTING CONTRACT + WORKFLOW — for the people who add device number nine. -->
+    <section class="lp-section lp-port">
       <div class="lp-container">
-        <div class="lp-secthead lp-reveal">
-          <span class="lp-kicker">The runtime, at a glance</span>
-          <h2 class="lp-h2">Modern UI physics on retro silicon.</h2>
-          <p class="lp-lead">You keep JSX and signals. Everything expensive becomes native data, native draw calls — and a testable machine.</p>
+        <div class="lp-secthead lp-secthead--wide lp-reveal">
+          <span class="lp-kicker">The porting contract</span>
+          <h2 class="lp-h2">Bring a screen. Bring some input.<br />Pocket provides the rest.</h2>
+          <p class="lp-lead">The newest ports &mdash; a 2011 Symbian phone and an e-ink reader &mdash; reuse the same retained draw list: conservative damage regions feed full framebuffers, MCU strips and e-ink tiles alike.</p>
         </div>
-
-        <div class="vb-grid lp-reveal">
-          <article class="vb-tile vb-tile--hero">
-            <h3>UI that can't flake</h3>
-            <p>A virtual clock makes every frame a pure function of the input tape. Golden tests compare whole framebuffers, byte for byte — the same on CI, desktop and hardware. Scrub backwards, replay any session, on a real PSP.</p>
-            <div class="vb-tape" aria-hidden="true">
-              <span class="vb-tape__label">input tape</span>
-              <div class="vb-tape__strip">
-                <i></i><i></i><i class="dn"></i><i></i><i class="dn"></i><i></i><i></i><i></i><i class="dn"></i><i></i><i></i><i class="dn"></i><i></i><i></i><i></i><i class="on"></i><i></i><i></i>
-              </div>
-              <span class="vb-tape__eq">&rarr;</span>
-              <span class="vb-tape__frame">frame 1487<br /><b>hash 7f3a9c01</b></span>
-            </div>
-            <p class="vb-meta">The wall above? Nine of these tapes, replayed headlessly against the core.</p>
-          </article>
-
-          <article class="vb-tile">
-            <h3>Compiled styling</h3>
-            <p>Tailwind literals become numeric style records at build time. No parser, no cascade, no utility runtime on the device.</p>
-          </article>
-
-          <article class="vb-tile">
-            <h3>Deterministic flexbox</h3>
-            <p>taffy 0.11 lays out in the Rust core — identical positions on every target, provable in goldens.</p>
-          </article>
-
-          <article class="vb-tile">
-            <h3>Baked text</h3>
-            <p>Coverage atlases with sub-pixel positioning. Runtime text is compositing, not font rasterization.</p>
-          </article>
-
-          <article class="vb-tile">
-            <h3>Native motion</h3>
-            <p>Tweens, springs and keyframe timelines tick in Rust at a fixed 1/60&nbsp;s. JS declares; the core animates.</p>
-          </article>
-
-          <article class="vb-tile">
-            <h3>Real input, system-wide</h3>
-            <p>D-pad focus, analog nub, touch, a virtual cursor — and a system on-screen keyboard any app can summon with one call.</p>
-          </article>
-
-          <article class="vb-tile vb-tile--half">
-            <h3>Time-travel DevTools</h3>
-            <p>Every session records itself. Step to any frame, inspect the native tree, diff against a golden — over USB to real hardware.</p>
-          </article>
-
-          <article class="vb-tile vb-tile--half">
-            <h3>3D, same discipline</h3>
-            <p>Pocket3D runs BSP worlds with PVS through sceGu on PSP and wgpu on desktop — OpenStrike holds a locked 60&nbsp;FPS with a Solid HUD on top.</p>
-          </article>
-
-          <article class="vb-tile vb-tile--wide">
-            <div class="vb-targets__head">
-              <h3>One core, many devices</h3>
-              <p>The <span class="lp-mono">no_std</span> core needs a framebuffer and a few buttons; a <span class="lp-mono">pocket.json</span> contract decides where a bundle may ship.</p>
-            </div>
-            <ul class="vb-chips">
-              <li class="is-live"><b></b>Sony PSP</li>
-              <li class="is-live"><b></b>PS Vita</li>
-              <li class="is-live"><b></b>macOS</li>
-              <li class="is-wip"><b></b>Symbian</li>
-              <li class="is-wip"><b></b>iOS</li>
-              <li><b></b>Nintendo 3DS</li>
-              <li><b></b>Steam Deck</li>
-              <li><b></b>Android</li>
-              <li><b></b>Embedded Linux</li>
+        <div class="lp-port__grid lp-reveal">
+          <div class="lp-port__card">
+            <h3>A port brings</h3>
+            <ul class="lp-port__list">
+              <li>A display surface</li>
+              <li>Input events</li>
+              <li>A clock</li>
+              <li>Storage</li>
+              <li>Optional host services</li>
             </ul>
-            <div class="vb-legend"><span><b class="is-live"></b>shipping</span><span><b class="is-wip"></b>in progress</span><span><b></b>planned</span></div>
-          </article>
+          </div>
+          <div class="lp-port__card lp-port__card--pocket">
+            <h3>PocketJS provides</h3>
+            <ul class="lp-port__list">
+              <li>Retained UI tree &amp; native flexbox</li>
+              <li>Text, glyph atlases &amp; runtime CJK</li>
+              <li>Animation engine &amp; damage tracking</li>
+              <li>Incremental RGBA8 / ARGB8 / RGB565 raster paths</li>
+              <li>Guest lifecycle, launcher &amp; app switching</li>
+              <li>Packages, OSK, DevTools</li>
+            </ul>
+          </div>
+          <div class="lp-port__side">
+            <div class="lp-term">
+              <div class="lp-term__bar">
+                <span class="lp-dot" aria-hidden="true"></span><span class="lp-dot" aria-hidden="true"></span><span class="lp-dot" aria-hidden="true"></span>
+                <span class="lp-codecard__name">from JSX to real hardware</span>
+              </div>
+              <pre class="lp-term__pre"><code><span class="lp-term__ps">$</span> pocket create my-app
+<span class="lp-term__ps">$</span> pocket check --target psp   <span class="lp-term__c"># will it fit?</span>
+<span class="lp-term__ps">$</span> pocket build --target psp -- --release
+<span class="lp-term__ps">$</span> pocket hw my-app            <span class="lp-term__c"># run it on real hardware</span></code></pre>
+            </div>
+            <p class="lp-port__note">Then debug the hardware like a deterministic browser tab &mdash; every session is a tape you can scrub. <a href="/blog/time-travel-devtools/">Time travel over a USB cable &rarr;</a></p>
+            <div class="lp-port__links">
+              <a href="/docs/native-contract/">Native contract</a>
+              <a href="/docs/architecture/">Architecture</a>
+              <a href="/docs/platform-contracts/">Target profiles</a>
+            </div>
+          </div>
         </div>
       </div>
     </section>
@@ -352,12 +610,13 @@
     <section class="lp-section lp-cta">
       <div class="lp-cta__glow" aria-hidden="true"></div>
       <div class="lp-container lp-cta__in lp-reveal">
-        <span class="lp-kicker">Start from the hardware up</span>
-        <h2 class="lp-h2" style="margin-top: 0.9rem;">Build modern UI where the browser cannot go.</h2>
-        <p>Bring modern frontend ergonomics to hardware that was never built for the web.</p>
+        <span class="lp-kicker">There is always one more device</span>
+        <h2 class="lp-h2" style="margin-top: 0.9rem;">The browser was never the limit.</h2>
+        <p>Take the app model you already know to the device everyone else gave up on.</p>
         <div class="lp-cta__btns">
-          <a class="lp-btn lp-btn--primary" href="/docs/getting-started/">Get started</a>
-          <a class="lp-btn lp-btn--ghost" href="/docs/overview/">Read the docs</a>
+          <a class="lp-btn lp-btn--primary" href="/docs/getting-started/">Start building</a>
+          <a class="lp-btn lp-btn--ghost" href="/docs/native-contract/">Add a device</a>
+          <a class="lp-btn lp-btn--ghost" href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">Explore GitHub</a>
         </div>
       </div>
     </section>
@@ -382,13 +641,14 @@
             </svg>
             <span>PocketJS</span>
           </a>
-          <p>Vue Vapor and Solid UI under 8 MB RAM, rendered through a tiny native core.</p>
+          <p>One application model &mdash; Vue, Solid, TypeScript &mdash; carried to consoles, e-readers, abandoned phones and microcontrollers by a tiny native core.</p>
         </div>
         <div>
           <h4>Docs</h4>
           <ul>
             <li><a href="/docs/overview/">Overview</a></li>
             <li><a href="/docs/getting-started/">Getting started</a></li>
+            <li><a href="/docs/platform-contracts/">Platform contracts</a></li>
             <li><a href="/docs/architecture/">Architecture</a></li>
             <li><a href="/docs/api/">API reference</a></li>
           </ul>
@@ -397,20 +657,20 @@
           <h4>Explore</h4>
           <ul>
             <li><a href="/playground/">Playground</a></li>
+            <li><a href="/blog/pocket-vapor/">Pocket Vapor</a></li>
             <li><a href="https://github.com/pocket-stack/open-strike" target="_blank" rel="noreferrer">OpenStrike</a></li>
             <li><a href="https://github.com/pocket-stack/pocket-figma" target="_blank" rel="noreferrer">Pocket Figma</a></li>
-            <li><a href="/docs/components/">Components</a></li>
-            <li><a href="/docs/styling/">Styling</a></li>
+            <li><a href="https://github.com/pocket-stack/pocket-character" target="_blank" rel="noreferrer">Pocket Character</a></li>
           </ul>
         </div>
         <div>
           <h4>Project</h4>
           <ul>
             <li><a href="/blog/">Blog</a></li>
+            <li><a href="/changelog/">Changelog</a></li>
             <li><a href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">GitHub</a></li>
             <li><a href="https://x.com/pocket_js" target="_blank" rel="noreferrer">X (Twitter)</a></li>
             <li><a href="/docs/native-contract/">Native contract</a></li>
-            <li><a href="/docs/build-pipeline/">Build pipeline</a></li>
           </ul>
         </div>
       </div>

--- a/site/home.html
+++ b/site/home.html
@@ -51,10 +51,9 @@
         </a>
         <h1 class="lp-h1">Build modern apps<span class="lp-grad">for impossible devices.</span></h1>
         <p class="lp-sub">
-          Write Vue, Solid and TypeScript once &mdash; run it on game consoles,
-          e-readers, abandoned smartphones and microcontrollers. A tiny
-          JavaScript guest where it fits; the framework compiled away where it
-          doesn&rsquo;t.
+          Vue, Solid and TypeScript for consoles, e-readers, abandoned phones
+          and microcontrollers. A tiny JS guest where it fits; the framework
+          compiled away where it doesn&rsquo;t.
         </p>
         <div class="lp-hero__cta">
           <a class="lp-btn lp-btn--primary" href="/docs/getting-started/">Get started</a>

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -7,9 +7,9 @@ const GH = "https://github.com/pocket-stack/pocketjs";
 const DISCORD = "https://discord.gg/cTce4eXzSK";
 const X_URL = "https://x.com/pocket_js";
 export const SITE_URL = "https://pocketjs.dev";
-export const SITE_TITLE = "PocketJS — Bare Metal Modern Web";
+export const SITE_TITLE = "PocketJS — Build Modern Apps for Impossible Devices";
 export const SITE_DESC =
-  "High-performance JSX UI outside the browser, with native rendering, standard Vue Vapor and Solid support, a Tailwind design system, and 60 FPS animation under an 8 MB memory budget.";
+  "Write Vue, Solid and TypeScript once — run it on game consoles, e-readers, abandoned smartphones and microcontrollers. A tiny JavaScript guest where it fits; the framework compiled away where it doesn't.";
 export const OG_IMAGE_URL = `${SITE_URL}/og-image.png`;
 
 export interface PageOpts {
@@ -138,7 +138,7 @@ export function renderPage(o: PageOpts): string {
 <meta property="og:image" content="${OG_IMAGE_URL}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
-<meta property="og:image:alt" content="PocketJS — Bare Metal Modern Web">
+<meta property="og:image:alt" content="PocketJS — Build Modern Apps for Impossible Devices">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="${fullTitle}">
 <meta name="twitter:description" content="${desc}">


### PR DESCRIPTION
## What

Replaces the homepage wholesale. The old page defined PocketJS as *Vue and Solid under 8 MB on a PSP*; the new one defines it as **a platform that brings the modern app model to hardware the traditional software stack can't reach** — with the PSP numbers demoted from product definition to evidence.

### New page flow

1. **Hero** — "Build modern apps for impossible devices." over the baked demo wall, with the live 3D Pocket Stage (launcher included) kept as the interactive centerpiece.
2. **Proof strip** — six clickable field results (Vue on a Game Boy, YouTube on a PSP, Figma at 333 MHz, Symbian, OpenStrike, Pocket Character), each linking to its story.
3. **Execution classes** — Pocket Guest (`execution: guest`) vs Pocket Vapor (`execution: aot`) side by side, with the admission-checked manifest note.
4. **Target selector** — the same Counter (Solid ⇄ Vue Vapor tabs) next to seven target panels: Browser, PSP, PS Vita, Nokia E7, PocketBook, ESP32-P4, Game Boy — each with execution/display/rendering/input/ships-as facts.
5. **.pocket** — package anatomy tree, toolchain verbs, and a six-card system-software grid (launcher, contracts, input/OSK, host services, DevTools, deterministic core).
6. **Device taxonomy** — "impossible" classified by constraint (retro consoles, abandoned smartphones, e-ink, microcontrollers, native desktop) with shipping/in-progress/planned chips.
7. **Showcase** — six proof apps instead of three PSP demos (adds Pocket Launcher, Pocket Character, Pocket Vapor Todo).
8. **Porting contract** — a-port-brings vs PocketJS-provides, plus the `pocket create/check/build/hw` terminal.
9. **Closing** — "The browser was never the limit."

Site-wide `SITE_TITLE`/`SITE_DESC`, OG alt text and JSON-LD `runtimePlatform` follow the new positioning.

### Verification

- `bun run site:build` passes; page served from `site/dist` and verified in headless Chrome: no page/console errors, Pocket Stage boots (launcher screen canvas ~90% non-black), all nine sections + footer present, showcase images load.
- All internal links point at existing docs/blog/changelog slugs; CLI commands in the terminal card match `tools/cli` (`create`, `check --target`, `build --target -- --release`, `hw`); capability ids in the package tree are real registry ids.

🤖 Generated with [Claude Code](https://claude.com/claude-code)