### PR TITLE
fix(tools): build desktop launchers from the engine workspace

### DIFF
--- a/tools/note.ts
+++ b/tools/note.ts
@@ -40,9 +40,9 @@ mkdirSync(resolvePath(planPath, ".."), { recursive: true });
 await Bun.write(planPath, JSON.stringify(resolution.plan, null, 2) + "\n");
 
 await $`bun tools/build.ts --plan=${planPath} --project-root=${root}`.cwd(root);
-await $`cargo build --release -p note-widget`.cwd(`${root}pocket3d`);
+await $`cargo build --release -p note-widget`.cwd(`${root}engine`);
 
-const bin = `${root}engine/pocket3d/target/release/note-widget`;
+const bin = `${root}engine/target/release/note-widget`;
 const env = { ...process.env, RUST_LOG: process.env.RUST_LOG ?? "info" };
 
 if (proof) {

--- a/tools/widget.ts
+++ b/tools/widget.ts
@@ -267,9 +267,9 @@ async function main(): Promise<void> {
   // target-flavored bundles in dist/ proper are never picked up by mistake.
   const stageDist = resolvePath(root, "dist", `stage-${stage}`);
   await $`bun tools/build.ts --plan=${planPath} --project-root=${root} --outdir=${stageDist}`.cwd(root);
-  await $`cargo build --release -p pocket-stage`.cwd(`${root}pocket3d`);
+  await $`cargo build --release -p pocket-stage`.cwd(`${root}engine`);
 
-  const bin = `${root}engine/pocket3d/target/release/pocket-stage`;
+  const bin = `${root}engine/target/release/pocket-stage`;
   const env = {
     ...process.env,
     RUST_LOG: process.env.RUST_LOG ?? "info",


### PR DESCRIPTION
## What

Fix the `note` and `widget` launchers after the repository layout
migration in #149.

#149 moved the desktop Cargo workspace from `pocket3d/` to `engine/`,
but these two launchers retained the old build cwd and an incorrect
nested target path.

Both launchers now:

- build from the `engine/` workspace
- resolve binaries from `engine/target/release/`

## Scope

This only fixes the stale Cargo workspace paths.

Windows filesystem URL handling and Windows desktop support are
intentionally out of scope.

## Verification

From the `engine/` workspace:

- `cargo build --release -p note-widget`
- `cargo build --release -p pocket-stage`

Both packages resolve from the workspace and emit their binaries under
`engine/target/release/`.
