### PR TITLE
fix(compiler): close open contours before filling glyph outlines

### DIFF
--- a/framework/compiler/bake-font.ts
+++ b/framework/compiler/bake-font.ts
@@ -81,8 +81,22 @@ function flatten(path: Path, curveSteps = CURVE_STEPS): Contour[] {
   let sy = 0;
   let cx = 0;
   let cy = 0;
+  // A contour has to end where it began, or the scanline fill below sees an
+  // unpaired edge and the row leaks. `Z` would say so explicitly, but
+  // opentype.js emits no `Z` for either outline format: a TrueType contour
+  // happens to end on its start point already, so the closing edge is
+  // degenerate and nothing was ever wrong here. A CFF contour is closed
+  // implicitly by the format and left open in the command list, so the edge
+  // from the last point back to the first is simply missing. Closing it costs
+  // one compare per contour and makes the fill independent of which format the
+  // outline came from.
   const close = () => {
-    if (cur.length > 1) contours.push(cur);
+    if (cur.length > 1) {
+      const first = cur[0];
+      const last = cur[cur.length - 1];
+      if (first.x !== last.x || first.y !== last.y) cur.push({ x: first.x, y: first.y });
+      contours.push(cur);
+    }
     cur = [];
   };
   for (const cmd of path.commands) {

--- a/tests/font-bake.test.ts
+++ b/tests/font-bake.test.ts
@@ -51,3 +51,55 @@ describe("font atlas density", () => {
     expect(() => bakeSlot(font, 0, 16, false, codepoints, 256)).toThrow(/rasterDensity/);
   });
 });
+
+describe("open contours", () => {
+  /**
+   * A face whose one glyph is exactly the commands given.
+   *
+   * The point is the command list, not the face: opentype.js emits no `Z` for
+   * either outline format, and a TrueType contour returns to its start point on
+   * its own while a CFF contour does not. So the difference between the two
+   * formats, as this module sees it, is precisely the presence of that last
+   * point — which is what these two paths are.
+   */
+  const face = (commands: unknown[]): typeof font => {
+    const glyph = { advanceWidth: 600, getPath: () => ({ commands }) };
+    return {
+      unitsPerEm: 1000,
+      ascender: 800,
+      descender: -200,
+      tables: { hhea: { lineGap: 0 } },
+      charToGlyphIndex: (ch: string) => (ch === "A" ? 1 : 0),
+      glyphs: { get: () => glyph },
+    } as unknown as typeof font;
+  };
+
+  const SQUARE = [
+    { type: "M", x: 2, y: 2 },
+    { type: "L", x: 12, y: 2 },
+    { type: "L", x: 12, y: 12 },
+    { type: "L", x: 2, y: 12 },
+  ];
+  const CLOSED = [...SQUARE, { type: "L", x: 2, y: 2 }];
+
+  const bake = (commands: unknown[]) => bakeSlot(face(commands), 0, 16, false, [0x41], 1);
+
+  test("bake the same coverage as the closed outline they mean", () => {
+    const open = bake(SQUARE);
+    const closed = bake(CLOSED);
+    expect([...open.bytes]).toEqual([...closed.bytes]);
+  });
+
+  test("and that coverage is the filled square, not an empty cell", () => {
+    // Without this the assertion above is satisfied by two empty cells.
+    const { bytes, glyphCount, coverageW, coverageH } = bake(SQUARE);
+    const coverage = bytes.subarray(
+      FONT_HEADER_SIZE + glyphCount * FONT_CMAP_ENTRY_SIZE + coverageW * coverageH, // gid 1
+    );
+    const inked = coverage.filter((sample) => sample > 0).length;
+    // 10x10 px of ink, minus antialiasing at the edges; assert the order of
+    // magnitude rather than the exact count.
+    expect(inked).toBeGreaterThan(80);
+    expect(coverage.some((sample) => sample === 255)).toBe(true);
+  });
+});


### PR DESCRIPTION
## The bug

`flatten()` in `framework/compiler/bake-font.ts` hands each contour to the scanline fill exactly as opentype.js reports it, and **opentype.js emits no `Z` command for either outline format**.

For TrueType that has never mattered: the contour already ends on its start point, so the closing edge is degenerate and the fill sees a closed polygon. CFF closes a contour implicitly and leaves the command list open, so the edge from the last point back to the first is missing, the fill meets an unpaired crossing, and rows leak or drop.

So the baker works on every face this repository ships and silently mangles any OTF/CFF face — which is most CJK faces, and the reason I ran into it: baking Noto Sans SC produced glyphs with strokes cut short, chunks missing, and fills bleeding sideways out of the outline.

`永` at 24 px, before and after (coverage cell as ASCII):

```
       :+****:                   #%+-
         .=%@@%=                 +%@@@*:
            :*@@.                  .=%@@%=
    .-------- .-                      :*@@.
    +@@@@@@@@               .-------- .-
    -******%@               +@@@@@@@@
           %@-     .--      -******%@       :
           %@*    -%@-                 %@-     :%#
 -******=  %@%   -@%-                  %@*    -%@-
 *@@@@@@@: %@@= +@%.        -******=   %@%   -@%-
```

## The fix

One compare per contour: if the last point is not the first point, append the first point. It costs nothing and makes the fill independent of which format the outline came from.

## Blast radius, measured

Every face in the tree, baked at 24 px through both versions and compared byte for byte:

| face | glyphs baked | changed by this PR |
| --- | ---: | ---: |
| Noto Sans SC (CFF/OTF) | 218 | **151** |
| HarmonyOS Sans (TrueType) | 76 | 0 |
| Inter (TrueType, `DEFAULT_REGULAR`) | 76 | 0 |

**Inter bakes byte-identically**, so no atlas this repository produces today changes and no golden moves. The only outputs that move are the ones that were wrong.

## The test

`tests/font-bake.test.ts` gains a case that needs no font asset: the same square described twice — once ending on its start point (TrueType's shape), once not (CFF's) — must bake to identical bytes, and those bytes must be a filled square rather than an empty cell.

With this commit reverted both assertions fail, the open square baking to **zero ink**.

## Checks

`bun run test` — 385 pass. One pre-existing failure in this environment: `tests/note.test.ts` needs a wasm build that this machine's toolchain cannot produce (`can't find crate for core` for `wasm32-unknown-unknown`). It fails identically with this commit reverted.

## Deliberately not included

While tracking this down I also looked at the fill rule itself: the crossings are paired off two at a time, which is even-odd, while both outline formats are drawn for non-zero winding. Changing it is a one-function patch, but on all three faces above it makes **zero** difference once contours are closed, so it is a spec-conformance change with no reproduction behind it and does not belong in a bug-fix PR. Happy to open it separately if you want it.
