### PR TITLE
perf(iphone2g): scope the composite to damage, and reach a locked 60 fps

### DIFF
--- a/docs/IPHONE2G.md
+++ b/docs/IPHONE2G.md
@@ -312,78 +312,119 @@ or touch on the phone.
 
 ## Render paths
 
-The host has two, and reports which one ran.
+The host has two. **The software rasterizer is the default** because it is
+measurably faster here; the GL backend is opt-in.
 
 | Path | Mechanism | Measured on `iPhone1,1` / 3.1.3 |
 | --- | --- | --- |
-| OpenGL ES 1.1 | The core walks its DrawList into the fixed-function pipeline; the CPU never touches a pixel. | **46.7–49.4 fps**, 1.7–1.8 ms guest + 15.7–16.8 ms submit |
-| Software raster | The core rasterizes ARGB32; `drawRect:` composites it as one `CGImage`. | **21.9–26.5 fps**, 1.4–2.7 ms guest + 9.6–11.5 ms raster + 22.1–26.9 ms composite |
+| Software raster (default) | The core rasterizes only the damaged spans; `drawRect:` composites only the damaged rectangle. | **59.99 fps**, 1.44 ms guest + 5.93 ms raster + 0.26 ms composite |
+| OpenGL ES 1.1 | The core walks its whole DrawList into the fixed-function pipeline every frame. | **48.6–50.7 fps**, 1.8–2.3 ms guest + 12.8–16.2 ms submit |
 
-The GPU path is **1.8–2× faster**, and the largest single cost anywhere is the
-software path's full-screen `CGImage` composite. Both figures come from one
-binary with the frame loop on `CADisplayLink`.
+The software path holds a **locked 60** at ~7.6 ms of a 16.67 ms budget. The GL
+path is correct and pixel-verified but costs 17–20 ms, because it re-submits and
+re-fills everything every frame; giving it the same damage treatment — scissor
+to the plan's bounds — is the open work.
 
-`renderer=` and `clock=` in the acceptance record name the path and the clock
-that actually ran. Neither is inferred: a GL failure falls back to the
-rasterizer by design, so without those fields a hardware receipt and a software
-receipt are byte-identical.
+### What made the difference
 
-Two fields make the rate exact rather than estimated. `window_frames` and
-`window_us` are counted on the device between record writes, because
-differencing two fetched records is worth about ±4 fps — the record is written
-once per heartbeat and its timestamp has one-second resolution.
+Scoping the composite, not the rasterizer. The rasterizer was always
+damage-limited; the composite was not. `setNeedsDisplay` invalidated the whole
+view and `pocket_draw_rect` discarded the rect UIKit passed, so every frame
+rebuilt a `CGImage` and blitted all 320×480. That cost **22–27 ms**. Now:
+
+- an **empty** damage plan invalidates nothing, so the frame costs no composite
+  at all — 626 of 961 frames in one sample;
+- a non-empty plan goes to `setNeedsDisplayInRect:`, and `drawRect:` clips to
+  whatever UIKit passes back.
+
+The composite fell from 22–27 ms to **0.26 ms**. No preservation guarantee is
+relied on: when UIKit discards the backing store it passes the full bounds and
+the code draws the full frame.
 
 ### Selecting a path
 
 ```sh
-# force the software rasterizer for the next launch
-ssh … 'touch /private/var/tmp/pocketjs-iphone2g.software'
-# back to the GPU
-ssh … 'rm -f /private/var/tmp/pocketjs-iphone2g.software'
+# opt into OpenGL ES 1.1 for the next launch
+ssh … 'touch /private/var/tmp/pocketjs-iphone2g.gles1'
+# back to the default software rasterizer
+ssh … 'rm -f /private/var/tmp/pocketjs-iphone2g.gles1'
 ```
 
-The marker is read in two places, and **both must agree**: `setup_gl` consults
+The marker is read in two places and **both must agree**: `setup_gl` consults
 it, and so does the view's `+layerClass`. A `CAEAGLLayer` never receives
 `drawRect:`, so a view backed by one cannot composite a software frame at all.
-Returning `CAEAGLLayer` unconditionally left the documented fallback computing
+Returning `CAEAGLLayer` unconditionally once left the software path computing
 frames that could not reach the screen.
 
 The app must be restarted for a change to take effect, and iPhone OS 3 has no
-third-party multitasking, so kill it rather than expecting a relaunch to
-replace it:
+third-party multitasking, so kill it rather than expecting a relaunch to replace
+it:
 
 ```sh
 ssh … 'kill -9 $(sed -n "s/^pid=//p" /private/var/tmp/pocketjs-iphone2g.status)'
 bun iphone2g launch
 ```
 
-Note that `ps ax` prints nothing on this installation. Use `kill -0 <pid>` to
-test liveness; `ps ax | grep` reports a running process as absent.
+`ps ax` prints nothing on this installation. Use `kill -0 <pid>` for liveness;
+`ps ax | grep` reports a running process as absent.
+
+### Reading the record
+
+`renderer=` and `clock=` name the path and the clock that actually ran. Neither
+is inferred: a GL failure falls back to the rasterizer by design, so without
+those fields a hardware receipt and a software receipt are byte-identical.
+
+`window_frames` and `window_us` are counted on the device between record writes,
+so the frame rate is exact. Differencing two fetched records is worth about
+±4 fps — the record is written once per heartbeat and its timestamp has
+one-second resolution.
+
+`damage_attempts`, `damage_failures`, `damage_full_redraws` and `damage_pixels`
+come from the plan the incremental rasterizer returns, which used to be
+discarded. **`damage_failures` is the one to watch:** planning that returns an
+error silently draws a complete frame, and without a counter that is
+indistinguishable from the machine being slow. `composites` counts `drawRect:`
+calls — compare it against `guest_frames`, because a scoped invalidation that
+never fires looks exactly like a very fast one.
 
 ### Pixel parity against the reference core
 
-The GPU path is verified by reading the device's own framebuffer back, not by
+Both paths can be verified by capturing the device's own output rather than by
 looking at the screen:
 
 ```sh
 ssh … 'touch /private/var/tmp/pocketjs-iphone2g.capture'
-# the next GL frame is written to pocketjs-iphone2g.frame.rgba and the
-# request is cleared; 614,400 bytes for 320x480 RGBA
+# the next frame is written to pocketjs-iphone2g.frame.rgba and the request is
+# cleared; 614,400 bytes for 320x480
 ssh … 'cat /private/var/tmp/pocketjs-iphone2g.frame.rgba' > device-frame.rgba
 ```
 
