### PR TITLE
fix(psp): stop the arena stranding memory a QuickJS boot needs

### DIFF
--- a/hosts/psp/src/arena.rs
+++ b/hosts/psp/src/arena.rs
@@ -128,6 +128,18 @@ fn class_of(need: usize) -> usize {
     c
 }
 
+/// True when `old` and `new` bytes land in the same class, i.e. a block already
+/// sized for `old` also holds `new`. A grow that stays inside its class owns the
+/// bytes already, so a caller can keep the pointer instead of copying (see
+/// qjs_alloc's realloc: QuickJS grows buffers geometrically, and half of those
+/// grows stay in class).
+#[inline]
+pub fn same_class(old: usize, new: usize, align: usize) -> bool {
+    let a = if align < 16 { 16 } else { align };
+    let norm = |n: usize| if n > a { n } else { a };
+    old != 0 && new != 0 && class_of(norm(old)) == class_of(norm(new))
+}
+
 /// Allocate `size` bytes aligned to `align` from the arena (null on OOM).
 #[inline]
 pub unsafe fn alloc(size: usize, align: usize) -> *mut u8 {
@@ -152,11 +164,43 @@ pub unsafe fn alloc(size: usize, align: usize) -> *mut u8 {
     // Carve a fresh 2^c block from the bump pointer, aligned to `a` (minimal waste).
     let p = (BUMP + a - 1) & !(a - 1);
     let np = p + (1usize << c);
-    if np > BUMP_END {
-        return ptr::null_mut();
+    if np <= BUMP_END {
+        BUMP = np;
+        return p as *mut u8;
     }
-    BUMP = np;
-    p as *mut u8
+    // The bump is spent. Before failing, split a larger free block: classes
+    // strand memory, because a buffer grown geometrically frees each old size
+    // into a class nothing asks for again (a one-shot boot that parses a
+    // megabyte of JSON can strand megabytes this way). Halving a free 2^k
+    // block yields two 2^(k-1) blocks, so any larger class can serve this one.
+    // Deliberately last: until the bump runs dry this allocator behaves exactly
+    // as before, and big blocks stay whole for the callers that want them.
+    let mut c2 = c + 1;
+    while c2 < NCLASS {
+        let big = FREE[c2];
+        if big.is_null() {
+            c2 += 1;
+            continue;
+        }
+        FREE[c2] = *(big as *mut *mut u8);
+        let base = big as usize;
+        let mut k = c2;
+        while k > c {
+            k -= 1;
+            let half = (base + (1usize << k)) as *mut u8;
+            *(half as *mut *mut u8) = FREE[k];
+            FREE[k] = half;
+        }
+        if base & (a - 1) == 0 {
+            return base as *mut u8;
+        }
+        // Alignment miss (only for align > 16): keep the block in its class
+        // rather than leaking it, and report OOM like the pre-split path did.
+        *(base as *mut *mut u8) = FREE[c];
+        FREE[c] = base as *mut u8;
+        break;
+    }
+    ptr::null_mut()
 }
 
 /// Free a pointer previously returned by `alloc` with the SAME size + align.

--- a/hosts/psp/src/qjs_alloc.rs
+++ b/hosts/psp/src/qjs_alloc.rs
@@ -55,7 +55,15 @@ unsafe fn raw_realloc(p: *mut c_void, size: usize) -> *mut c_void {
     }
     let base = (p as *mut u8).sub(HEADER);
     let old = *(base as *mut usize);
-    // No in-place grow in the free-list heap: allocate, copy, free.
+    // In-place when the block already spans the new size: the arena rounds
+    // every request up to its power-of-two class, so a grow that stays inside
+    // the class owns those bytes already. QuickJS grows its string and array
+    // builders geometrically, so this skips both the copy and the churn that
+    // would strand the old block in a class nothing asks for again.
+    if arena::same_class(old + HEADER, size + HEADER, 16) {
+        *(base as *mut usize) = size;
+        return p;
+    }
     let np = raw_alloc(size);
     if np.is_null() {
         return ptr::null_mut();


### PR DESCRIPTION
## The bug

A guest whose boot parses a megabyte of JSON runs the PSP arena out of memory **while megabytes sit free**. The sub-allocator's power-of-two size classes never hand a block to a different class, and QuickJS grows its string and array builders geometrically: every grow allocated a bigger block, copied, and freed the old one into a class nothing asks for again.

Found on a real PSP-2000 with [Pocket Voxel](https://github.com/pocket-stack/pocket-voxel): its 32 MB pak leaves the arena ~14 MB, the guest boot peaked past **15.5 MB**, and `JS_Eval` threw the *null* exception that means "out of memory before an `Error` object could even be built."

Measured on the device by raising `POCKETJS_ARENA_BYTES` in steps:

| arena | result |
| --- | --- |
| 14.2 MB (default) | OOM at `JS_Eval` |
| 15.5 MB | OOM at `JS_Eval` |
| 19.0 MB | boots |

The same bundle needs only **12.3 MB** under desktop QuickJS (`qjs --memory-limit`), so ~25% of the device heap was going to class rounding and stranding.

## The fix

- **`qjs_alloc`'s realloc keeps the pointer when the new size stays inside the block's class.** The arena rounds every request up to a power of two, so those bytes are already owned: no copy, and no freed block to strand. This is the common case for geometric growth.
- **`arena::alloc` splits a larger free block when the bump is spent**, halving down to the class it needs. Deliberately the *last* resort — a heap with room behaves exactly as before, and large blocks stay whole for the callers that want them.

## Verification

Pocket Voxel, same 32 MB pak, **default arena size**:

- Real PSP-2000 over PSPLINK: boots and renders (previously OOM). Screenshot in the linked repo's issue thread.
- `bun tests/e2e/voxel-ppsspp.ts`: **11/11 marks live**, every mark within the AE tolerance.
- `bun tools/voxel.ts check`: frame-hash goldens hold at both quality rungs (exit 0).
- `bun test tests/`: 226 pass, 47,715 assertions.

Nothing about rendering or determinism moves — the allocator is invisible to output, which is why the goldens are the right gate here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)