### PR TITLE
fix(site): share footer description

### DIFF
--- a/site/build.ts
+++ b/site/build.ts
@@ -28,7 +28,7 @@ import {
   vdomHelperCode,
   vdomHelperId,
 } from "@vue-jsx-vapor/runtime/raw";
-import { OG_IMAGE_URL, SITE_DESC, SITE_TITLE, SITE_URL, renderPage } from "./templates.ts";
+import { OG_IMAGE_URL, SITE_DESC, SITE_TITLE, SITE_URL, injectSiteFooterDescription, renderPage } from "./templates.ts";
 import { BLOG_POSTS, DOC_NAV, type DocSection } from "./nav.ts";
 import { emitSingleLodStagePackage } from "./stage-package.ts";
 
@@ -442,7 +442,7 @@ async function main() {
 // footer + CSS). site/home.html holds the body; site/assets/home.css the styles.
 const HOME_DESC = SITE_DESC;
 function renderHome(): string {
-  const body = readFileSync(SITE + "home.html", "utf8");
+  const body = injectSiteFooterDescription(readFileSync(SITE + "home.html", "utf8"));
   const jsonLd = JSON.stringify({
     "@context": "https://schema.org",
     "@type": "SoftwareSourceCode",

--- a/site/home.html
+++ b/site/home.html
@@ -603,7 +603,7 @@
             </svg>
             <span>PocketJS</span>
           </a>
-          <p>A compact JavaScript runtime for UI, games, 3D and AI-native software, carried to radically different devices by a tiny native core.</p>
+          <p>{{SITE_FOOTER_DESC}}</p>
         </div>
         <div>
           <h4>Docs</h4>

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -10,7 +10,19 @@ export const SITE_URL = "https://pocketjs.dev";
 export const SITE_TITLE = "PocketJS · Compact JavaScript Runtime for Rich Interactive Software";
 export const SITE_DESC =
   "A compact JavaScript runtime for building UI, games, 3D experiences and AI-native applications across radically different devices. A tiny JavaScript guest where it fits; the framework compiled away where it doesn't.";
+// Shared by the standalone homepage and every page rendered through renderPage().
+export const SITE_FOOTER_DESC =
+  "A compact JavaScript runtime for UI, games, 3D and AI-native software, carried to radically different devices by a tiny native core.";
+export const SITE_FOOTER_DESC_SLOT = "{{SITE_FOOTER_DESC}}";
 export const OG_IMAGE_URL = `${SITE_URL}/og-image.png`;
+
+export function injectSiteFooterDescription(template: string): string {
+  const slots = template.split(SITE_FOOTER_DESC_SLOT).length - 1;
+  if (slots !== 1) {
+    throw new Error(`Expected ${SITE_FOOTER_DESC_SLOT} exactly once in the homepage template; found ${slots}`);
+  }
+  return template.replace(SITE_FOOTER_DESC_SLOT, () => SITE_FOOTER_DESC);
+}
 
 export interface PageOpts {
   title: string | null; // null uses the bare wordmark (homepage)
@@ -69,7 +81,7 @@ const footer = `<footer class="mt-24 border-t border-line/70 bg-ink-2/60">
     <div class="grid gap-10 sm:grid-cols-2 lg:grid-cols-4">
       <div>
         <div class="flex items-center gap-2 font-semibold text-slate-100">${LOGO}<span>PocketJS</span></div>
-        <p class="mt-3 max-w-xs text-sm text-slate-400">Vue Vapor and Solid UI under 8 MB RAM, rendered through a tiny native core.</p>
+        <p class="mt-3 max-w-xs text-sm text-slate-400">${SITE_FOOTER_DESC}</p>
       </div>
       <div class="text-sm">
         <h4 class="mb-3 font-semibold text-slate-200">Docs</h4>

--- a/tests/site-stage.test.ts
+++ b/tests/site-stage.test.ts
@@ -4,6 +4,12 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { emitSingleLodStagePackage } from "../site/stage-package.ts";
 import { BTN, PocketHost } from "../site/playground/host.js";
+import {
+  SITE_FOOTER_DESC,
+  SITE_FOOTER_DESC_SLOT,
+  injectSiteFooterDescription,
+  renderPage,
+} from "../site/templates.ts";
 
 const ROOT = new URL("..", import.meta.url).pathname;
 const PACKAGE = ROOT + "engine/pocket3d/examples/handheld/assets/dibad-psp/";
@@ -88,6 +94,24 @@ test("homepage declares the live launcher and visible attributions", () => {
     const source = readFileSync(ROOT + ".github/workflows/" + workflow, "utf8");
     expect(source).toContain("bun run site:build");
   }
+});
+
+test("homepage and shared pages use one footer description", () => {
+  const homeTemplate = readFileSync(ROOT + "site/home.html", "utf8");
+  const siteBuild = readFileSync(ROOT + "site/build.ts", "utf8");
+  expect(homeTemplate).toContain(SITE_FOOTER_DESC_SLOT);
+  expect(homeTemplate).not.toContain(SITE_FOOTER_DESC);
+  expect(siteBuild).toContain('injectSiteFooterDescription(readFileSync(SITE + "home.html", "utf8"))');
+
+  const homepage = injectSiteFooterDescription(homeTemplate);
+  const sharedPage = renderPage({ title: "Docs", active: "docs", body: "" });
+  for (const html of [homepage, sharedPage]) {
+    expect(html.split(SITE_FOOTER_DESC)).toHaveLength(2);
+    expect(html).not.toContain(SITE_FOOTER_DESC_SLOT);
+  }
+
+  expect(() => injectSiteFooterDescription("")).toThrow("found 0");
+  expect(() => injectSiteFooterDescription(SITE_FOOTER_DESC_SLOT.repeat(2))).toThrow("found 2");
 });
 
 test("public PocketJS icon surfaces keep the metal mark on a black backing", () => {


### PR DESCRIPTION
## Summary

- replace the stale shared-page footer text with the homepage description
- keep the description in one exported site constant and inject it into the standalone homepage template
- fail on missing or duplicate placeholders and cover both rendering paths with a regression test

## Validation

- bun test tests/site-stage.test.ts
- bun run site:build
- bunx tsc --noEmit
- git diff --check