### PR TITLE
fix(vapor): allow env overrides for mgba and cc65 toolchain paths

### DIFF
--- a/vapor/compiler/rom.ts
+++ b/vapor/compiler/rom.ts
@@ -17,7 +17,7 @@ import {
 } from "./playdate.ts";
 
 const RUNTIME = join(import.meta.dir, "..", "runtime");
-const CC65_LIB = "/opt/homebrew/share/cc65/lib/none.lib";
+const CC65_LIB = process.env.CC65_LIB ?? "/opt/homebrew/share/cc65/lib/none.lib";
 
 // The GBA BIOS validates these 156 bytes at boot on real hardware; every
 // homebrew toolchain (gbafix, devkitARM, tonc) ships the same table.

--- a/vapor/tests/harness/build.ts
+++ b/vapor/tests/harness/build.ts
@@ -5,7 +5,7 @@
 import { $ } from "bun";
 import { join } from "node:path";
 
-const prefix = (await $`brew --prefix mgba`.text()).trim();
+const prefix = process.env.MGBA_PREFIX ?? (await $`brew --prefix mgba`.text()).trim();
 const here = import.meta.dir;
 const out = join(here, "mgba_runner");
 


### PR DESCRIPTION
The parity harness assumes a macOS Homebrew layout in two places: `vapor/tests/harness/build.ts` resolves libmgba through `brew --prefix mgba`, and `vapor/compiler/rom.ts` hardcodes `/opt/homebrew/share/cc65/lib/none.lib`. On a Linux host neither holds — Linuxbrew installs cc65 under `/home/linuxbrew/.linuxbrew`, and the current Linuxbrew mgba bottle links against ffmpeg sonames (`libavcodec.so.62`) that its own ffmpeg dependency no longer provides, so libmgba has to be built from source into a custom prefix anyway.

This adds two environment overrides, keeping the existing defaults for macOS:

- `MGBA_PREFIX` — prefix containing `include/mgba` and `lib/libmgba.so` for the harness runner build
- `CC65_LIB` — path to cc65's `none.lib` for the NES link step

Verified on Linux (x64): with libmgba 0.10 built from source (`-DBUILD_QT=OFF -DBUILD_SDL=OFF -DUSE_FFMPEG=OFF ...`) and sdcc/rgbds/cc65 from Linuxbrew, the full suite runs — **75 tests, 7,414 assertions, 0 fail**, including the three-console oracle↔ROM parity over the 31-press tape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)