### PR TITLE
fix(playground): export TICKS_PER_SECOND from the browser clock module

### DIFF
--- a/site/playground/runtime-entry.ts
+++ b/site/playground/runtime-entry.ts
@@ -60,7 +60,7 @@ export {
   touches,
 } from "../../framework/src/input-api.ts";
 export { createWavPlayer } from "../../framework/src/audio-api.ts";
-export { ticksPerFrame } from "../../framework/src/clock.ts";
+export { TICKS_PER_SECOND, ticksPerFrame } from "../../framework/src/clock.ts";
 export { getOps, hostViewport } from "../../framework/src/host.ts";
 export { appTable, frozenShot, launchApp } from "../../framework/src/launcher.ts";
 


### PR DESCRIPTION
`main` fails `bun run site:build` — a release-workflow step — and has since #257 merged. This is what broke the v0.10.0 publish (the run failed at "Build documentation and public schema", before any npm publish, so both packages are untouched at 0.9.3).

## The failure

```
playground module audit failed:
  hero/solid: @pocketjs/framework/clock does not export TICKS_PER_SECOND
```

The playground serves every `@pocketjs/framework/*` specifier out of a few hand-written re-export modules (`site/build.ts`'s import map points `@pocketjs/framework/clock` at `/pg/runtime.js`, built from `site/playground/runtime-entry.ts`). That module named only `ticksPerFrame`. #257 made hero's headline and FPS tile derive from `TICKS_PER_SECOND`, and hero is a playground demo — so the audit added in #254 caught the drift, at release time.

## The fix

One line: name `TICKS_PER_SECOND` in the same re-export. Only the solid entry needs it — the vue-vapor and octane import maps carry no clock entry at all, and #257 changed only `apps/hero/app.tsx`, which is why the audit reported exactly `hero/solid`.

Verified: `bun run site:build` completes, **28 playground variants linked**.

## Why the local gate did not catch it

`bun run test` has no site stage — `site:build` runs only in `release.yml`. So any change to a framework symbol a playground demo imports can break the site build and stay invisible until the next release. Worth considering as a follow-up: either add `site:build` to `tools/test.ts`, or derive the playground re-export surface from `framework/compiler/subpaths.ts` instead of maintaining it by hand (the same governed-surface idiom the npm `files` map uses).

🤖 Generated with [Claude Code](https://claude.com/claude-code)