### PR TITLE
fix(audio): audioFramesForTick counts frames at the realm's declared rate

### DIFF
--- a/contracts/spec/audio.ts
+++ b/contracts/spec/audio.ts
@@ -136,18 +136,28 @@ export const AUDIO_MAX_STREAMS = 4;
 
 /**
  * Frames the audio clock consumes on virtual tick `tick` (0-based, counted
- * per stream while playing) at 60 core ticks per second. The Bresenham-style
- * floor difference distributes non-divisible rates (22050/60 = 367.5) with
- * zero drift: the sum over any 60 consecutive ticks is exactly `rate`.
+ * per stream while playing) at `ticksPerSecond` core ticks per second — the
+ * realm's declared rate, 60 unless the host declares otherwise. The
+ * Bresenham-style floor difference distributes non-divisible rates
+ * (22050/60 = 367.5) with zero drift: the sum over any `ticksPerSecond`
+ * consecutive ticks is exactly `rate`.
  *
  * This formula IS the deterministic-audio contract: virtual-clock hosts
  * (hosts/sim) consume exactly this many frames per playing tick, making the
  * consumed PCM byte-stream a pure function of (tick index, op stream).
  * Real-time hosts consume on the device clock instead and report through
  * `credit` — the formula is their long-run average by construction.
+ *
+ * An audio-capable host that declares a non-60 realm rate must pass that
+ * rate here; the pairing invariant (framework/src/host.ts) refuses the
+ * mismatched mount, so formula and realm can only disagree through a host
+ * bug, never through a bundle.
  */