-`glReadPixels` reports rows **bottom-up**, so the host-side tool flips them.
-Rendering the same guest bundle through the wasm core at the same viewport,
-200 frames in with animations settled and no presses, gives:
+**The two paths differ in byte order and orientation, and getting this wrong
+produces a convincing false failure:**
+
+| Path | Bytes | Rows |
+| --- | --- | --- |
+| GL (`glReadPixels`, `GL_RGBA`) | R,G,B,A | bottom-up |
+| Software (the core's ARGB32 words) | B,G,R,A | top-down |
+
+The wasm reference core emits R,G,B,A top-down. Comparing the software capture
+without swapping red and blue reports a mean difference of 9.3/255 and a picture
+in which every blue is orange.
+
+Against the same guest rendered by the reference core, 200 frames in with
+animations settled:
 
 ```text
-mean abs channel diff : 0.04 / 255
-channels off by >32   : 0 of 460800
-worst single channel  : 7
+GL path                     mean 0.04 / 255, worst channel 7
+software, after 2581 frames mean 0.039 / 255, worst channel 186
 ```
 
-The residue is antialiased glyph edges: the GPU interpolates the gradient and
-filters the font atlas where the software rasterizer does exact integer math.
+Both residues are the animating spinner at a different phase — for the software
+capture the differing pixels sit inside x 37..56, y 253..281, within the
+spinner's own 40×40 box, with `damage_failures=0`. That is the test that matters
+for a damage-limited rasterizer: the framebuffer persists across frames and only
+damaged spans are rewritten, so under-reported damage accumulates as staleness
+a from-scratch reference render will catch.
 
 ### ES 1.1 state the ES 2 pipeline does not need
 

--- a/engine/symbian/src/lib.rs
+++ b/engine/symbian/src/lib.rs
@@ -94,6 +94,21 @@ fn allocation_error(_layout: Layout) -> ! {
 static mut UI: Option<Ui> = None;
 static mut FRAMEBUFFER: Vec<u8> = Vec::new();
 static mut DAMAGE_TRACKER: DamageTracker<DEFAULT_DAMAGE_REGIONS> = DamageTracker::new();
+/*
+ * Damage statistics for the incremental raster path.
+ *
+ * These exist because the failure mode they describe is invisible without
+ * them: when damage planning returns Err the renderer quietly draws a complete
+ * frame, and a per-frame failure is then indistinguishable from the machine
+ * simply being slow. `failures` counts planning that FAILED; `full_redraws`
+ * counts a plan that legitimately chose to cover everything.
+ */
+static mut DAMAGE_ATTEMPTS: u64 = 0;
+static mut DAMAGE_FAILURES: u64 = 0;
+static mut DAMAGE_FULL_REDRAWS: u64 = 0;
+static mut DAMAGE_REGIONS: u32 = 0;
+static mut DAMAGE_PIXELS: u64 = 0;
+static mut DAMAGE_BOUNDS: [i32; 4] = [0, 0, 0, 0];
 static mut FRAMEBUFFER_WIDTH: u32 = 0;
 static mut FRAMEBUFFER_HEIGHT: u32 = 0;
 static mut FRAMEBUFFER_STRIDE: u32 = 0;
@@ -574,31 +589,104 @@ fn render_at_scale(scale: u32, incremental: bool) -> *const u8 {
         }
 
         if incremental {
-            if raster::render_scaled_argb_incremental(
+            DAMAGE_ATTEMPTS = DAMAGE_ATTEMPTS.wrapping_add(1);
+            match raster::render_scaled_argb_incremental(
                 instance_ref,
                 &(*draw_list).words,
                 &mut FRAMEBUFFER,
                 scale,
                 &mut DAMAGE_TRACKER,
                 DamagePolicy::default(),
-            )
-            .is_err()
-            {
-                raster::render_scaled_argb(
-                    instance_ref,
-                    &(*draw_list).words,
-                    &mut FRAMEBUFFER,
-                    scale,
-                );
-                DAMAGE_TRACKER.invalidate();
+            ) {
+                Ok(plan) => {
+                    // The plan is the only evidence that damage is doing
+                    // anything. Discarding it is what made a per-frame
+                    // full-redraw regression indistinguishable from a slow
+                    // machine, so record it instead.
+                    let bounds = plan.bounds();
+                    DAMAGE_REGIONS = plan.region_count() as u32;
+                    DAMAGE_PIXELS = plan.area();
+                    DAMAGE_BOUNDS = [bounds.x0, bounds.y0, bounds.x1, bounds.y1];
+                    if plan.is_full_redraw() {
+                        DAMAGE_FULL_REDRAWS = DAMAGE_FULL_REDRAWS.wrapping_add(1);
+                    }
+                }
+                Err(_) => {
+                    // Silent fallback to a complete frame. Counted separately
+                    // from a policy-chosen full redraw, because this one means
+                    // damage planning FAILED.
+                    DAMAGE_FAILURES = DAMAGE_FAILURES.wrapping_add(1);
+                    DAMAGE_REGIONS = 0;
+                    DAMAGE_PIXELS = (width as u64) * (height as u64);
+                    DAMAGE_BOUNDS = [0, 0, width as i32, height as i32];
+                    raster::render_scaled_argb(
+                        instance_ref,
+                        &(*draw_list).words,
+                        &mut FRAMEBUFFER,
+                        scale,
+                    );
+                    DAMAGE_TRACKER.invalidate();
+                }
             }
         } else {
             raster::render_scaled_argb(instance_ref, &(*draw_list).words, &mut FRAMEBUFFER, scale);
             DAMAGE_TRACKER.invalidate();
+            DAMAGE_REGIONS = 0;
+            DAMAGE_PIXELS = (width as u64) * (height as u64);
+            DAMAGE_BOUNDS = [0, 0, width as i32, height as i32];
         }
 
         remember_framebuffer_geometry(width, height);
         FRAMEBUFFER.as_ptr()
+    }
+}
+
+/// Incremental-raster statistics, so a host can tell a working damage plan
+/// from a silent per-frame fallback. Counts are cumulative; the region,
+/// pixel and bounds values describe the most recent frame.
+#[no_mangle]
+pub extern "C" fn ui_damage_attempts() -> u64 {
+    unsafe { DAMAGE_ATTEMPTS }
+}
+
+/// Times damage planning returned an error and a complete frame was drawn.
+#[no_mangle]
+pub extern "C" fn ui_damage_failures() -> u64 {
+    unsafe { DAMAGE_FAILURES }
+}
+
+/// Times a successful plan covered the whole target by policy.
+#[no_mangle]
+pub extern "C" fn ui_damage_full_redraws() -> u64 {
+    unsafe { DAMAGE_FULL_REDRAWS }
+}
+
+/// Regions in the most recent plan; 0 means nothing changed.
+#[no_mangle]
+pub extern "C" fn ui_damage_regions() -> u32 {
+    unsafe { DAMAGE_REGIONS }
+}
+
+/// Logical pixels the most recent plan covers.
+#[no_mangle]
+pub extern "C" fn ui_damage_pixels() -> u64 {
+    unsafe { DAMAGE_PIXELS }
+}
+
+/// Union bounds of the most recent plan, packed x0,y0,x1,y1 into the caller's
+/// four ints. Half-open, logical pixels, top-left origin — the same space the
+/// DrawList uses. Returns 0 when the plan is empty.
+#[no_mangle]
+pub extern "C" fn ui_damage_bounds(out: *mut i32) -> i32 {
+    if out.is_null() {
+        return 0;
+    }
+    unsafe {
+        let bounds = DAMAGE_BOUNDS;
+        for (index, value) in bounds.iter().enumerate() {
+            *out.add(index) = *value;
+        }
+        i32::from(bounds[2] > bounds[0] && bounds[3] > bounds[1])
     }
 }
 

--- a/hosts/iphone2g/README.md
+++ b/hosts/iphone2g/README.md
@@ -60,13 +60,17 @@ helper across a Home + Power restart after device-side `/sbin/reboot` stalled
 on its shutdown spinner. That is a forced-restart recovery result, not proof
 that unattended `/sbin/reboot` completes on this installation.
 
-The host renders through **OpenGL ES 1.1** on the device's PowerVR MBX Lite,
-with the software rasterizer as a fallback. The GPU path is 1.8-2x faster and
-is verified pixel-for-pixel against the reference core by reading the device
-framebuffer back with `glReadPixels` (mean absolute channel difference 0.04 of
-255). `docs/IPHONE2G.md` documents both paths, the marker files that select
-between them and request a capture, and the ES 1.1 state that has no ES 2
-equivalent.
+The host has two render paths. **The software rasterizer is the default** and
+holds a locked 60 fps at ~7.6 ms per frame, because both the rasterize and the
+composite are limited to the damaged rectangle. The OpenGL ES 1.1 backend for
+the device's PowerVR MBX Lite is opt-in (`touch
+/private/var/tmp/pocketjs-iphone2g.gles1`), correct, and pixel-verified, but
+costs 17-20 ms because it re-submits the whole DrawList every frame.
+
+Both paths are verified against the reference core by capturing the device's own
+output; `docs/IPHONE2G.md` documents the marker files, the byte-order and
+orientation difference between the two captures, and the ES 1.1 state that has
+no ES 2 equivalent.
 
 Artifacts are written to `dist/iphone2g/PocketJSDemo.app`. The app contains
 the generated Solid/PocketJS guest, pinned QuickJS, PocketJS raster core, and

--- a/hosts/iphone2g/pocket_core.h
+++ b/hosts/iphone2g/pocket_core.h
@@ -64,6 +64,18 @@ uint32_t ui_framebuffer_stride(void);
 size_t ui_framebuffer_len(void);
 
 /*
+ * Incremental-raster statistics. Without these a per-frame damage-planning
+ * failure — which silently draws a complete frame — is indistinguishable from
+ * the machine being slow.
+ */
+uint64_t ui_damage_attempts(void);
+uint64_t ui_damage_failures(void);
+uint64_t ui_damage_full_redraws(void);
+uint32_t ui_damage_regions(void);
+uint64_t ui_damage_pixels(void);
+int32_t ui_damage_bounds(int32_t *out);
+
+/*
  * Hardware DrawList path. The core walks its own DrawList straight into the
  * OpenGL ES 1.1 fixed-function pipeline instead of rasterizing to a
  * framebuffer, so the CPU never touches a pixel. Callers must have a current

--- a/hosts/iphone2g/pocket_runtime.c
+++ b/hosts/iphone2g/pocket_runtime.c
@@ -694,6 +694,37 @@ const uint8_t *pocket_runtime_render(void) {
   return ui_render_incremental();
 }
 
+unsigned long pocket_runtime_damage_attempts(void) {
+  if (runtime == 0 || context == 0 || runtime_failed) return 0;
+  return (unsigned long)ui_damage_attempts();
+}
+
+unsigned long pocket_runtime_damage_failures(void) {
+  if (runtime == 0 || context == 0 || runtime_failed) return 0;
+  return (unsigned long)ui_damage_failures();
+}
+
+unsigned long pocket_runtime_damage_full_redraws(void) {
+  if (runtime == 0 || context == 0 || runtime_failed) return 0;
+  return (unsigned long)ui_damage_full_redraws();
+}
+
+unsigned long pocket_runtime_damage_pixels(void) {
+  if (runtime == 0 || context == 0 || runtime_failed) return 0;
+  return (unsigned long)ui_damage_pixels();
+}
+
+int pocket_runtime_damage_bounds(int *bounds) {
+  int32_t packed[4];
+  if (runtime == 0 || context == 0 || runtime_failed || bounds == 0) return 0;
+  if (!ui_damage_bounds(packed)) return 0;
+  bounds[0] = (int)packed[0];
+  bounds[1] = (int)packed[1];
+  bounds[2] = (int)packed[2];
+  bounds[3] = (int)packed[3];
+  return 1;
+}
+
 int pocket_runtime_gl_initialize(void) {
   if (runtime == 0 || context == 0 || runtime_failed) return 0;
   return ui_gl_initialize() != 0;

--- a/hosts/iphone2g/pocket_runtime.h
+++ b/hosts/iphone2g/pocket_runtime.h
@@ -26,6 +26,17 @@ const uint8_t *pocket_runtime_render(void);
  */
 
 /*
+ * Damage statistics for the software raster path, and the most recent plan's
+ * bounds so the host can scope its composite. `bounds` receives x0,y0,x1,y1 in
+ * logical pixels, top-left origin; the return is zero when nothing changed.
+ */
+unsigned long pocket_runtime_damage_attempts(void);
+unsigned long pocket_runtime_damage_failures(void);
+unsigned long pocket_runtime_damage_full_redraws(void);
+unsigned long pocket_runtime_damage_pixels(void);
+int pocket_runtime_damage_bounds(int *bounds);
+
+/*
  * Hardware path. `pocket_runtime_gl_initialize` needs a current OpenGL ES 1.1
  * context and returns zero if the GPU pipeline cannot be established, which is
  * the host's signal to keep using the software rasterizer above.

--- a/hosts/iphone2g/runtime.c
+++ b/hosts/iphone2g/runtime.c
@@ -71,11 +71,18 @@ typedef enum {
 #define POCKET_STATUS_HEARTBEAT_FRAMES 60UL
 #define POCKET_ACCEPTANCE_PATH "/private/var/tmp/pocketjs-iphone2g.status"
 /*
- * Presence of this file forces the software rasterizer. It exists so the two
- * render paths can be measured against each other on one build, instead of
- * comparing numbers from two binaries that differ in more than the renderer.
+ * The renderer is chosen by this marker, and the default is the software
+ * rasterizer because it is measurably faster here: with the composite scoped to
+ * the damage rectangle it holds a locked 60 fps at ~7.5 ms per frame, where the
+ * OpenGL ES 1.1 path costs ~17-20 ms and delivers 48-51. The GL backend is
+ * correct and pixel-verified, it simply re-submits and re-fills the entire
+ * DrawList every frame; giving it the same damage treatment is the open work.
+ *
+ * Touch the file to opt into GL. Two places must agree on the answer — setup_gl
+ * and the view's +layerClass — because a CAEAGLLayer never receives drawRect:
+ * and so cannot composite a software frame.
  */
-#define POCKET_FORCE_SOFTWARE_PATH "/private/var/tmp/pocketjs-iphone2g.software"
+#define POCKET_PREFER_GL_PATH "/private/var/tmp/pocketjs-iphone2g.gles1"
 /*
  * Touch this file and the next GL frame is read back with glReadPixels and
  * written next to it, then the request is cleared. It exists so device output
@@ -132,6 +139,7 @@ extern void CGContextRestoreGState(CGContextRef context);
 extern void CGContextTranslateCTM(CGContextRef context, float tx, float ty);
 extern void CGContextScaleCTM(CGContextRef context, float sx, float sy);
 extern void CGContextDrawImage(CGContextRef context, CGRect rect, CGImageRef image);
+extern void CGContextClipToRect(CGContextRef context, CGRect rect);
 extern CGColorSpaceRef CGColorSpaceCreateDeviceRGB(void);
 extern void CGColorSpaceRelease(CGColorSpaceRef color_space);
 extern CGDataProviderRef CGDataProviderCreateWithData(
@@ -235,6 +243,13 @@ static unsigned long g_last_record_attempt_frame;
 static unsigned long g_blit_us_total;
 static unsigned long g_blit_frames;
 static unsigned long g_blit_us_mean;
+/*
+ * Cumulative drawRect: calls. The ratio of this to guest_frames is what
+ * distinguishes a cheap composite from a frozen screen — a scoped invalidation
+ * that never fires looks exactly like a very fast one.
+ */
+static unsigned long g_composites;
+static unsigned long g_damage_regions_last;
 
 static unsigned long g_window_start_us;
 static unsigned long g_window_start_frame;
@@ -291,7 +306,9 @@ static void write_acceptance_record(void) {
     "touch_down=%d\nlast_touch_x=%d\nlast_touch_y=%d\nlast_touch_hit=%d\n"
     "action_name=%s\naction_value=%d\naction_sequence=%lu\n"
     "renderer=%s\nclock=%s\nframe_us=%lu\nsubmit_us=%lu\npresent_us=%lu\n"
-    "window_frames=%lu\nwindow_us=%lu\nblit_us=%lu\nerror=%s\n",
+    "window_frames=%lu\nwindow_us=%lu\nblit_us=%lu\n"
+    "damage_attempts=%lu\ndamage_failures=%lu\ndamage_full_redraws=%lu\n"
+    "damage_pixels=%lu\ncomposites=%lu\ndamage_regions_last=%lu\nerror=%s\n",
     POCKET_BUILD_ID,
     state,
     (long)getpid(),
@@ -315,6 +332,12 @@ static void write_acceptance_record(void) {
     g_window_frames,
     g_window_us,
     g_blit_us_mean,
+    pocket_runtime_damage_attempts(),
+    pocket_runtime_damage_failures(),
+    pocket_runtime_damage_full_redraws(),
+    pocket_runtime_damage_pixels(),
+    g_composites,
+    g_damage_regions_last,
     g_state == POCKET_STATE_FAILED ? g_status_message : ""
   );
   g_last_record_attempt_frame = g_guest_frames;
@@ -397,6 +420,10 @@ static void send_void(id receiver, const char *selector) {
 
 static void send_void_object(id receiver, const char *selector, id value) {
   ((void (*)(id, SEL, id))objc_msgSend)(receiver, sel_registerName(selector), value);
+}
+
+static void send_void_rect(id receiver, const char *selector, CGRect rect) {
+  ((void (*)(id, SEL, CGRect))objc_msgSend)(receiver, sel_registerName(selector), rect);
 }
 
 static void send_void_bool(id receiver, const char *selector, BOOL value) {
@@ -600,7 +627,7 @@ static int refresh_framebuffer(void) {
   return 1;
 }
 
-static int draw_framebuffer(CGContextRef context, CGRect bounds) {
+static int draw_framebuffer(CGContextRef context, CGRect bounds, CGRect dirty) {
   CGColorSpaceRef color_space;
   CGDataProviderRef provider;
   CGImageRef image;
@@ -671,6 +698,14 @@ static int draw_framebuffer(CGContextRef context, CGRect bounds) {
   CGContextSaveGState(context);
   CGContextTranslateCTM(context, 0.0f, destination.size.height);
   CGContextScaleCTM(context, 1.0f, -1.0f);
+  /*
+   * After that flip the space is top-down with the origin at the top left,
+   * which is the same space UIKit expressed `dirty` in, so it clips directly.
+   * A degenerate rect means draw everything rather than nothing.
+   */
+  if (dirty.size.width > 0.0f && dirty.size.height > 0.0f) {
+    CGContextClipToRect(context, dirty);
+  }
   CGContextDrawImage(context, destination, image);
   CGContextRestoreGState(context);
 
@@ -857,10 +892,10 @@ static BOOL send_bool_class_object(Class cls, const char *selector, id value) {
 static Class pocket_layer_class(id self, SEL command) {
   (void)self;
   (void)command;
-  if (access(POCKET_FORCE_SOFTWARE_PATH, F_OK) == 0) {
-    return objc_getClass("CALayer");
+  if (access(POCKET_PREFER_GL_PATH, F_OK) == 0) {
+    return objc_getClass("CAEAGLLayer");
   }
-  return objc_getClass("CAEAGLLayer");
+  return objc_getClass("CALayer");
 }
 
 static int resolve_gl_extension(void) {
@@ -918,7 +953,7 @@ static int setup_gl(id view) {
   int32_t status;
   int forced_software;
 
-  forced_software = access(POCKET_FORCE_SOFTWARE_PATH, F_OK) == 0;
+  forced_software = access(POCKET_PREFER_GL_PATH, F_OK) != 0;
   if (forced_software) return 0;
   if (eagl == NULL || objc_getClass("CAEAGLLayer") == NULL) return 0;
   if (!resolve_gl_extension()) return 0;
@@ -981,6 +1016,34 @@ static int setup_gl(id view) {
   return 1;
 }
 
+/* Shared by both capture paths: write `length` bytes and clear the request. */
+static void write_capture(const uint8_t *pixels, size_t length) {
+  int descriptor = open(POCKET_CAPTURE_OUTPUT_PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
+  size_t written = 0;
+  if (descriptor < 0) {
+    return;
+  }
+  while (written < length) {
+    ssize_t count = write(descriptor, pixels + written, length - written);
+    if (count <= 0) break;
+    written += (size_t)count;
+  }
+  (void)fsync(descriptor);
+  (void)close(descriptor);
+  (void)unlink(POCKET_CAPTURE_REQUEST_PATH);
+}
+
+/* The rasterizer's own framebuffer: top-down, ARGB32 words (BGRA bytes). */
+static void capture_software_frame_if_requested(void) {
+  if (access(POCKET_CAPTURE_REQUEST_PATH, F_OK) != 0) {
+    return;
+  }
+  if (g_framebuffer == NULL || g_framebuffer_length == 0) {
+    return;
+  }
+  write_capture(g_framebuffer, g_framebuffer_length);
+}
+
 /*
  * Read the just-drawn frame back off the GPU when asked. GL reports rows
  * bottom-up; the raw dump is left in that order and the host-side tool flips
@@ -989,8 +1052,6 @@ static int setup_gl(id view) {
 static void capture_frame_if_requested(void) {
   size_t length;
   uint8_t *pixels;
-  int descriptor;
-  size_t written = 0;
 
   if (access(POCKET_CAPTURE_REQUEST_PATH, F_OK) != 0) {
     return;
@@ -1006,19 +1067,8 @@ static void capture_frame_if_requested(void) {
   glFinish();
   /* GL_RGBA + GL_UNSIGNED_BYTE is the one combination ES 1.1 always allows. */
   glReadPixels(0, 0, g_gl_width, g_gl_height, 0x1908U, 0x1401U, pixels);
-  descriptor = open(POCKET_CAPTURE_OUTPUT_PATH, O_WRONLY | O_CREAT | O_TRUNC, 0644);
-  if (descriptor >= 0) {
-    while (written < length) {
-      ssize_t count = write(descriptor, pixels + written, length - written);
-      if (count <= 0) break;
-      written += (size_t)count;
-    }
-    (void)fsync(descriptor);
-    (void)close(descriptor);
-  }
+  write_capture(pixels, length);
   free(pixels);
-  /* One shot: clearing the request is what proves the capture ran. */
-  (void)unlink(POCKET_CAPTURE_REQUEST_PATH);
 }
 
 /*
@@ -1094,6 +1144,45 @@ static int boot_embedded_runtime(void) {
   return 1;
 }
 
+/*
+ * Ask UIKit to recomposite only the rectangle the core says changed.
+ *
+ * An empty damage plan means nothing changed, so nothing is invalidated and the
+ * frame costs no composite at all — which is most frames for a UI that is
+ * mostly still. When the plan is non-empty the rect is handed to
+ * setNeedsDisplayInRect:, and drawRect: clips to whatever UIKit passes back.
+ *
+ * If setNeedsDisplayInRect: is unavailable, or the plan covers everything, this
+ * degrades to invalidating the whole view — the behaviour it replaces.
+ */
+static void invalidate_damaged_region(void) {
+  int bounds[4];
+  CGRect dirty;
+
+  if (g_view == NULL) {
+    return;
+  }
+  if (!pocket_runtime_damage_bounds(bounds)) {
+    /* Empty plan: the previous composite is still correct. */
+    return;
+  }
+  if (!responds_to(g_view, "setNeedsDisplayInRect:")) {
+    send_void(g_view, "setNeedsDisplay");
+    return;
+  }
+  /* Damage is half-open logical pixels, top-left origin — the view's space. */
+  dirty.origin.x = (float)bounds[0];
+  dirty.origin.y = (float)bounds[1];
+  dirty.size.width = (float)(bounds[2] - bounds[0]);
+  dirty.size.height = (float)(bounds[3] - bounds[1]);
+  if (dirty.size.width <= 0.0f || dirty.size.height <= 0.0f) {
+    return;
+  }
+  g_damage_regions_last = (unsigned long)(bounds[2] - bounds[0]) *
+    (unsigned long)(bounds[3] - bounds[1]);
+  send_void_rect(g_view, "setNeedsDisplayInRect:", dirty);
+}
+
 static void pocket_tick(id self, SEL command, id timer) {
   int completed_touch;
   int delivered_touch;
@@ -1164,6 +1253,13 @@ static void pocket_tick(id self, SEL command, id timer) {
     if (!refresh_framebuffer()) {
       return;
     }
+    /*
+     * Capture the software framebuffer on request too. This is the test that
+     * matters for a damage-limited rasterizer: the framebuffer persists across
+     * frames and only damaged spans are rewritten, so under-reported damage
+     * shows up as staleness that a from-scratch reference render will catch.
+     */
+    capture_software_frame_if_requested();
   }
   finished_us = now_us();
   if (finished_us >= frame_started_us) {
@@ -1200,7 +1296,7 @@ static void pocket_tick(id self, SEL command, id timer) {
     write_acceptance_record();
   }
   if (!g_gl_ready) {
-    send_void(g_view, "setNeedsDisplay");
+    invalidate_damaged_region();
   }
 }
 
@@ -1209,7 +1305,6 @@ static void pocket_draw_rect(id self, SEL command, CGRect rect) {
   CGRect bounds;
   unsigned long blit_started_us = now_us();
   (void)command;
-  (void)rect;
 
   if (context == NULL) {
     if (g_state != POCKET_STATE_FAILED) {
@@ -1219,7 +1314,14 @@ static void pocket_draw_rect(id self, SEL command, CGRect rect) {
   }
   bounds = send_rect(self, "bounds");
   if (g_state == POCKET_STATE_RUNNING) {
-    if (!draw_framebuffer(context, bounds)) {
+    /*
+     * `rect` is what UIKit decided needs recompositing, which is normally the
+     * damage rectangle we asked for. Honouring it is the difference between
+     * blitting 320x480 and blitting what changed. When UIKit has discarded the
+     * backing store it passes the full bounds and this is a no-op, so no
+     * preservation guarantee is being relied on.
+     */
+    if (!draw_framebuffer(context, bounds, rect)) {
       draw_status(context, bounds);
     }
   } else {
@@ -1227,6 +1329,7 @@ static void pocket_draw_rect(id self, SEL command, CGRect rect) {
   }
   g_blit_us_total += now_us() - blit_started_us;
   g_blit_frames += 1;
+  g_composites += 1;
 }
 
 static void begin_touch(void) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pocketjs/framework",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "type": "module",
   "repository": {

--- a/pocket.json
+++ b/pocket.json
@@ -4,7 +4,7 @@
   "id": "dev.pocket-stack.hero",
   "name": "pocketjs-hero",
   "title": "PocketJS Hero",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "engine": {
     "capabilities": {
       "requires": [

--- a/site/content/blog/pocketjs-on-the-first-iphone.md
+++ b/site/content/blog/pocketjs-on-the-first-iphone.md
@@ -273,42 +273,106 @@ None of the three was found by a test. The first two were found by a measurement
 
 ## What the numbers actually are
 
-Same binary, same `CADisplayLink`, switched by the marker file, screen on, complete UI on both paths:
+Same binary, same `CADisplayLink`, switched by a marker file, screen on,
+complete UI on both paths — and with one change that turns out to matter more
+than the renderer choice.
 
-<svg viewBox="0 0 760 262" width="100%" role="img" aria-label="Benchmark of the two render paths on the same binary. OpenGL ES 1.1 delivers 46.7 to 49.4 frames per second, with 1.7 to 1.8 milliseconds in JavaScript plus core and 15.7 to 16.8 milliseconds submitting to the GPU, totalling 19.4 to 20.5 milliseconds. The software rasterizer delivers 21.9 to 26.5 frames per second, with 1.4 to 2.7 milliseconds in JavaScript plus core, 9.6 to 11.5 milliseconds rasterizing, and 22.1 to 26.9 milliseconds for the full-screen CGImage composite, totalling 33.9 to 40.8 milliseconds. The GPU path is roughly 1.8 to 2 times faster, and the CGImage composite is the single largest cost anywhere." font-family="ui-monospace,SFMono-Regular,Menlo,monospace">
+<svg viewBox="0 0 760 286" width="100%" role="img" aria-label="Benchmark of the two render paths on the same binary. The software rasterizer with a damage-scoped composite delivers 59.99 frames per second: 1.44 milliseconds in JavaScript plus core, 5.93 milliseconds rasterizing only damaged spans, and 0.26 milliseconds compositing only the damaged rectangle, totalling 7.63 milliseconds. The OpenGL ES 1.1 path delivers 48.6 to 50.7 frames per second: 1.8 to 2.3 milliseconds in JavaScript plus core and 12.8 to 16.2 milliseconds submitting the whole DrawList, totalling 17.2 to 19.7 milliseconds. Before the composite was scoped the software path was 21.9 to 26.5 frames per second with a 22 to 27 millisecond full-screen composite." font-family="ui-monospace,SFMono-Regular,Menlo,monospace">
   <text x="14" y="20" fill="#64748b" font-size="11">ONE BINARY · ONE DISPLAY LINK · COMPLETE UI ON BOTH · MEAN ms PER FRAME</text>
   <line x1="14" y1="28" x2="746" y2="28" stroke="#1e293b"/>
   <text x="14" y="52" fill="#64748b" font-size="11">PATH</text>
-  <text x="150" y="52" fill="#64748b" font-size="11">FPS</text>
-  <text x="248" y="52" fill="#64748b" font-size="11">JS + CORE</text>
-  <text x="368" y="52" fill="#64748b" font-size="11">DRAW</text>
-  <text x="500" y="52" fill="#64748b" font-size="11">COMPOSITE</text>
-  <text x="646" y="52" fill="#64748b" font-size="11">TOTAL</text>
+  <text x="186" y="52" fill="#64748b" font-size="11">FPS</text>
+  <text x="284" y="52" fill="#64748b" font-size="11">JS + CORE</text>
+  <text x="404" y="52" fill="#64748b" font-size="11">DRAW</text>
+  <text x="536" y="52" fill="#64748b" font-size="11">COMPOSITE</text>
+  <text x="666" y="52" fill="#64748b" font-size="11">TOTAL</text>
   <rect x="8" y="62" width="738" height="30" rx="7" fill="#0c1a22" stroke="#22d3ee" stroke-width="1.2"/>
-  <text x="14" y="82" fill="#f1f5f9" font-size="12" font-weight="700">OpenGL ES 1.1</text>
-  <text x="150" y="82" fill="#22d3ee" font-size="12">46.7–49.4</text>
-  <text x="248" y="82" fill="#22d3ee" font-size="12">1.7–1.8</text>
-  <text x="368" y="82" fill="#22d3ee" font-size="12">15.7–16.8</text>
-  <text x="500" y="82" fill="#22d3ee" font-size="12">—</text>
-  <text x="646" y="82" fill="#22d3ee" font-size="12">19.4–20.5</text>
-  <text x="14" y="116" fill="#e2e8f0" font-size="12" font-weight="700">software raster</text>
-  <text x="150" y="116" fill="#eab308" font-size="12">21.9–26.5</text>
-  <text x="248" y="116" fill="#94a3b8" font-size="12">1.4–2.7</text>
-  <text x="368" y="116" fill="#94a3b8" font-size="12">9.6–11.5</text>
-  <text x="500" y="116" fill="#eab308" font-size="12">22.1–26.9</text>
-  <text x="646" y="116" fill="#eab308" font-size="12">33.9–40.8</text>
-  <line x1="14" y1="134" x2="746" y2="134" stroke="#1e293b"/>
-  <text x="14" y="156" fill="#e2e8f0" font-size="11">The GPU path is 1.8–2× faster. The single largest cost anywhere is the software path's full-screen</text>
-  <text x="14" y="174" fill="#e2e8f0" font-size="11">CGImage composite at 22–27 ms — the stage that was never being timed.</text>
-  <text x="14" y="200" fill="#64748b" font-size="11">Enabling texturing raised GL submit from ~11 ms to ~16 ms, because it is now actually sampling. That</text>
-  <text x="14" y="218" fill="#64748b" font-size="11">is the cost of drawing the whole UI instead of colour blocks.</text>
-  <line x1="14" y1="234" x2="746" y2="234" stroke="#1e293b"/>
-  <text x="14" y="256" fill="#38bdf8" font-size="11">Frame rate comes from the device: window_frames and window_us, not two coarse samples differenced.</text>
+  <text x="14" y="82" fill="#f1f5f9" font-size="12" font-weight="700">software, scoped</text>
+  <text x="186" y="82" fill="#22d3ee" font-size="12">59.99</text>
+  <text x="284" y="82" fill="#22d3ee" font-size="12">1.44</text>
+  <text x="404" y="82" fill="#22d3ee" font-size="12">5.93</text>
+  <text x="536" y="82" fill="#22d3ee" font-size="12">0.26</text>
+  <text x="666" y="82" fill="#22d3ee" font-size="12">7.63</text>
+  <text x="14" y="116" fill="#e2e8f0" font-size="12" font-weight="700">OpenGL ES 1.1</text>
+  <text x="186" y="116" fill="#94a3b8" font-size="12">48.6–50.7</text>
+  <text x="284" y="116" fill="#94a3b8" font-size="12">1.8–2.3</text>
+  <text x="404" y="116" fill="#eab308" font-size="12">12.8–16.2</text>
+  <text x="536" y="116" fill="#94a3b8" font-size="12">—</text>
+  <text x="666" y="116" fill="#eab308" font-size="12">17.2–19.7</text>
+  <text x="14" y="146" fill="#64748b" font-size="12">software, full-screen</text>
+  <text x="186" y="146" fill="#64748b" font-size="12">21.9–26.5</text>
+  <text x="284" y="146" fill="#64748b" font-size="12">1.4–2.7</text>
+  <text x="404" y="146" fill="#64748b" font-size="12">9.6–11.5</text>
+  <text x="536" y="146" fill="#64748b" font-size="12">22.1–26.9</text>
+  <text x="666" y="146" fill="#64748b" font-size="12">33.9–40.8</text>
+  <line x1="14" y1="164" x2="746" y2="164" stroke="#1e293b"/>
+  <text x="14" y="186" fill="#e2e8f0" font-size="11">The third row is the second row's own past. Scoping the composite to the damage rectangle took it from</text>
+  <text x="14" y="204" fill="#e2e8f0" font-size="11">22–27 ms to 0.26 ms, and the software path from 22–26 fps to a locked 60.</text>
+  <text x="14" y="230" fill="#64748b" font-size="11">The GL path is unchanged: it does no damage tracking, and re-fills the whole screen every frame.</text>
+  <text x="14" y="248" fill="#64748b" font-size="11">Giving it the same treatment — scissor to the plan's bounds — is the open work.</text>
+  <line x1="14" y1="264" x2="746" y2="264" stroke="#1e293b"/>
+  <text x="14" y="282" fill="#38bdf8" font-size="11">Frame rate comes from the device: window_frames and window_us, not two coarse samples differenced.</text>
 </svg>
 
-Getting these required fixing the ruler as well as the renderer. The earlier fps figures came from differencing two fetched status records, whose timestamps have one-second resolution and which are only written every heartbeat — worth about ±4 fps of uncertainty, comfortably enough to hide the discrepancy that eventually exposed bug one.
+Getting these required fixing the ruler as well as the renderer. The earlier fps
+figures came from differencing two fetched status records, whose timestamps have
+one-second resolution and which are only written every heartbeat — worth about
+±4 fps of uncertainty, comfortably enough to hide the discrepancy that exposed
+bug one.
 
-**47–49 fps, not 60.** GL's measured work is 19.4–20.5 ms against a 16.67 ms budget, so it misses roughly every fifth vsync and `CADisplayLink` hands back the next one. The honest next step is damage-aware submission — scissoring to the rectangle the core already tracks, so the GPU stops re-filling a full-screen gradient sixty times a second — and since the backend now serves two GPU generations, that is a decision about shared code rather than a patch.
+### The composite was never damage-limited
+
+The rasterizer always was. `ui_render_incremental` writes only the spans the
+damage plan covers, and it works: instrumenting the plan the core already
+returns — and which `engine/symbian` was discarding — gives
+`damage_failures=0`, two full redraws in 361 frames, and an **empty** plan on
+most frames, because a mostly-still UI mostly does not change.
+
+The composite threw all of that away. The tick called `setNeedsDisplay`, which
+invalidates the whole view, and `pocket_draw_rect` began with `(void)rect;` —
+discarding the dirty rectangle UIKit hands you — then re-read full `bounds` and
+rebuilt a `CGImage` over all 320×480. Every frame. That is the 22–27 ms.
+
+Two changes, neither clever:
+
+- An empty damage plan now invalidates **nothing**, so the frame costs no
+  composite at all. In one sample that was 626 of 961 frames.
+- A non-empty plan goes to `setNeedsDisplayInRect:`, and `drawRect:` clips to
+  whatever UIKit passes back.
+
+This needs no preservation guarantee, which is what makes it sounder than the
+GL equivalent: when UIKit does discard the backing store it passes the full
+bounds, and the code draws the full frame. The fallback is the default.
+
+**And this is where the earlier claim gets superseded rather than corrected.**
+"The GPU path is 1.8–2× faster" was true of the code as it stood. Then the CPU
+path got the optimization the GPU path still lacks, and the ordering flipped.
+That is not a fourth measurement bug; it is the first time the instrument was
+good enough to aim.
+
+Verifying it needed the capture again, and the capture had a trap of its own.
+The two paths disagree about pixel format: `glReadPixels` gives R,G,B,A
+bottom-up, while the core's ARGB32 words are B,G,R,A top-down. Comparing the
+software capture without swapping red and blue reports a mean difference of
+9.3/255 and produces a picture in which every blue is orange — a completely
+convincing failure that is entirely in the comparison. Swapped, after 2,581
+frames of damage-limited rendering:
+
+```text
+mean abs channel diff : 0.039 / 255
+worst single channel  : 186, in 109 pixels
+```
+
+Those 109 pixels sit inside x 37..56, y 253..281 — within the animating
+spinner's own 40×40 box, at a different phase than the reference. Everywhere
+else the framebuffer is identical after 2,581 incremental frames, which is the
+test that matters: the framebuffer persists and only damaged spans are
+rewritten, so under-reported damage would accumulate as staleness that a
+from-scratch render catches.
+
+**Locked 60 fps on a 2007 iPhone, compositing 0.26 ms per frame.** The GPU path
+stays in the tree, opt-in, correct and pixel-verified, waiting for the same
+treatment.
 
 ## The icon, which took four tries
 
@@ -348,8 +412,8 @@ This is **not** a production PocketJS target.
 
 - The build profile lives in `tools/`, deliberately outside the production registry, with a test asserting it stays there.
 - Everything is verified on **one** device: `iPhone1,1` running iPhone OS 3.1.3. The pixel parity above is one frame, at rest, on one phone — a strong result, and not a golden suite.
-- **47–49 fps, not a locked 60.** GL's work exceeds the 16.67 ms budget, so vsyncs are missed. Damage-aware submission is the open work.
-- The software fallback now composites correctly, but it is a fallback at 22–27 ms of CGImage per frame. Its cost is probably not inherent: the composite applies a Y-flip CTM, which likely pushes old CoreGraphics onto a general resampling path instead of a direct copy. Pre-flipping in the rasterizer is untested.
+- The default path holds **59.99 fps**; the GL path, which is opt-in, delivers 48.6–50.7 because its work exceeds the 16.67 ms budget. Damage-aware GL submission is the open work, and it is now clearly worth doing.
+- `Ui::draw()` calls `draw::build()` unconditionally, so the whole DrawList is rebuilt from the tree every frame on **both** paths. That cost sits inside the timed window and nobody has separated it yet. It is the next thing to measure.
 - To reproduce any of this you need a jailbroken `iPhone1,1` on 3.1.3, because the host relies on an `ldid` pseudo-signature being accepted and on SSH over USB. Getting a device into that state is out of scope here and there is no repository command for it.
 - No firmware, system file or extracted sysroot is in the repository. You supply your own copies of the historical inputs under their original terms; the toolchain verifies their hashes.
 
@@ -363,7 +427,11 @@ The runtime went onto it without a fork. What changed was a toolchain, a host, o
 
 The rest of it is a lesson about evidence I would rather have learned more cheaply. We published that a GPU backend lost to a CPU rasterizer by 2.4×. Every number in that claim was real. The stage we forgot to time was the largest one; the fallback we measured against was not drawing; and the renderer we were defending was painting rectangles where the text should be. **Three separate mistakes, each individually plausible, composing into a confident published conclusion that was exactly backwards.**
 
-What broke the chain was not a cleverer benchmark. It was `glReadPixels` — pulling the actual pixels off the actual phone and subtracting them from the reference — and a person picking up the device to say it still looked like colour blocks. On hardware you can only touch one machine at a time, the cheapest instrument you can build is the one that shows you what the machine is really doing, and the most valuable participant is whoever is holding it.
+What broke the chain was not a cleverer benchmark. It was `glReadPixels` — pulling the actual pixels off the actual phone and subtracting them from the reference — and a person picking up the device to say it still looked like colour blocks.
+
+And once the instrument existed it kept paying. It showed that the rasterizer's damage plan was fine and the *composite* was throwing it away, which is worth 22 ms a frame and a locked 60. It caught a red/blue swap in my own comparison that would otherwise have read as a rendering bug. It proved 2,581 frames of incremental rendering leave no stale pixels. Every one of those is a question I would previously have answered by looking at the screen and forming an impression.
+
+On hardware you can only touch one machine at a time. The cheapest thing you can build is the instrument that shows you what the machine is really doing — and the most valuable participant is whoever is holding it.
 
 ---
 

--- a/site/content/changelog.md
+++ b/site/content/changelog.md
@@ -3,6 +3,47 @@
 Engine and site milestones, newest first. Versions track the
 `@pocketjs/framework` npm package.
 
+## 0.9.2 — August 6, 2026
+
+**A locked 60 fps on a 2007 iPhone, because the composite was the only stage that was never damage-limited.**
+PocketJS 0.9.2 makes the software rasterizer scope its screen composite to the
+damaged rectangle, which takes the original iPhone from 22–26 fps to **59.99**,
+and exposes the damage statistics that made the diagnosis possible. The
+[deep dive](/blog/pocketjs-on-the-first-iphone/) has the numbers.
+
+- **The composite now follows the damage plan.** The rasterizer was always
+  incremental; the composite was not. The tick called `setNeedsDisplay` on the
+  whole view and `drawRect:` discarded the dirty rectangle UIKit passes, so every
+  frame rebuilt a `CGImage` over all 320×480 — **22–27 ms**. An empty plan now
+  invalidates nothing (626 of 961 frames in one sample), and a non-empty plan
+  goes to `setNeedsDisplayInRect:` with `drawRect:` clipping to what it is
+  handed. The composite costs **0.26 ms**, and the frame **7.63 ms** of a
+  16.67 ms budget. No preservation guarantee is relied on: when UIKit discards
+  the backing store it passes full bounds and the full frame is drawn.
+- **Damage is observable.** `engine/symbian` was discarding the `DamagePlan` the
+  incremental rasterizer returns. Six new C ABI accessors expose attempts,
+  failures, policy-chosen full redraws, region count, pixel area and union
+  bounds, and four of them ride in the device record. **`damage_failures` is the
+  one that matters:** planning that errors silently draws a complete frame, and
+  without a counter that is indistinguishable from a slow machine. A
+  `composites` counter sits beside it, because a scoped invalidation that never
+  fires looks exactly like a very fast one.
+- **The software rasterizer is now the default on this target**, and the OpenGL
+  ES 1.1 backend is opt-in. The GL path is correct and pixel-verified but costs
+  17.2–19.7 ms and delivers 48.6–50.7 fps, because it re-submits and re-fills
+  the entire DrawList every frame. **This supersedes rather than corrects
+  0.9.1:** the GPU path really was faster than the CPU path as that code stood;
+  the CPU path then got an optimization the GPU path still lacks.
+- **Both paths can be captured and diffed.** The capture works on the software
+  path too, which is the test that matters for a damage-limited rasterizer —
+  the framebuffer persists and only damaged spans are rewritten, so
+  under-reported damage would accumulate as staleness. After **2,581 frames**:
+  mean absolute channel difference 0.039 of 255, with the only residue inside
+  the animating spinner's own 40×40 box. Note the two captures disagree about
+  format — `glReadPixels` is R,G,B,A bottom-up, the core's ARGB32 words are
+  B,G,R,A top-down — and comparing the software one unswapped reports a
+  convincing 9.3/255 failure that is entirely in the comparison.
+
 ## 0.9.1 — August 6, 2026
 
 **The GPU path on the original iPhone was never losing; three stacked measurement bugs said it was.**
@@ -17,7 +58,8 @@ dive](/blog/pocketjs-on-the-first-iphone/) tells it in order.
   **1.8–2× faster**: 46.7–49.4 fps against 21.9–26.5, and 19.4–20.5 ms per
   frame against 33.9–40.8. The old comparison timed GL's rasterize *and*
   present against software's rasterize *only*, because the software
-  composite runs in `drawRect:` later in the run loop.
+  composite runs in `drawRect:` later in the run loop. (0.9.2 then scoped that
+  composite and the ordering flipped again — see above.)
 - **Fixed: the software fallback never composited.** `+layerClass` returned
   `CAEAGLLayer` unconditionally, and a GL-backed layer never receives
   `drawRect:`. The documented fallback — the one the host drops to whenever GL

--- a/tools/cli/package.json
+++ b/tools/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pocketjs/cli",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "The PocketJS CLI — manifest-first handheld builds, app scaffolding, and pinned native toolchain setup.",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
0.9.2.

**The composite was the only stage that was never damage-limited.** `pocket_draw_rect` opened with `(void)rect;`, discarding the dirty rectangle UIKit hands it, and the tick invalidated the whole view — so every frame rebuilt a `CGImage` over all 320×480. That was 22–27 ms.

An empty damage plan now invalidates nothing (626 of 961 frames in one sample); a non-empty one goes to `setNeedsDisplayInRect:` and `drawRect:` clips to what it is handed. **Composite 22–27 ms → 0.26 ms. Frame 33.9–40.8 ms → 7.63 ms. 21.9–26.5 fps → 59.99.**

No preservation guarantee is relied on: when UIKit discards the backing store it passes full bounds and the full frame is drawn, so the fallback is the default.

The software rasterizer becomes the default on this target and GL becomes opt-in. This **supersedes rather than corrects** 0.9.1 — the GPU path really was faster as that code stood; the CPU path then got an optimization GL still lacks (17.2–19.7 ms, 48.6–50.7 fps, because it re-submits and re-fills everything every frame).

**Damage is now observable**, which is how this was found: `engine/symbian` was discarding the `DamagePlan` the incremental rasterizer returns. Six C ABI accessors plus a `composites` counter ride in the device record. `damage_failures` is the one that matters — planning that errors silently draws a complete frame, which is otherwise indistinguishable from a slow machine. The counters immediately refuted the hypothesis they were built to confirm: damage was working fine, and the composite was throwing it away.

**Verified on device:** software capture diffed against the reference core after 2,581 damage-limited frames — mean 0.039/255, residue confined to the animating spinner's own 40×40 box, `damage_failures=0`. The two captures disagree about format (`glReadPixels` R,G,B,A bottom-up vs the core's ARGB32 words B,G,R,A top-down); comparing unswapped reports a convincing 9.3/255 failure that lives entirely in the comparison.

Gate: 11/11 stages, 54/54 goldens, 180 tape frames, engine/core 110 tests, both GL pipelines 0 warnings, tsc clean, ARMv6 bundle links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)