### PR TITLE
feat(vapor): overlay allocation for frame-local temporaries

### DIFF
--- a/vapor/DESIGN.md
+++ b/vapor/DESIGN.md
@@ -101,8 +101,19 @@ The runtime never calls `malloc` and never frees:
   inside their record. Exceeding a budget drops the operation and raises a
   tripwire flag the debug block exposes — never UB.
 - **Bounded strings** — a `ref<string>` is a `{len, bytes[24]}` slot;
-  string expressions build into stack scratch and assign through a
+  string expressions build into overlay scratch and assign through a
   change-compare (Vue's `Object.is` set gate, by value).
+- **Overlay slots for frame-local temporaries** — materialized view
+  chains and string scratch compile to shared static slots, not
+  per-site statics or C-stack frames. Every temporary is tagged with the
+  generated function that owns it; two temporaries share a slot unless
+  their owners can be live at the same time — same function, or one
+  reachable from the other in the static call graph (helpers, computed
+  accessors, keymap dispatch). The subset forbids recursion and nothing
+  runs from interrupts, so reachability is the whole liveness story. On
+  the 6502 and SM83 this also converts stack-relative addressing into
+  absolute addressing, which is smaller and faster; the compiler prints
+  the overlay plan (slots, bytes, temps served) with the memory plan.
 
 Nothing is ever collected because nothing is ever untracked: object shapes
 are closed (the TS subset forbids dynamic keys), so lifetime is the pool

--- a/vapor/compiler/compile.ts
+++ b/vapor/compiler/compile.ts
@@ -266,6 +266,95 @@ class AppCompiler {
    * ternary/if branches drop their dead arm from masks and ROM alike. */
   private sccpFolded: Map<string, number> | null = null;
 
+  // ---- overlay allocation of frame-local temporaries -----------------------
+  // Materialized view chains and string scratch used to be either permanent
+  // statics (a `vt` lives forever for one call's worth of work) or C-stack
+  // locals (21-33 B frames on the cc65/sdcc software stack). Both are wrong
+  // for the 8-bit targets: statics never share, stack frames cost code and
+  // cycles on every access. Instead every temporary is tagged with the
+  // generated function that owns it; two temporaries may share one static
+  // slot unless their owners can be live at the same time — same owner, or
+  // one owner reachable from the other in the static call graph (helpers,
+  // computed accessors, keymap actions). The subset forbids recursion and
+  // nothing runs from interrupts, so reachability is the whole story.
+  // Placeholders are substituted with colored slot names at emit time.
+  private ovlTemps: { id: number; kind: "view" | "sb"; owner: string }[] = [];
+  private ovlEdges = new Map<string, Set<string>>(); // caller -> callees
+  private ovlOwnerStack: string[] = [];
+  private unitCounter = 0;
+
+  private ovlOwner(): string {
+    return this.ovlOwnerStack[this.ovlOwnerStack.length - 1] ?? "app_init";
+  }
+
+  private withOwner<T>(owner: string, build: () => T): T {
+    this.ovlOwnerStack.push(owner);
+    try {
+      return build();
+    } finally {
+      this.ovlOwnerStack.pop();
+    }
+  }
+
+  private allocTemp(kind: "view" | "sb"): string {
+    const id = this.ovlTemps.length;
+    this.ovlTemps.push({ id, kind, owner: this.ovlOwner() });
+    return `@OVL${id}@`;
+  }
+
+  private ovlCall(callee: string): void {
+    const caller = this.ovlOwner();
+    if (caller === callee) return;
+    let set = this.ovlEdges.get(caller);
+    if (!set) this.ovlEdges.set(caller, (set = new Set()));
+    set.add(callee);
+  }
+
+  /** Color temporaries into shared static slots; returns decls + name map. */
+  private ovlAssign(): { decls: string[]; names: Map<number, string>; slotBytes: number } {
+    // transitive reachability over owners
+    const reach = new Map<string, Set<string>>();
+    const reaches = (from: string, to: string): boolean => {
+      let r = reach.get(from);
+      if (!r) {
+        r = new Set();
+        reach.set(from, r);
+        const walk = (o: string) => {
+          for (const callee of this.ovlEdges.get(o) ?? []) {
+            if (!r!.has(callee)) {
+              r!.add(callee);
+              walk(callee);
+            }
+          }
+        };
+        walk(from);
+      }
+      return r.has(to);
+    };
+    const interferes = (a: { owner: string }, b: { owner: string }): boolean =>
+      a.owner === b.owner || reaches(a.owner, b.owner) || reaches(b.owner, a.owner);
+
+    const names = new Map<number, string>();
+    const decls: string[] = [];
+    let slotBytes = 0;
+    for (const kind of ["view", "sb"] as const) {
+      const temps = this.ovlTemps.filter((t) => t.kind === kind);
+      const slots: { name: string; members: { owner: string }[] }[] = [];
+      for (const t of temps) {
+        let slot = slots.find((s) => s.members.every((m) => !interferes(t, m)));
+        if (!slot) {
+          slot = { name: `ovl_${kind}${slots.length}`, members: [] };
+          slots.push(slot);
+          decls.push(`static ${kind === "view" ? "vp_view" : "vp_sb"} ${slot.name};`);
+          slotBytes += kind === "view" ? 1 + this.target.poolCap : 1 + this.target.strCap;
+        }
+        slot.members.push(t);
+        names.set(t.id, slot.name);
+      }
+    }
+    return { decls, names, slotBytes };
+  }
+
   constructor(
     private sf: ts.SourceFile,
     private title: string,
@@ -651,13 +740,13 @@ class AppCompiler {
 
   private compileActionArrow(cName: string, arrow: ts.ArrowFunction): void {
     const saved = new Map(this.scope);
-    const { decls, body } = this.withHoist((out) => {
+    const { decls, body } = this.withOwner(cName, () => this.withHoist((out) => {
       if (ts.isBlock(arrow.body)) {
         for (const stmt of arrow.body.statements) this.compileStmt(stmt, out, "  ");
       } else {
         this.compileExprStmt(arrow.body, out, "  ");
       }
-    });
+    }));
     this.scope = saved;
     this.bodies.push(`static void ${cName}(void) {\n${[...decls, ...body].join("\n")}\n}\n`);
   }
@@ -667,7 +756,10 @@ class AppCompiler {
     e = this.unparen(e);
     if (ts.isIdentifier(e)) {
       const b = this.scope.get(e.text);
-      return b?.kind === "keymap" ? `KM_${b.name}` : null;
+      if (b?.kind !== "keymap") return null;
+      // indirect dispatch: the caller may enter any action in this table
+      for (const cName of b.entries.values()) this.ovlCall(cName);
+      return `KM_${b.name}`;
     }
     if (ts.isConditionalExpression(e)) {
       const a = this.compileKeymapExpr(e.whenTrue, out, ind);
@@ -727,7 +819,7 @@ class AppCompiler {
 
     const index = this.computeds.length;
     let binding!: ComputedBinding;
-    const hoisted = this.withHoist((lines) => {
+    const hoisted = this.withOwner(`c_${name}_update`, () => this.withHoist((lines) => {
     if (this.isViewExpr(body)) {
       const maxLen = this.viewMaxLen(body);
       binding = { kind: "computed", name, index, valTy: this.viewTyOf(body), deps, maxLen };
@@ -746,7 +838,7 @@ class AppCompiler {
       };
       lines.push(`  c_${name}_v = ${val.c};`);
     }
-    });
+    }));
     const lines = [...hoisted.decls, ...hoisted.body];
     this.curDeps = prevDeps;
 
@@ -1042,16 +1134,16 @@ class AppCompiler {
       }
       if (b?.kind === "computed" && b.valTy.k === "view") {
         for (const d of b.deps) this.depRef(d);
+        this.ovlCall(`c_${b.name}_update`);
         const v = this.tmp("v");
         this.declare(`const vp_view *${v};`);
         out.push(`${ind}${v} = c_${b.name}();`);
         return { len: `${v}->len`, at: (i) => `${v}->idx[${i}]` };
       }
     }
-    // nested filter/slice chain: materialize into a temp view
+    // nested filter/slice chain: materialize into an overlay temp view
     if (ts.isCallExpression(e)) {
-      const v = this.tmp("vt");
-      this.decls.push(`static vp_view ${v};`);
+      const v = this.allocTemp("view");
       this.compileViewInto(e, v, out, ind);
       return { len: `${v}.len`, at: (i) => `${v}.idx[${i}]` };
     }
@@ -1110,6 +1202,7 @@ class AppCompiler {
       }
       if (b?.kind === "computed") {
         for (const d of b.deps) this.depRef(d);
+        this.ovlCall(`c_${base}_update`);
         if (b.valTy.k === "num") return { c: `c_${base}()`, ty: NUM };
         if (b.valTy.k === "obj") return { c: `c_${base}()`, ty: b.valTy };
         this.err(e, "view computeds can only be used through list operations");
@@ -1255,6 +1348,7 @@ class AppCompiler {
         });
         this.emitFn(b);
         for (const d of b.deps) this.depRef(d);
+        this.ovlCall(`fn_${b.name}`);
         return { c: `fn_${b.name}(${args.join(", ")})`, ty: { k: "void" } };
       }
     }
@@ -1314,7 +1408,8 @@ class AppCompiler {
       const b = e.arguments[1]
         ? this.compileExpr(e.arguments[1], out, ind)
         : { c: `(s32)(${srcV.c})->len`, ty: NUM };
-      out.push(`${ind}{ vp_sb sl; vp_sb_slice(&sl, ${srcV.c}, ${a.c}, ${b.c}); vp_sb_sb(&${sb}, &sl); }`);
+      const sl = this.allocTemp("sb");
+      out.push(`${ind}{ vp_sb_slice(&${sl}, ${srcV.c}, ${a.c}, ${b.c}); vp_sb_sb(&${sb}, &${sl}); }`);
       return;
     }
     const v = this.compileExpr(e, out, ind);
@@ -1511,8 +1606,8 @@ class AppCompiler {
         return;
       }
       if (b.refTy === "str") {
-        const tmp = this.tmp("sb");
-        out.push(`${ind}{ vp_sb ${tmp}; vp_sb_reset(&${tmp});`);
+        const tmp = this.allocTemp("sb");
+        out.push(`${ind}{ vp_sb_reset(&${tmp});`);
         this.compileStringInto(rhs, tmp, out, ind + "  ");
         out.push(`${ind}  if (vp_sb_assign(&g_${b.name}, &${tmp})) ${this.markCode(b.name)};`);
         out.push(`${ind}}`);
@@ -1526,9 +1621,9 @@ class AppCompiler {
           this.err(rhs, "list refs can only be assigned a filter/slice view");
         if (this.viewListRef(this.unparen(rhs)) !== b.name)
           this.err(rhs, "list assignment must derive from the same list");
-        const nv = this.tmp("nv");
+        const nv = this.allocTemp("view");
         const k = this.tmp("k");
-        out.push(`${ind}{ vp_view ${nv}; u8 ${k};`);
+        out.push(`${ind}{ u8 ${k};`);
         this.compileViewInto(this.unparen(rhs), nv, out, ind + "  ");
         out.push(`${ind}  for (${k} = 0; ${k} < ${nv}.len; ${k}++) *(g_${b.name} + (u16)${k}) = *(g_${b.name} + (u16)(${nv}.idx[${k}]));`);
         out.push(`${ind}  g_${b.name}_len = ${nv}.len;`);
@@ -1572,8 +1667,8 @@ class AppCompiler {
       const field = iface.fields.find((f) => f.name === (propNode.name as ts.Identifier).text);
       if (!field) this.err(propNode, `no field ${propNode.name.getText(this.sf)} on ${iface.name}`);
       if (field.ty === "str") {
-        const tmp = this.tmp("sb");
-        out.push(`${ind}  { vp_sb ${tmp}; vp_sb_reset(&${tmp});`);
+        const tmp = this.allocTemp("sb");
+        out.push(`${ind}  { vp_sb_reset(&${tmp});`);
         this.compileStringInto(propNode.initializer, tmp, out, ind + "    ");
         out.push(`${ind}    vp_sb_assign(&np->${field.name}, &${tmp}); }`);
       } else {
@@ -1609,10 +1704,10 @@ class AppCompiler {
     const prevDeps = this.curDeps;
     this.curDeps = b.deps;
     const saved = new Map(this.scope);
-    const { decls, body } = this.withHoist((out) => {
+    const { decls, body } = this.withOwner(`fn_${b.name}`, () => this.withHoist((out) => {
       for (const p of b.params) this.scope.set(p, { kind: "local", cName: `p_${p}`, ty: NUM });
       for (const stmt of b.decl.body!.statements) this.compileStmt(stmt, out, "  ");
-    });
+    }));
     this.scope = saved;
     this.curDeps = prevDeps;
     const sig = b.params.length ? b.params.map((p) => `s32 p_${p}`).join(", ") : "void";
@@ -1869,9 +1964,13 @@ class AppCompiler {
     const deps = new Set<string>();
     const prev = this.curDeps;
     this.curDeps = deps;
-    const { decls, body } = this.withHoist((out) => {
-      this.compileRowPaint(src, String(y), out, "  ");
-    });
+    // each unit is its own overlay owner: merged units run sequentially
+    // inside one effect, so their temps may share slots
+    const { decls, body } = this.withOwner(`unit${this.unitCounter++}`, () =>
+      this.withHoist((out) => {
+        this.compileRowPaint(src, String(y), out, "  ");
+      }),
+    );
     this.curDeps = prev;
     this.propsCtx = prevCtx;
     return { span: [y, y + 1], deps, decls, body, isStatic: deps.size === 0 };
@@ -1901,7 +2000,7 @@ class AppCompiler {
     const prev = this.curDeps;
     this.curDeps = deps;
     let y = 0;
-    const { decls, body } = this.withHoist((out) => {
+    const { decls, body } = this.withOwner(`unit${this.unitCounter++}`, () => this.withHoist((out) => {
       const cond = this.compileExpr(e.condition, out, "  ");
       const { src, ctx } = this.resolveRenderable(whenTrue);
       const prevCtx = this.propsCtx;
@@ -1911,7 +2010,7 @@ class AppCompiler {
       this.compileRowPaint(src, String(y), out, "    ");
       out.push(`  }`);
       this.propsCtx = prevCtx;
-    });
+    }));
     this.curDeps = prev;
     return { span: [y, y + 1], deps, decls, body, isStatic: false };
   }
@@ -1938,7 +2037,7 @@ class AppCompiler {
     this.curDeps = deps;
     let yBase = 0;
     let maxLenOut = 0;
-    const { decls, body } = this.withHoist((body) => {
+    const { decls, body } = this.withOwner(`unit${this.unitCounter++}`, () => this.withHoist((body) => {
     const src = this.viewSource(viewExpr, body, "  ");
     const listRef = this.viewListRef(viewExpr);
     const iface = this.viewIface(viewExpr);
@@ -1970,7 +2069,7 @@ class AppCompiler {
     body.push(`  } }`);
     yBase = yBaseInner;
     maxLenOut = maxLen;
-    });
+    }));
     this.curDeps = prev;
 
     const span: [number, number] = [yBase, Math.min(this.target.height, yBase + maxLenOut)];
@@ -2004,13 +2103,13 @@ class AppCompiler {
       if (!param) this.err(this.handler, "onButton arrow needs a (b) param");
       this.scope.set(param, { kind: "local", cName: "b_arg", ty: NUM });
       const handlerArrow = this.handler;
-      const { decls, body } = this.withHoist((out) => {
+      const { decls, body } = this.withOwner("app_on_button", () => this.withHoist((out) => {
         if (ts.isBlock(handlerArrow.body)) {
           for (const stmt of handlerArrow.body.statements) this.compileStmt(stmt, out, "  ");
         } else {
           this.compileExprStmt(handlerArrow.body, out, "  ");
         }
-      });
+      }));
       handlerOut = [...decls, ...body];
       this.scope = saved;
     }
@@ -2027,13 +2126,13 @@ class AppCompiler {
         cName: "axis_delta_arg",
         ty: NUM,
       });
-      const { decls, body } = this.withHoist((out) => {
+      const { decls, body } = this.withOwner(`vp_axis_handler_${axis}`, () => this.withHoist((out) => {
         if (ts.isBlock(handler.body)) {
           for (const stmt of handler.body.statements) this.compileStmt(stmt, out, "  ");
         } else {
           this.compileExprStmt(handler.body, out, "  ");
         }
-      });
+      }));
       axisHandlerFns.push(
         `static void vp_axis_handler_${axis}(s32 axis_delta_arg) {\n${[...decls, ...body].join("\n")}\n}`,
       );
@@ -2110,6 +2209,10 @@ class AppCompiler {
         dbgOff += 4;
       }
     }
+
+    // ---- overlay slot coloring (all bodies are emitted by now) ----
+    const ovl = this.ovlAssign();
+    if (ovl.decls.length) this.decls.push(...ovl.decls);
 
     // ---- assemble C ----
     const c: string[] = [];
@@ -2292,12 +2395,13 @@ class AppCompiler {
           : pairCount;
     const planLines = [
       `state RAM: ${scalarBytes} B scalars/strings + ${poolBytes} B pools + ${viewBytes} B computed views`,
+      `overlay RAM: ${ovl.slotBytes} B in ${ovl.decls.length} shared slots (${this.ovlTemps.length} frame-local temps off the C stack)`,
       `reactive tables: ${this.refs.length} dirty bits, ${this.computeds.length} validity bits, ${effects.length} effects`,
       `ROM data: ${romStrings} B strings + ${fontBytes} B font + ${styleBytes} B style data`,
     ];
 
     return {
-      c: c.join("\n"),
+      c: c.join("\n").replace(/@OVL(\d+)@/g, (_m, id) => ovl.names.get(Number(id))!),
       title: this.title,
       graph: graphLines.join("\n"),
       plan: planLines.join("\n"),

--- a/vapor/compiler/rom.ts
+++ b/vapor/compiler/rom.ts
@@ -186,7 +186,11 @@ MEMORY {
   CHR: start = $0000, size = $2000, type = ro, file = %O, fill = yes;
   ZP: start = $0002, size = $00fa, type = rw;
   DEBUGRAM: start = $0200, size = $0358, type = rw;
-  RAM: start = $0558, size = $01a8, type = rw;
+  # RAM ends at $0720; the cc65 soft stack runs $0720-$07FF (crt0 inits sp
+  # to $07FF). The 32-byte extension over the old $0700 boundary is funded
+  # by the overlay allocator: the >=42 B of vp_sb/vp_view frames it moved
+  # off the deepest stack path exceed the 32 B taken, so stack margin grows.
+  RAM: start = $0558, size = $01c8, type = rw;
 }
 SEGMENTS {
   HEADER: load = HDR, type = ro;

--- a/vapor/tests/overlay.test.ts
+++ b/vapor/tests/overlay.test.ts
@@ -1,0 +1,105 @@
+// vapor/tests/overlay.test.ts — overlay allocation of frame-local temps.
+//
+// Materialized view chains and string scratch compile to shared static
+// slots instead of permanent statics / C-stack frames. Two temps share a
+// slot unless their owners can be live at once: same generated function,
+// or one reachable from the other through helpers, computed accessors, or
+// keymap dispatch.
+
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { compileVaporApp } from "../compiler/compile.ts";
+
+const ENTRY = join(import.meta.dir, "..", "examples", "todo", "todo.tsx");
+
+const HEADER = `
+import { computed, ref } from "vue";
+import { Button, onButton } from "../../host/input.ts";
+`;
+
+function slots(c: string, kind: "view" | "sb"): string[] {
+  return [...c.matchAll(new RegExp(`static vp_${kind} (ovl_${kind}\\d+);`, "g"))].map((m) => m[1]);
+}
+
+describe("overlay allocation", () => {
+  test("todo/nes: all large frame-locals leave the C stack into 3 shared slots", async () => {
+    const source = await Bun.file(ENTRY).text();
+    const app = compileVaporApp(ENTRY, source, "VAPOR TODO", "nes");
+    expect(app.plan).toContain("overlay RAM: 51 B in 3 shared slots (8 frame-local temps off the C stack)");
+    expect(slots(app.c, "view")).toEqual(["ovl_view0"]);
+    expect(slots(app.c, "sb")).toEqual(["ovl_sb0", "ovl_sb1"]);
+    // no vp_sb/vp_view stack frames remain in function bodies
+    expect(app.c).not.toMatch(/\{ vp_sb sb/);
+    expect(app.c).not.toMatch(/\{ vp_view /);
+    // and no permanent per-chain statics either
+    expect(app.c).not.toMatch(/static vp_view vt/);
+  });
+
+  test("temps in mutually-exclusive keymap actions share one slot", () => {
+    const src = `${HEADER}
+export default () => {
+  const a = ref("x");
+  const bb = ref("y");
+  const keys = {
+    [Button.A]: () => { a.value = a.value + "!"; },
+    [Button.B]: () => { bb.value = bb.value + "?"; },
+  };
+  onButton((b) => {
+    keys[b]?.();
+  });
+  return (
+    <>
+      <row y={0}>{a.value}{bb.value}</row>
+    </>
+  );
+};
+`;
+    const app = compileVaporApp("ovl.tsx", src);
+    // two sb temps, one per action; actions are dispatch-exclusive, so they
+    // interfere with the handler but not with each other -> one slot
+    expect(slots(app.c, "sb")).toEqual(["ovl_sb0"]);
+  });
+
+  test("nested slice scratch interferes with its enclosing string build", () => {
+    const src = `${HEADER}
+export default () => {
+  const s = ref("hello");
+  onButton((b) => {
+    if (b === Button.A) s.value = s.value.slice(0, -1);
+  });
+  return (
+    <>
+      <row y={0}>{s.value}</row>
+    </>
+  );
+};
+`;
+    const app = compileVaporApp("ovl.tsx", src);
+    // outer build target + nested slice scratch live at once -> two slots
+    expect(slots(app.c, "sb")).toEqual(["ovl_sb0", "ovl_sb1"]);
+  });
+
+  test("view temps split when an effect's chain reads through a computed's chain", () => {
+    const src = `${HEADER}
+interface T { n: number; done: boolean; }
+export default () => {
+  const items = ref<T[]>([{ n: 1, done: false }]);
+  const doneCount = computed(() => items.value.filter((t) => t.done).length);
+  onButton((b) => {
+    if (b === Button.A) items.value.push({ n: doneCount.value, done: false });
+  });
+  return (
+    <>
+      {items.value.slice(0, 0 + 4).map((t, i) => (
+        <row y={i}>{t.n} of {doneCount.value}</row>
+      ))}
+    </>
+  );
+};
+`;
+    const app = compileVaporApp("ovl.tsx", src);
+    // the map unit's slice temp is live across c_doneCount_update, whose
+    // filter().length also materializes a temp -> reachability forces 2 slots
+    expect(slots(app.c, "view")).toEqual(["ovl_view0", "ovl_view1"]);
+  });
+});


### PR DESCRIPTION
> Stacked on #268 (its toolchain-path commit is included here so the parity suite runs on Linux; rebases away once #268 lands).

## What

Materialized view chains and string scratch used to be either **permanent statics** (`static vp_view vt5` lives forever for one call's worth of work) or **C-stack locals** (21–33 B `vp_sb`/`vp_view` frames on the cc65/sdcc software stack). Both are wrong for the 8-bit targets: statics never share, stack frames cost code and cycles on every access, and on the NES the stack shares 2 KB with the pool, the computed views, and the shadow grid.

This PR compiles every frame-local temporary into a **shared static overlay slot** — the classic 6502/8051 overlay technique, driven by the compiler's own call graph.

## How

- Every temporary is tagged with the generated function that owns it (effect unit, computed update, handler, keymap action, helper).
- Two temporaries may share one slot unless their owners can be live at the same time: same function, or one owner reachable from the other in the static call graph. Helpers, computed accessors, and keymap dispatch contribute edges — an indirect dispatch edges to every action in its table.
- The subset forbids recursion and nothing runs from interrupts, so reachability is the whole liveness story. Units merged into one effect run sequentially, so their temps share slots naturally.
- Greedy coloring assigns slots; placeholders substitute at emit time; the memory plan prints the overlay plan:
  ```
  overlay RAM: 51 B in 3 shared slots (8 frame-local temps off the C stack)
  ```

## Measured on the todo example

| target | ROM | RAM/stack |
|---|---|---|
| NES | CODE **8,806 → 8,666 B (−140 B)** — absolute beats stack-relative on the 6502 | 8 temps → 3 slots; ≥42 B of frames leave the deepest stack path; RAM/stack boundary moves up 32 B (funded by those 42 B, so stack margin grows) |
| GB | used bytes **11,413 → 11,383 (−30 B)** | SM83 stack relieved; RAM impact negligible in 8 KB |
| GBA | 9,328 → 9,356 B (+28 B) | ARM stack addressing is cheap, so the slot indirection costs slightly more there — the honest cost of a uniform lowering |

The structural point for the NES: string scratch and view materialization no longer scale the *stack* with app complexity — they scale a statically-known, deduplicated overlay region the memory plan accounts for byte-by-byte.

## Tests

- `vapor/tests/overlay.test.ts`: todo/NES slot inventory; mutually-exclusive keymap actions sharing one string slot; nested slice scratch interfering with its enclosing build; view temps splitting when an effect's chain reads through a computed's chain.
- Full suite **71 tests, 7,398 assertions, 0 fail** — including three-console oracle↔ROM parity, whose 31-press tape exercises every converted site (draft editing, glyph commit, filter cycling, clear-completed).
- `vapor/DESIGN.md` §3 documents the overlay model.

This is also groundwork for the storage-allocation direction discussed around #267: the owner/interference machinery is the substrate a future lifetime-aware packer (field narrowing, bool bit-packing) would build on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)