### PR TITLE
fix(psp): audio credit-mirror decay + standalone audio module mount

### DIFF
--- a/docs/RUNTIMES.md
+++ b/docs/RUNTIMES.md
@@ -174,6 +174,14 @@ The PSP UI runtime, in the same notation: a QuickJS guest + the `ui` surface
 + the sceGu backend. It was the first instance of the pattern all along; the
 architecture names it and makes it repeatable.
 
+[Pocket Voxel](https://github.com/pocket-stack/pocket-voxel) inverts the
+ownership split the other instances share: the GAME STATE lives in the
+QuickJS guest (a TypeScript port of a Game Boy RPG engine) and the Rust core
+owns only the retained diorama scene — cooked voxel chunks, billboards,
+camera rungs, a GB UI tile layer — behind its own `voxel` surface, next to
+the mounted `audio` module. It incubated in this repo and now lives in its
+own repository, vendoring this engine the way OpenStrike does.
+
 And the composition is now proven portable: **OpenStrike runs on a real PSP**
 as `openstrike-core` (the same FPS simulation) + `pocket3d-gu` over a cooked
 map + the `pocketjs-psp` host library + the same `strike` surface mounted

--- a/hosts/psp/src/audio_mod.rs
+++ b/hosts/psp/src/audio_mod.rs
@@ -278,6 +278,16 @@ pub unsafe fn write_pcm(handle: i32, pcm: &[i16]) -> i32 {
         }
     }
     WRITE_POS[slot].store(write.wrapping_add(n), Ordering::Release);
+    // Keep the credit mirror honest. LAST_FREE models "the free count the
+    // guest last saw", and the guest subtracts what it wrote from its own
+    // mirror (music.ts `this.free -= accepted`). Without this line the two
+    // mirrors diverge by every accepted frame, and when the mixer happens to
+    // drain the ring completely between two polls, poll() reads
+    // free == LAST_FREE == RING_FRAMES both times, sends no credit, and the
+    // guest's mirror decays monotonically until `want <= 0` and it stops
+    // feeding — silently, forever. Symptom: audio plays for a couple of
+    // seconds and stops. Only reachable when the guest actually writes PCM.
+    LAST_FREE[slot] = LAST_FREE[slot].saturating_sub(n);
     n as i32
 }
 

--- a/hosts/psp/src/ffi.rs
+++ b/hosts/psp/src/ffi.rs
@@ -1056,9 +1056,20 @@ pub unsafe fn register(
     // JS_SetPropertyStr consumes ownership of ui_obj.
     JS_SetPropertyStr(ctx, global, b"ui\0".as_ptr() as *const _, ui_obj);
 
-    // The audio MODULE mounts as its own namespace (capability audio.pcm =
-    // spec namespace, contracts/spec/audio.ts) — the pocket-mod
-    // `mount("audio", …)` shape spelled in raw QuickJS.
+    register_audio(ctx, global);
+}
+
+/// Install `globalThis.audio` — the audio MODULE as its own namespace
+/// (capability audio.pcm = spec namespace, contracts/spec/audio.ts), the
+/// pocket-mod `mount("audio", …)` shape spelled in raw QuickJS.
+///
+/// Separate from [`register`] so a host with its own surface instead of `ui`
+/// (pocketvoxel-psp's `voxel`) can mount the module without the UI ops. The
+/// mixer thread and hardware channel start lazily on the first createStream.
+///
+/// # Safety
+/// QuickJS context alive, worker thread.
+pub unsafe fn register_audio(ctx: *mut JSContext, global: JSValue) {
     let audio_obj = JS_NewObject(ctx);
     add_fn(ctx, audio_obj, b"createStream\0", js_audio_create_stream, 2);
     add_fn(ctx, audio_obj, b"destroyStream\0", js_audio_destroy_stream, 1);


### PR DESCRIPTION
Two host changes the Pocket Voxel runtime needed while incubating on `periwinkle-jeep`, extracted as that runtime moves to its own repository (pocket-stack/pocket-voxel, the OpenStrike-style vendoring pattern):

- **`audio_mod.rs`** — `poll()`'s `LAST_FREE` mirror never subtracted what `write()` accepted. Whenever the mixer drained the ring completely between two polls, the host saw `free == LAST_FREE` and sent no credit, so the guest's own mirror decayed monotonically until it stopped feeding: audio played for a couple of seconds and went silent, forever. Only reachable when a guest actually writes PCM, which no in-repo host did yet.
- **`ffi.rs`** — split `register_audio` out of `register`, so a host that mounts its own surface instead of `ui` (Pocket Voxel's `voxel`) can still mount `globalThis.audio` (the `audio.pcm` capability) without the UI ops.
- **`docs/RUNTIMES.md`** — the registry entry for the extracted runtime.

The incubation branch's full history stays on `periwinkle-jeep` (PR #225, superseded by the extraction).

🤖 Generated with [Claude Code](https://claude.com/claude-code)