### PR TITLE
fix(iphone2g): compile the device helper test in the gnu dialect

### DIFF
--- a/tests/iphone2g-device-transaction.test.ts
+++ b/tests/iphone2g-device-transaction.test.ts
@@ -91,7 +91,15 @@ beforeAll(() => {
   const compile = Bun.spawnSync({
     cmd: [
       "cc",
-      "-std=c99",
+      // The gnu dialect, not strict c99, because that is what actually builds
+      // this file for the device. Under -std=c99 glibc defines __STRICT_ANSI__
+      // and hides the POSIX declarations device_tool.c legitimately uses
+      // (sigaction, lstat, fchmod, sync), so the test passed on macOS — whose
+      // headers expose them regardless — and failed only on Linux CI.
+      "-std=gnu99",
+      // Stated explicitly as well, so the POSIX surface does not depend on a
+      // dialect side-effect. glibc needs this for sync(); macOS ignores it.
+      "-D_DEFAULT_SOURCE",
       "-Wall",
       "-Wextra",
       "-Werror",


### PR DESCRIPTION
The v0.9.0 release run failed in `bun run test`: `tests/iphone2g-device-transaction.test.ts` compiles `hosts/iphone2g/device_tool.c` natively with `-std=c99`, and on glibc that defines `__STRICT_ANSI__`, hiding `sigaction`, `lstat`, `fchmod` and `sync`. macOS exposes them regardless, so it passed locally.

Switches to `-std=gnu99` — the dialect that actually builds this file for the device — and states `-D_DEFAULT_SOURCE` explicitly.

Nothing published: the test step gates the publish steps, so the release aborted cleanly. Retagging v0.9.0 at this commit after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)