### PR TITLE
docs: fix broken RUNTIMES.md link in pocket3d README

### DIFF
--- a/engine/pocket3d/README.md
+++ b/engine/pocket3d/README.md
@@ -1,7 +1,7 @@
 # Pocket3D
 
 A small, modern, extensible 3D runtime in Rust — the native desktop base of
-the Pocket runtime family (see [docs/RUNTIMES.md](../RUNTIMES.md)). Built on
+the Pocket runtime family (see [docs/RUNTIMES.md](../../docs/RUNTIMES.md)). Built on
 **wgpu** (Metal/Vulkan/DX12) + **winit**, with GoldSrc **BSP maps as a
 first-class world format**.
 


### PR DESCRIPTION
In `engine/pocket3d/README.md`, the link to the runtimes doc is `see [docs/RUNTIMES.md](../RUNTIMES.md)`.

From `engine/pocket3d/`, `../RUNTIMES.md` resolves to `engine/RUNTIMES.md`, which does not exist. The file is at `docs/RUNTIMES.md` (which the link text already names), so this repoints the link to `../../docs/RUNTIMES.md`.
