### PR TITLE
chore(ios): pin ns-shell to @nativescript/pocketjs 0.2.1

### DIFF
--- a/hosts/apple/ns-shell/package.json
+++ b/hosts/apple/ns-shell/package.json
@@ -5,7 +5,7 @@
   "main": "src/app.ts",
   "dependencies": {
     "@nativescript/core": "9.1.0-alpha.11",
-    "@nativescript/pocketjs": "0.2.0"
+    "@nativescript/pocketjs": "0.2.1"
   },
   "devDependencies": {
     "@nativescript/ios-quickjs": "9.0.0-preview.3",


### PR DESCRIPTION
The one-line pin bump flagged in the #257 thread. `@nativescript/pocketjs@0.2.1` is the plugin rebuild from post-merge main ([NativeScript/pocketjs#1](https://github.com/NativeScript/pocketjs/pull/1), merged): the xcframework is built from upstream `main` after #257/#258 landed (so it also picks up #270's allocator change), `PocketHostView._mountUi` publishes `__tickHz` next to `__host`/`__hostAbi`, and `tickRate` applies ahead of guest eval in both views — completing the pairing invariant for external-guest mounts.

Validated against the rebuilt binary on the iPhone 17 Pro Max simulator (iOS 26.5) with `nsengine --hz=120 --density=4`: guest mode (`[pocket-shell] guest loaded`, pong round trip, "sandboxed realm") and `--external-guest --no-build` (build stamp staged 120 Hz, "iOS 26.5 via NativeScript"). `render_hero` at declared 120 Hz: 180 deterministic non-blank frames, damage_px matching the #257 merge-time verification.

**Draft until `0.2.1` is live on npm** (publish is in flight); merging before then would break the shell's `npm install`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)