-export function audioFramesForTick(rate: number, tick: number): number {
-  return Math.floor(((tick + 1) * rate) / 60) - Math.floor((tick * rate) / 60);
+export function audioFramesForTick(rate: number, tick: number, ticksPerSecond = 60): number {
+  return (
+    Math.floor(((tick + 1) * rate) / ticksPerSecond) -
+    Math.floor((tick * rate) / ticksPerSecond)
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/contracts/spec/gen-rust.ts
+++ b/contracts/spec/gen-rust.ts
@@ -478,10 +478,14 @@ export function generateRust(): string {
   if (audioFramesForTick(22050, 0) !== 367 || audioFramesForTick(22050, 1) !== 368) {
     throw new Error("audioFramesForTick drifted from the pinned Bresenham formula");
   }
+  if (audioFramesForTick(22050, 0, 120) !== 183 || audioFramesForTick(22050, 1, 120) !== 184) {
+    throw new Error("audioFramesForTick drifted from the pinned Bresenham formula (declared rate)");
+  }
   put("/// AUDIO module boundary (contracts/spec/audio.ts — `globalThis.audio`).");
   put("/// Credit-based PCM streaming; events batch to tick boundaries via poll().");
-  put("/// Frames consumed on virtual tick n at 60 ticks/s (the determinism");
-  put("/// contract): floor((n+1)*rate/60) - floor(n*rate/60).");
+  put("/// Frames consumed on virtual tick n at the realm's declared ticks/s hz");
+  put("/// (60 default — the determinism contract):");
+  put("/// floor((n+1)*rate/hz) - floor(n*rate/hz).");
   put("pub mod audio {");
   for (const [name, v] of Object.entries(AUDIO_OP)) {
     put(`    pub const OP_${screaming(name)}: u8 = ${v};`);

--- a/engine/core/src/spec.rs
+++ b/engine/core/src/spec.rs
@@ -476,8 +476,9 @@ pub const ANALOG_CENTER: u32 = 0x8080;
 
 /// AUDIO module boundary (contracts/spec/audio.ts — `globalThis.audio`).
 /// Credit-based PCM streaming; events batch to tick boundaries via poll().
-/// Frames consumed on virtual tick n at 60 ticks/s (the determinism
-/// contract): floor((n+1)*rate/60) - floor(n*rate/60).
+/// Frames consumed on virtual tick n at the realm's declared ticks/s hz
+/// (60 default — the determinism contract):
+/// floor((n+1)*rate/hz) - floor(n*rate/hz).
 pub mod audio {
     pub const OP_CREATE_STREAM: u8 = 1;
     pub const OP_DESTROY_STREAM: u8 = 2;

--- a/hosts/sim/audio.ts
+++ b/hosts/sim/audio.ts
@@ -2,8 +2,10 @@
 // the audio module (contracts/spec/audio.ts) for the headless sim host.
 //
 // Where the browser host's worklet consumes on the device clock, this sink
-// consumes EXACTLY audioFramesForTick(rate, n) source frames on each core
-// tick a stream spends playing — the formula pinned in the spec. Everything
+// consumes EXACTLY audioFramesForTick(rate, n, ticksPerSecond) source frames
+// on each core tick a stream spends playing — the formula pinned in the
+// spec, at the realm's declared rate (default 60; a runner driving a non-60
+// realm must construct the sink at that rate). Everything
 // downstream is therefore a pure function of (tick index, op stream): the
 // consumed PCM byte-stream, the credit/underrun/ended event log, all of it
 // byte-reproducible. tests/audio-sim.test.ts runs the music demo through two
@@ -49,7 +51,7 @@ export interface SimAudioSink {
   log: string[];
 }
 
-export function createSimAudioSink(): SimAudioSink {
+export function createSimAudioSink(ticksPerSecond = 60): SimAudioSink {
   const streams = new Map<number, SimStream>();
   const events: string[] = [];
   const log: string[] = [];
@@ -149,7 +151,7 @@ export function createSimAudioSink(): SimAudioSink {
       // and event order are stable by construction.
       for (const [handle, s] of streams) {
         if (s.playing) {
-          const want = audioFramesForTick(s.rate, s.playedTicks);
+          const want = audioFramesForTick(s.rate, s.playedTicks, ticksPerSecond);
           s.playedTicks++;
           const avail = s.writePos - s.readPos;
           const take = Math.min(want, avail);

--- a/tests/audio.test.ts
+++ b/tests/audio.test.ts
@@ -34,6 +34,26 @@ describe("audioFramesForTick", () => {
       }
     }
   });
+
+  test("zero drift holds at any declared realm rate", () => {
+    for (const ticksPerSecond of [90, 120, 240]) {
+      for (const rate of AUDIO_RATES) {
+        for (const start of [0, 1, 59, 600]) {
+          let sum = 0;
+          for (let t = start; t < start + ticksPerSecond; t++) {
+            sum += audioFramesForTick(rate, t, ticksPerSecond);
+          }
+          expect(sum).toBe(rate);
+        }
+        const ideal = rate / ticksPerSecond;
+        for (let t = 0; t < 2 * ticksPerSecond; t++) {
+          expect(
+            Math.abs(audioFramesForTick(rate, t, ticksPerSecond) - ideal),
+          ).toBeLessThanOrEqual(1);
+        }
+      }
+    }
+  });
 });
 
 // --- decodeWav (the audio:wav.* data-contract reference decoder) -----------
@@ -169,6 +189,38 @@ describe("WavPlayer x sim sink", () => {
       player2.pump();
       expect(sink2.pcmHash()).toBe(sink.pcmHash());
       expect(sink2.log).toEqual(sink.log);
+    } finally {
+      delete (globalThis as Record<string, unknown>).audio;
+    }
+  });
+
+  test("a declared-rate sink consumes the same PCM bytes, retimed", () => {
+    const run = (ticksPerSecond: number, ticks: number) => {
+      const sink = createSimAudioSink(ticksPerSecond);
+      (globalThis as Record<string, unknown>).audio = sink.ns;
+      const player = createWavPlayer();
+      const frames = 22050;
+      const data = new Int16Array(frames);
+      for (let i = 0; i < frames; i++) data[i] = (i % 2000) - 1000;
+      player.loadPcm({ sampleRate: 22050, channels: 1, frames, data });
+      player.play();
+      for (let t = 0; t < ticks; t++) {
+        player.pump();
+        sink.tick();
+      }
+      player.pump();
+      return { sink, player };
+    };
+    try {
+      // 1.5 virtual seconds at each rate: the whole 1 s track plus drain.
+      const at60 = run(60, 90);
+      const at120 = run(120, 180);
+      expect(at60.sink.consumedFrames()).toBe(22050);
+      expect(at120.sink.consumedFrames()).toBe(22050);
+      // The declared rate changes per-tick chunking, never the byte-stream.
+      expect(at120.sink.pcmHash()).toBe(at60.sink.pcmHash());
+      expect(at120.player.stats().underruns).toBe(0);
+      expect(at120.player.playing()).toBe(false);
     } finally {
       delete (globalThis as Record<string, unknown>).audio;
     }


### PR DESCRIPTION
The audio deferral from #257, closed before any audio-capable host grows a declared rate: `audioFramesForTick` divided by a literal 60, so a 120 realm would consume PCM at 2x and the zero-drift statement went false.

### What changed

- **`contracts/spec/audio.ts`**: `audioFramesForTick(rate, tick, ticksPerSecond = 60)`. The default keeps every existing callsite byte-identical — the 60-window tests now pin the default path. The doc states the generalized property (sum over any `ticksPerSecond` consecutive ticks is exactly `rate`) and the reachability argument: the pairing invariant refuses a mismatched mount, so formula and realm can only disagree through a host bug, never through a bundle.
- **`hosts/sim/audio.ts`**: `createSimAudioSink(ticksPerSecond = 60)` — a runner driving a non-60 realm constructs the sink at that rate, keeping one-tick-one-`sink.tick()` pairing intact.
- **`contracts/spec/gen-rust.ts` + regenerated `engine/core/src/spec.rs`**: the pin now also asserts the formula at a declared 120 (`22050 -> 183, 184`), and the emitted doc states the rate-parameterized form.

### Tests

- Zero drift at declared 90/120/240 for every `AUDIO_RATES` entry, window starts 0/1/59/600, plus the ±1-frame bound.
- Sink x WavPlayer at a declared 120: the same 1 s track consumes exactly 22050 frames in 120 ticks with zero underruns, and the consumed byte-stream hash equals the 60-sink run — the declared rate changes per-tick chunking, never the bytes.

### Verification

`bun run test` **11/11 stages green (38.5 s)**; `bunx tsc --noEmit` clean; `bun tests/contract.ts` green against the regenerated spec.rs; `cargo check -p pocketjs-core` clean (the spec.rs delta is doc text).

Deliberately not here: nothing calls this with a non-60 rate yet — the sim can't reach a non-60 realm until `engine/wasm` exports `ui_set_tick_rate` (next PR in this follow-up series).

🤖 Generated with [Claude Code](https://claude.com/claude-code)