### PR TITLE
feat(site): landing copy pass — reframe hero, shelve execution classes

### DIFF
--- a/site/assets/home.css
+++ b/site/assets/home.css
@@ -542,129 +542,15 @@ a.lp-btn--primary:hover {
   white-space: nowrap;
 }
 
-/* ---- Execution classes -----------------------------------------------------
-   The page's central claim: one authoring model, two ways down to silicon. */
-.lp-exec {
+/* ---- Target selector -------------------------------------------------------
+   Same component on the left, pick the machine on the right. Panels are static
+   HTML; home.js only toggles [hidden]. First section after the proof strip
+   (which owns the divider), with a soft glow to open the page body. */
+.lp-targets {
   background:
     radial-gradient(38% 50% at 0% 8%, rgba(96, 165, 250, 0.06), transparent 70%),
     radial-gradient(36% 48% at 100% 14%, rgba(34, 211, 238, 0.035), transparent 72%);
 }
-.lp-exec__grid {
-  display: grid;
-  gap: 1rem;
-  margin-top: clamp(2.4rem, 5vw, 3.6rem);
-}
-@media (min-width: 880px) { .lp-exec__grid { grid-template-columns: 1fr 1fr; } }
-.lp-exec__card {
-  position: relative;
-  display: flex;
-  flex-direction: column;
-  padding: clamp(1.5rem, 3vw, 2.1rem);
-  border-radius: 18px;
-  border: 1px solid transparent;
-  background:
-    linear-gradient(180deg, rgba(15, 22, 38, 0.92), rgba(9, 12, 20, 0.88)) padding-box,
-    linear-gradient(165deg, rgba(96, 165, 250, 0.34), rgba(43, 58, 85, 0.5) 42%, rgba(34, 211, 238, 0.16)) border-box;
-  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.04), 0 22px 50px -32px rgba(0, 0, 0, 0.9);
-}
-.lp-exec__card--aot {
-  background:
-    linear-gradient(180deg, rgba(15, 22, 38, 0.92), rgba(9, 12, 20, 0.88)) padding-box,
-    linear-gradient(165deg, rgba(157, 229, 199, 0.36), rgba(43, 58, 85, 0.5) 42%, rgba(96, 165, 250, 0.16)) border-box;
-}
-.lp-exec__head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.8rem;
-  flex-wrap: wrap;
-}
-.lp-exec__head h3 {
-  font-size: clamp(1.3rem, 2.4vw, 1.6rem);
-  font-weight: 800;
-  letter-spacing: -0.02em;
-  color: var(--ink);
-}
-.lp-exec__badge {
-  font: 700 11px/1 var(--mono);
-  letter-spacing: 0.04em;
-  color: var(--sky);
-  padding: 0.42rem 0.6rem;
-  border-radius: 8px;
-  border: 1px solid rgba(96, 165, 250, 0.32);
-  background: rgba(20, 29, 49, 0.7);
-}
-.lp-exec__card--aot .lp-exec__badge {
-  color: var(--mint);
-  border-color: rgba(157, 229, 199, 0.32);
-}
-.lp-exec__tag {
-  margin-top: 0.45rem;
-  font-size: 1.02rem;
-  font-weight: 600;
-  color: var(--ink-2);
-}
-.lp-exec__list {
-  list-style: none;
-  padding: 0;
-  margin: 1.25rem 0 0;
-  display: flex;
-  flex-direction: column;
-  gap: 0.7rem;
-}
-.lp-exec__list li {
-  position: relative;
-  padding-left: 1.35rem;
-  font-size: 0.95rem;
-  line-height: 1.55;
-  color: var(--ink-2);
-}
-.lp-exec__list li::before {
-  content: "";
-  position: absolute;
-  left: 0.15rem;
-  top: 0.58em;
-  width: 6px;
-  height: 6px;
-  border-radius: 999px;
-  background: var(--sky);
-  box-shadow: 0 0 8px rgba(96, 165, 250, 0.5);
-}
-.lp-exec__card--aot .lp-exec__list li::before {
-  background: var(--mint);
-  box-shadow: 0 0 8px rgba(157, 229, 199, 0.55);
-}
-.lp-exec__for {
-  margin-top: 1.4rem;
-  padding-top: 1.05rem;
-  border-top: 1px solid var(--line);
-  font-size: 0.86rem;
-  line-height: 1.6;
-  color: var(--ink-2);
-}
-.lp-exec__for span {
-  display: block;
-  font: 600 10.5px/1 var(--mono);
-  letter-spacing: 0.1em;
-  text-transform: uppercase;
-  color: var(--muted);
-  margin-bottom: 0.4rem;
-}
-.lp-exec__note {
-  margin: clamp(1.6rem, 3vw, 2.2rem) auto 0;
-  max-width: 720px;
-  text-align: center;
-  font-size: 0.92rem;
-  line-height: 1.65;
-  color: var(--muted);
-}
-.lp-exec__note a { color: var(--ink-2); text-underline-offset: 3px; }
-.lp-exec__note a:hover { color: var(--ink); }
-
-/* ---- Target selector -------------------------------------------------------
-   Same component on the left, pick the machine on the right. Panels are static
-   HTML; home.js only toggles [hidden]. */
-.lp-targets { border-top: 1px solid var(--line); }
 .lp-tools__row {
   display: flex;
   flex-wrap: wrap;
@@ -943,6 +829,14 @@ a.lp-btn--primary:hover {
   box-shadow: none;
 }
 .lp-imp--legend:hover { transform: none; }
+.lp-imp__note {
+  margin-top: 0.95rem;
+  font-size: 0.82rem;
+  line-height: 1.55;
+  color: var(--muted);
+}
+.lp-imp__note a { color: var(--ink-2); text-underline-offset: 3px; }
+.lp-imp__note a:hover { color: var(--ink); }
 .lp-imp--legend p { margin-top: 0; font-size: 0.88rem; color: var(--muted); line-height: 1.6; flex: 1 1 320px; }
 .lp-imp--legend a { color: var(--ink-2); text-underline-offset: 3px; }
 .lp-imp--legend a:hover { color: var(--ink); }

--- a/site/home.html
+++ b/site/home.html
@@ -51,8 +51,8 @@
         </a>
         <h1 class="lp-h1">Build modern apps<span class="lp-grad">for impossible devices.</span></h1>
         <p class="lp-sub">
-          Vue, Solid and TypeScript for consoles, e-readers, abandoned phones
-          and microcontrollers. A tiny JS guest where it fits; the framework
+          Components, signals and Tailwind &mdash; on consoles, e-readers and
+          microcontrollers. A tiny JS guest where it fits; the framework
           compiled away where it doesn&rsquo;t.
         </p>
         <div class="lp-hero__cta">

--- a/site/home.html
+++ b/site/home.html
@@ -97,52 +97,6 @@
       </div>
     </section>
 
-    <!-- EXECUTION CLASSES — the central abstraction: one app model, two ways down. -->
-    <section class="lp-section lp-exec">
-      <div class="lp-container">
-        <div class="lp-secthead lp-reveal">
-          <span class="lp-kicker">One app model, two execution classes</span>
-          <h2 class="lp-h2">Choose how low you need&nbsp;to&nbsp;go.</h2>
-          <p class="lp-lead">Some devices can host a tiny JavaScript engine. Some can&rsquo;t host a heap. PocketJS treats that as a build decision, not a rewrite.</p>
-        </div>
-        <div class="lp-exec__grid lp-reveal">
-          <article class="lp-exec__card">
-            <div class="lp-exec__head">
-              <h3>Pocket Guest</h3>
-              <span class="lp-exec__badge">execution:&nbsp;guest</span>
-            </div>
-            <p class="lp-exec__tag">Keep JavaScript dynamic.</p>
-            <ul class="lp-exec__list">
-              <li>Solid and Vue Vapor with their real reactivity, running on QuickJS</li>
-              <li>A native Rust core owns layout, text, animation and damage tracking</li>
-              <li>Hot-swappable app logic &mdash; replace the bundle, keep the device</li>
-              <li>Time-travel DevTools over USB to real hardware</li>
-            </ul>
-            <p class="lp-exec__for"><span>Runs on</span> PSP &middot; PS&nbsp;Vita &middot; Nokia&nbsp;E7 &middot; PocketBook &middot; ESP32&#8209;P4 &middot; macOS &middot; browser</p>
-          </article>
-          <article class="lp-exec__card lp-exec__card--aot">
-            <div class="lp-exec__head">
-              <h3>Pocket Vapor</h3>
-              <span class="lp-exec__badge">execution:&nbsp;aot</span>
-            </div>
-            <p class="lp-exec__tag">Compile the runtime away.</p>
-            <ul class="lp-exec__list">
-              <li>The Vue authoring model &mdash; <span class="lp-mono">ref</span>, <span class="lp-mono">computed</span>, JSX, list rendering</li>
-              <li>Reactivity becomes compile-time dirty-bit graphs</li>
-              <li>No JavaScript engine, no GC, no allocator on the device</li>
-              <li>Verified frame-by-frame against real Vue on the same inputs</li>
-            </ul>
-            <p class="lp-exec__for"><span>Runs on</span> Game&nbsp;Boy Advance &middot; Game&nbsp;Boy &middot; NES &middot; ESP32 microcontrollers</p>
-          </article>
-        </div>
-        <p class="lp-exec__note lp-reveal">
-          The manifest declares what an app needs; every target profile declares which execution
-          classes and capabilities it admits. Admission is checked before anything ships &mdash;
-          not discovered on the device. <a href="/docs/platform-contracts/">Platform contracts &rarr;</a>
-        </p>
-      </div>
-    </section>
-
     <!-- CODE + TARGET SELECTOR — same component, pick the machine underneath it. -->
     <section class="lp-section lp-targets">
       <div class="lp-container">
@@ -331,7 +285,7 @@
       <div class="lp-container">
         <div class="lp-pkg__split">
           <div class="lp-pkg__copy lp-reveal">
-            <span class="lp-kicker">One app. Every target. One package.</span>
+            <span class="lp-kicker">The .pocket format</span>
             <h2 class="lp-h2">Ship the application,<br />not the port.</h2>
             <p>A <span class="lp-mono">.pocket</span> file describes what the app <em>is</em> and what it <em>needs</em> &mdash; identity, capabilities, build plan, payloads. Each device decides how it should run: which viewport, which presentation, which execution class. If a target can&rsquo;t honor the contract, it says so before launch, not after.</p>
             <div class="lp-pkg__verbs" aria-label="Package toolchain verbs">
@@ -416,7 +370,7 @@
             <h3>Abandoned smartphones</h3>
             <p>The vendor moved on. The hardware didn&rsquo;t.</p>
             <ul class="lp-chips">
-              <li class="is-live"><b></b>Nokia E7 &middot; Symbian</li>
+              <li class="is-live"><b></b>Symbian Belle</li>
               <li><b></b>MeeGo</li>
               <li><b></b>BlackBerry</li>
               <li><b></b>Windows Phone</li>
@@ -438,6 +392,7 @@
               <li class="is-live"><b></b>ESP32&#8209;P4</li>
               <li><b></b>M5Stack Tab5</li>
             </ul>
+            <p class="lp-imp__note">Built on <a href="/blog/pocket-vapor/">Pocket Vapor</a>, the experimental compile-away pipeline.</p>
           </article>
           <article class="lp-imp lp-reveal">
             <h3>Native desktop surfaces</h3>
@@ -445,7 +400,7 @@
             <ul class="lp-chips">
               <li class="is-live"><b></b>macOS widgets</li>
               <li class="is-live"><b></b>Transparent windows</li>
-              <li class="is-wip"><b></b>iOS</li>
+              <li><b></b>iOS</li>
             </ul>
           </article>
           <div class="lp-imp lp-imp--legend lp-reveal">
@@ -460,7 +415,7 @@
     <section class="lp-section lp-showcase">
       <div class="lp-container">
         <div class="lp-secthead lp-reveal">
-          <span class="lp-kicker">Real software, not rendering demos</span>
+          <span class="lp-kicker">Shipped on real hardware</span>
           <h2 class="lp-h2">The proof is what it can carry.</h2>
           <p class="lp-lead">Complete open-source apps, each shipped to stress a different part of the platform.</p>
         </div>
@@ -559,7 +514,7 @@
         <div class="lp-secthead lp-secthead--wide lp-reveal">
           <span class="lp-kicker">The porting contract</span>
           <h2 class="lp-h2">Bring a screen. Bring some input.<br />Pocket provides the rest.</h2>
-          <p class="lp-lead">The newest ports &mdash; a 2011 Symbian phone and an e-ink reader &mdash; reuse the same retained draw list: conservative damage regions feed full framebuffers, MCU strips and e-ink tiles alike.</p>
+          <p class="lp-lead">Every port reuses the same retained draw list &mdash; conservative damage regions feed full framebuffers, MCU strips and e-ink tiles alike.</p>
         </div>
         <div class="lp-port__grid lp-reveal">
           <div class="lp-port__card">
@@ -609,7 +564,7 @@
     <section class="lp-section lp-cta">
       <div class="lp-cta__glow" aria-hidden="true"></div>
       <div class="lp-container lp-cta__in lp-reveal">
-        <span class="lp-kicker">There is always one more device</span>
+        <span class="lp-kicker">Your turn</span>
         <h2 class="lp-h2" style="margin-top: 0.9rem;">The browser was never the limit.</h2>
         <p>Take the app model you already know to the device everyone else gave up on.</p>
         <div class="lp-cta__btns">

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -9,7 +9,7 @@ const X_URL = "https://x.com/pocket_js";
 export const SITE_URL = "https://pocketjs.dev";
 export const SITE_TITLE = "PocketJS — Build Modern Apps for Impossible Devices";
 export const SITE_DESC =
-  "Write Vue, Solid and TypeScript once — run it on game consoles, e-readers, abandoned smartphones and microcontrollers. A tiny JavaScript guest where it fits; the framework compiled away where it doesn't.";
+  "Components, signals and Tailwind — on game consoles, e-readers and microcontrollers. A tiny JavaScript guest where it fits; the framework compiled away where it doesn't.";
 export const OG_IMAGE_URL = `${SITE_URL}/og-image.png`;
 
 export interface PageOpts {


### PR DESCRIPTION
## What

Second copy round on the new landing page, per review:

- **Hero subtitle** → "Components, signals and Tailwind — on consoles, e-readers and microcontrollers." Names the vocabulary every modern frontend developer shares instead of two specific frameworks, and drops the confusing "abandoned phones" item. `SITE_DESC` matches.
- **Removed the "Choose how low you need to go" execution-classes section** — Pocket Vapor isn't ready to carry a top-level pillar yet. The compile-away story lives on as a note on the Microcontrollers taxonomy card: "Built on Pocket Vapor, the experimental compile-away pipeline" → links the blog post.
- **Plainer kickers** replacing the "One …" slogans: "The .pocket format", "Shipped on real hardware", "Your turn".
- Device chips: "Nokia E7 · Symbian" → **"Symbian Belle"**; **iOS** back to *planned*.
- Porting lead no longer name-drops the newest ports (it went stale with every new device): "Every port reuses the same retained draw list — conservative damage regions feed full framebuffers, MCU strips and e-ink tiles alike."

## Verification

`bun site/build.ts` + headless screenshots of the proof-strip junction, target selector, taxonomy and showcase; grep of built HTML confirms all replacements and that the removed section is gone. No page/console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)