### PR TITLE
feat(mod): allow host-selected guest allocators

### DIFF
--- a/engine/crates/pocket-mod/src/lib.rs
+++ b/engine/crates/pocket-mod/src/lib.rs
@@ -36,7 +36,18 @@ impl Guest {
     /// Create an empty realm with `console.*` installed. Mount surfaces and
     /// eval the product bundle next; drop and rebuild for a hot reload.
     pub fn new() -> Result<Guest> {
-        let rt = Runtime::new()?;
+        Self::from_runtime(Runtime::new()?)
+    }
+
+    /// Create an empty realm backed by a host-selected QuickJS allocator.
+    pub fn new_with_alloc<A>(allocator: A) -> Result<Guest>
+    where
+        A: qjs::allocator::Allocator + 'static,
+    {
+        Self::from_runtime(Runtime::new_with_alloc(allocator)?)
+    }
+
+    fn from_runtime(rt: Runtime) -> Result<Guest> {
         let ctx = Context::full(&rt)?;
         ctx.with(|ctx| install_console(&ctx))
             .map_err(|e| anyhow!("pocket-mod: installing console: {e}"))?;


### PR DESCRIPTION
## Summary

- add Guest::new_with_alloc for host-selected QuickJS allocators
- share the existing context and console initialization through a private helper
- keep Guest::new behavior unchanged

## Why

Some constrained hosts need to place QuickJS heaps in a host-selected memory region. This API stays platform-neutral; allocator policy remains in the host.

## Validation

- cargo fmt --manifest-path engine/Cargo.toml -p pocket-mod -- --check
- cargo test --manifest-path engine/Cargo.toml -p pocket-mod
- cargo clippy --manifest-path engine/Cargo.toml -p pocket-mod --all-targets -- -D warnings