### PR TITLE
ci(actions): upgrade workflows to Node 24 runtime

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -31,7 +31,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo + wasm target
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry

--- a/.github/workflows/esp32p4.yml
+++ b/.github/workflows/esp32p4.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: dtolnay/rust-toolchain@stable
 
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Build ESP32-P4 component smoke app
         uses: espressif/esp-idf-ci-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -43,7 +43,7 @@ jobs:
       # npm (not bun) does the publishing. Trusted Publishing needs npm >=
       # 11.5.1 (Node 22 bundles 10.x), and no registry-url: setup-node's
       # auth-token .npmrc placeholder would fail without a token env var.
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v7
         with:
           node-version: 22
 
@@ -57,7 +57,7 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Cache cargo + wasm target
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## Summary

- upgrade all `actions/checkout` uses from v4 to v7
- upgrade all `actions/cache` uses from v4 to v6
- upgrade the release workflow from `actions/setup-node` v4 to v7
- keep job inputs, permissions, cache keys, and release behavior unchanged

The selected action majors declare `runs.using: node24`; `oven-sh/setup-bun@v2` already uses Node 24, while the Rust and ESP-IDF actions are composite. No Node 20 JavaScript action remains in `.github/workflows`.

## Validation

- all workflow YAML files parse successfully
- `actionlint v1.7.12 .github/workflows/*.yml`
- `git diff --check`
- `bun run test`: 411 pass, 1 pre-existing failure
  - `tests/npm-package.test.ts` cannot resolve the packaged Apple workspace because `engine/pocket3d/crates/pocket3d-world/Cargo.toml` is absent from the framework tarball; the same failure is present on current `main` and is unrelated to these workflow-only changes
