### PR TITLE
feat(windows): W1 desktop enablement — generic window host, paired acceptance identity

### DIFF
--- a/apps/acceptance/app.tsx
+++ b/apps/acceptance/app.tsx
@@ -3,10 +3,11 @@
 // Deliberately the smallest thing that exercises every desktop-host
 // mechanism the acceptance rig exists to prove, over ONE plain-string
 // document: live typing with a caret, drag selection, word-dance
-// (Primary+Left/Right), copy/cut/paste through the system clipboard, basic
-// formatting via Primary+B/I/U, wheel scroll, live resize re-wrap, IME
-// composition and runtime CJK glyphs. There is no markdown, no undo/redo
-// and no save — the host only forwards input and mirrors the clipboard.
+// (Primary+Left/Right), copy/cut/paste through the system clipboard, wheel
+// scroll, live resize re-wrap, IME composition and runtime CJK glyphs.
+// There is no markdown, no rich text, no undo/redo and no save — the host
+// only forwards input and mirrors the clipboard. Rich-text formatting is
+// out of scope on purpose: W1 proves the substrate, not an editor product.
 //
 // The editing math is the same framework-free editor.ts the note app uses
 // (soft wrap + caret/selection over a string); this file is the thin
@@ -52,9 +53,8 @@ const INK = {
   thumb: "#414d5b",
 };
 
-/** Build-pinned font slot for body text (layout.ts FONT_BODY / bold). */
+/** Build-pinned font slot for body text (layout.ts FONT_BODY). */
 const FONT_BODY = 1;
-const FONT_BODY_BOLD = 8;
 
 /** The editor's measure fn (body font) — same contract as editor.ts. */
 function measure(text: string): number {
@@ -96,10 +96,10 @@ function wordRight(doc: string, pos: number): number {
 const SAMPLE_DOC =
   "Pocket Acceptance — a plain text surface.\n\n" +
   "Type here. Select with the mouse. Copy (Primary+C), cut (Primary+X),\n" +
-  "paste (Primary+V). Word-dance with Primary+Left/Right. Bold with\n" +
-  "Primary+B. IME composition and CJK 汉字 render through the runtime\n" +
-  "glyph atlas. Resize the window — the text re-wraps. Scroll with the\n" +
-  "wheel. Every row is the stock host mechanism doing its real job.";
+  "paste (Primary+V). Word-dance with Primary+Left/Right. IME composition\n" +
+  "and CJK 汉字 render through the runtime glyph atlas. Resize the window —\n" +
+  "the text re-wraps. Scroll with the wheel. Every row is the stock host\n" +
+  "mechanism doing its real job.";
 
 export default function Acceptance(): ReturnType<typeof View> {
   const svc = connectSvc();
@@ -110,7 +110,6 @@ export default function Acceptance(): ReturnType<typeof View> {
   const [anchor, setAnchor] = createSignal(0);
   const [preedit, setPreedit] = createSignal<{ text: string; cursor: number } | null>(null);
   const [scrollE, setScrollE] = createSignal(0);
-  const [fmt, setFmt] = createSignal({ bold: false, italic: false, underline: false });
 
   const viewH = () => vp().h - HEADER_H;
   const contentW = () => Math.max(40, vp().w - EDGE_PAD * 2);
@@ -148,9 +147,6 @@ export default function Acceptance(): ReturnType<typeof View> {
     const [lo, hi] = selBounds({ doc: doc(), caret: caret(), anchor: anchor() });
     return { lo, hi };
   };
-
-  const slot = () => (fmt().bold ? FONT_BODY_BOLD : FONT_BODY);
-  const mSlot = (text: string) => getOps().measureText(text, slot());
 
   // ---- edits --------------------------------------------------------------
   let goalX = 0;
@@ -329,12 +325,6 @@ export default function Acceptance(): ReturnType<typeof View> {
         resizeViewport(ev.w ?? 480, ev.h ?? 272);
         setScrollE(Math.max(0, Math.min(maxScrollE(), scrollE())));
         break;
-      case "load":
-        setDoc(ev.text ?? "");
-        setCaret(0);
-        setAnchor(0);
-        setPreedit(null);
-        break;
       case "ch":
         if (canEdit && ev.s) {
           setPreedit(null); // a commit replaces the preedit it finalizes
@@ -403,8 +393,8 @@ export default function Acceptance(): ReturnType<typeof View> {
     if (hi < lo) return null;
     if (hi === lo && !(sel.lo < line.start && sel.hi > line.end)) return null;
     return {
-      x0: mSlot(displayDoc().slice(line.start, lo)),
-      x1: mSlot(displayDoc().slice(line.start, hi)),
+      x0: measure(displayDoc().slice(line.start, lo)),
+      x1: measure(displayDoc().slice(line.start, hi)),
     };
   };
   const preeditRect = (line: { index: number; start: number; end: number }) => {
@@ -414,8 +404,8 @@ export default function Acceptance(): ReturnType<typeof View> {
     const hi = Math.min(caret() + p.text.length, line.end);
     if (hi <= lo) return null;
     return {
-      x0: mSlot(displayDoc().slice(line.start, lo)),
-      x1: mSlot(displayDoc().slice(line.start, hi)),
+      x0: measure(displayDoc().slice(line.start, lo)),
+      x1: measure(displayDoc().slice(line.start, hi)),
     };
   };
   const thumbH = (total: number) => Math.max(24, (viewH() * viewH()) / total);
@@ -433,16 +423,6 @@ export default function Acceptance(): ReturnType<typeof View> {
       />
     </Show>
   );
-  const fmtChip = (label: string, active: boolean, onPress: () => void) => (
-    <Focusable
-      class={active ? "px-2 rounded-md focus:bg-[#1d242e] bg-[#1d242e]" : "px-2 rounded-md focus:bg-[#1d242e]"}
-      onPress={onPress}
-    >
-      <Text class="text-xs font-bold" style={{ textColor: active ? INK.accent : INK.dim }}>
-        {label}
-      </Text>
-    </Focusable>
-  );
 
   return (
     <View class="flex-col w-full h-full bg-[#11151b]">
@@ -451,11 +431,6 @@ export default function Acceptance(): ReturnType<typeof View> {
           POCKET ACCEPTANCE
         </Text>
         <View class="flex-1" />
-        <Show when={canEdit}>
-          {fmtChip("B", fmt().bold, () => setFmt((f) => ({ ...f, bold: !f.bold })))}
-          {fmtChip("I", fmt().italic, () => setFmt((f) => ({ ...f, italic: !f.italic })))}
-          {fmtChip("U", fmt().underline, () => setFmt((f) => ({ ...f, underline: !f.underline })))}
-        </Show>
         <Text class="text-xs" style={{ textColor: INK.dim }}>
           {doc().length}
         </Text>
@@ -490,12 +465,6 @@ export default function Acceptance(): ReturnType<typeof View> {
                     }}
                   />
                 </Show>
-                <Show when={fmt().underline}>
-                  <View
-                    class="absolute rounded-sm"
-                    style={{ insetL: 0, insetR: 0, insetB: 2, height: 2, bgColor: INK.dim }}
-                  />
-                </Show>
                 <Show when={preeditRect(line) != null}>
                   <View
                     class="absolute rounded-sm"
@@ -509,7 +478,7 @@ export default function Acceptance(): ReturnType<typeof View> {
                   />
                 </Show>
                 <Text
-                  class={fmt().bold ? "absolute text-sm font-bold" : "absolute text-sm"}
+                  class="absolute text-sm"
                   style={{
                     insetL: 0,
                     insetT: 0,

--- a/apps/acceptance/app.tsx
+++ b/apps/acceptance/app.tsx
@@ -1,0 +1,543 @@
+// apps/acceptance/app.tsx — Pocket Acceptance: the generic text editor.
+//
+// Deliberately the smallest thing that exercises every desktop-host
+// mechanism the acceptance rig exists to prove, over ONE plain-string
+// document: live typing with a caret, drag selection, word-dance
+// (Primary+Left/Right), copy/cut/paste through the system clipboard, basic
+// formatting via Primary+B/I/U, wheel scroll, live resize re-wrap, IME
+// composition and runtime CJK glyphs. There is no markdown, no undo/redo
+// and no save — the host only forwards input and mirrors the clipboard.
+//
+// The editing math is the same framework-free editor.ts the note app uses
+// (soft wrap + caret/selection over a string); this file is the thin
+// Solid surface around it. The svc channel (svc.ts) is the flat host's
+// wire protocol: keys/chars/IME/mouse/scroll/resize in, copy/caret out.
+
+import { createMemo, createSignal, For, Show } from "solid-js";
+import { Focusable, Text, View } from "@pocketjs/framework/components";
+import { onFrame } from "@pocketjs/framework/lifecycle";
+import { focusNode, hitFocusable } from "@pocketjs/framework/input";
+import { getOps, resizeViewport } from "@pocketjs/framework";
+import { hasFeature } from "@pocketjs/framework/platform";
+import {
+  backspaceSel,
+  caretFromX,
+  caretLine,
+  caretX,
+  deleteSel,
+  layoutDoc,
+  lineEnd,
+  lineStart,
+  moveVertical,
+  selBounds,
+  typeText,
+  type SelEdit,
+} from "../note/editor.ts";
+import { connectSvc, type HostEvent } from "../note/svc.ts";
+
+const HEADER_H = 30;
+const EDGE_PAD = 10;
+const BODY_LINE_H = 20;
+const CARET_H = 16;
+const SCROLL_STEP = 40;
+const OVERSCAN = 40;
+const DRAG_SLOP = 3;
+
+const INK = {
+  body: "#d7dee7",
+  dim: "#7e8994",
+  accent: "#6fb3ff",
+  sel: "#2a4a6e",
+  header: "#8d98a5",
+  thumb: "#414d5b",
+};
+
+/** Build-pinned font slot for body text (layout.ts FONT_BODY / bold). */
+const FONT_BODY = 1;
+const FONT_BODY_BOLD = 8;
+
+/** The editor's measure fn (body font) — same contract as editor.ts. */
+function measure(text: string): number {
+  return getOps().measureText(text, FONT_BODY);
+}
+
+/** A char counts as a word character: ASCII word, or any non-ASCII glyph
+ *  (CJK moves one hanzi at a time — the natural word unit). */
+function isWordChar(c: string): boolean {
+  const code = c.codePointAt(0)!;
+  return (
+    (code >= 0x30 && code <= 0x39) ||
+    (code >= 0x41 && code <= 0x5a) ||
+    (code >= 0x61 && code <= 0x7a) ||
+    code > 0x7f
+  );
+}
+
+/** Caret → start of the current/previous word (word-dance: Primary+Left). */
+function wordLeft(doc: string, pos: number): number {
+  let i = pos;
+  if (i > 0 && isWordChar(doc[i - 1])) {
+    while (i > 0 && isWordChar(doc[i - 1])) i--;
+    return i;
+  }
+  while (i > 0 && !isWordChar(doc[i - 1])) i--;
+  while (i > 0 && isWordChar(doc[i - 1])) i--;
+  return i;
+}
+
+/** Caret → end of the current/next word (word-dance: Primary+Right). */
+function wordRight(doc: string, pos: number): number {
+  let i = pos;
+  while (i < doc.length && isWordChar(doc[i])) i++;
+  while (i < doc.length && !isWordChar(doc[i])) i++;
+  return i;
+}
+
+const SAMPLE_DOC =
+  "Pocket Acceptance — a plain text surface.\n\n" +
+  "Type here. Select with the mouse. Copy (Primary+C), cut (Primary+X),\n" +
+  "paste (Primary+V). Word-dance with Primary+Left/Right. Bold with\n" +
+  "Primary+B. IME composition and CJK 汉字 render through the runtime\n" +
+  "glyph atlas. Resize the window — the text re-wraps. Scroll with the\n" +
+  "wheel. Every row is the stock host mechanism doing its real job.";
+
+export default function Acceptance(): ReturnType<typeof View> {
+  const svc = connectSvc();
+  const canEdit = hasFeature("input.text");
+  const [vp, setVp] = createSignal({ w: 480, h: 272 });
+  const [doc, setDoc] = createSignal(SAMPLE_DOC);
+  const [caret, setCaret] = createSignal(0);
+  const [anchor, setAnchor] = createSignal(0);
+  const [preedit, setPreedit] = createSignal<{ text: string; cursor: number } | null>(null);
+  const [scrollE, setScrollE] = createSignal(0);
+  const [fmt, setFmt] = createSignal({ bold: false, italic: false, underline: false });
+
+  const viewH = () => vp().h - HEADER_H;
+  const contentW = () => Math.max(40, vp().w - EDGE_PAD * 2);
+
+  // ---- edit layout -------------------------------------------------------
+  const displayDoc = createMemo(() => {
+    const p = preedit();
+    if (!p) return doc();
+    return doc().slice(0, caret()) + p.text + doc().slice(caret());
+  });
+  const displayCaret = () => {
+    const p = preedit();
+    return p ? caret() + p.cursor : caret();
+  };
+  const dlines = createMemo(() => layoutDoc(displayDoc(), contentW(), measure));
+  const editTotal = () => dlines().length * BODY_LINE_H + EDGE_PAD * 2;
+  const maxScrollE = () => Math.max(0, editTotal() - viewH());
+  const visibleLines = createMemo(() => {
+    const lines = dlines();
+    const from = Math.max(0, Math.floor((scrollE() - OVERSCAN - EDGE_PAD) / BODY_LINE_H));
+    const to = Math.min(
+      lines.length,
+      Math.ceil((scrollE() + viewH() + OVERSCAN - EDGE_PAD) / BODY_LINE_H),
+    );
+    const out: { index: number; start: number; end: number; soft: boolean }[] = [];
+    for (let i = from; i < to; i++) {
+      out.push({ index: i, start: lines[i].start, end: lines[i].end, soft: lines[i].soft });
+    }
+    return out;
+  });
+  const caretRow = () => caretLine(dlines(), displayCaret());
+  const caretPx = () => caretX(displayDoc(), dlines(), displayCaret(), measure);
+  const editSel = () => {
+    if (caret() === anchor()) return null;
+    const [lo, hi] = selBounds({ doc: doc(), caret: caret(), anchor: anchor() });
+    return { lo, hi };
+  };
+
+  const slot = () => (fmt().bold ? FONT_BODY_BOLD : FONT_BODY);
+  const mSlot = (text: string) => getOps().measureText(text, slot());
+
+  // ---- edits --------------------------------------------------------------
+  let goalX = 0;
+  let goalSticky = false;
+  let lastHover: unknown = null;
+  let prevDown = false;
+  let press: { x: number; y: number; dragged: boolean } | null = null;
+
+  const revealCaret = () => {
+    const y = EDGE_PAD + caretRow() * BODY_LINE_H;
+    if (y < scrollE() + 4) setScrollE(Math.max(0, y - 4));
+    else if (y + BODY_LINE_H > scrollE() + viewH() - 4) {
+      setScrollE(Math.min(maxScrollE(), y + BODY_LINE_H - viewH() + 4));
+    }
+  };
+  const selState = (): SelEdit => ({ doc: doc(), caret: caret(), anchor: anchor() });
+  const applyState = (s: SelEdit) => {
+    setDoc(s.doc);
+    setCaret(s.caret);
+    setAnchor(s.anchor);
+  };
+  const mutate = (fn: (s: SelEdit) => SelEdit) => {
+    applyState(fn(selState()));
+    goalSticky = false;
+    revealCaret();
+  };
+  /** Collapse-or-move for plain arrows (a selection collapses to its edge). */
+  const collapseOr = (edge: "lo" | "hi", move: (s: SelEdit) => number) => {
+    const s = selState();
+    const [lo, hi] = selBounds(s);
+    const pos = s.caret === s.anchor ? move(s) : edge === "lo" ? lo : hi;
+    setCaret(pos);
+    setAnchor(pos);
+    goalSticky = false;
+  };
+
+  const handleKey = (k: string, shift = false) => {
+    const extend = (pos: number) => {
+      setCaret(Math.max(0, Math.min(pos, doc().length)));
+      revealCaret();
+    };
+    if (shift && !preedit()) {
+      switch (k) {
+        case "Left":
+          extend(caret() - 1);
+          return;
+        case "Right":
+          extend(caret() + 1);
+          return;
+        case "WordLeft":
+          extend(wordLeft(doc(), caret()));
+          return;
+        case "WordRight":
+          extend(wordRight(doc(), caret()));
+          return;
+        case "Home":
+          extend(lineStart(dlines(), caret()));
+          return;
+        case "End":
+          extend(lineEnd(dlines(), caret()));
+          return;
+        case "Up":
+        case "Down": {
+          if (!goalSticky) {
+            goalX = caretPx();
+            goalSticky = true;
+          }
+          extend(moveVertical(doc(), dlines(), caret(), k === "Up" ? -1 : 1, goalX, measure));
+          return;
+        }
+      }
+    }
+    if (k === "Escape") {
+      if (editSel()) setAnchor(caret());
+      return;
+    }
+    if (k === "Copy") {
+      const sel = editSel();
+      if (sel) svc?.send({ t: "copy", text: doc().slice(sel.lo, sel.hi) });
+      return;
+    }
+    if (k === "Cut") {
+      const sel = editSel();
+      if (sel) {
+        svc?.send({ t: "copy", text: doc().slice(sel.lo, sel.hi) });
+        mutate((s) => typeText(s, ""));
+      }
+      return;
+    }
+    switch (k) {
+      case "Backspace":
+        mutate(backspaceSel);
+        break;
+      case "Delete":
+        mutate(deleteSel);
+        break;
+      case "Enter":
+        mutate((s) => typeText(s, "\n"));
+        break;
+      case "Tab":
+        mutate((s) => typeText(s, "  "));
+        break;
+      case "Left":
+        collapseOr("lo", (s) => Math.max(0, s.caret - 1));
+        break;
+      case "Right":
+        collapseOr("hi", (s) => Math.min(s.doc.length, s.caret + 1));
+        break;
+      case "WordLeft":
+        collapseOr("lo", (s) => wordLeft(s.doc, s.caret));
+        break;
+      case "WordRight":
+        collapseOr("hi", (s) => wordRight(s.doc, s.caret));
+        break;
+      case "Home":
+        collapseOr("lo", (s) => lineStart(dlines(), s.caret));
+        break;
+      case "End":
+        collapseOr("hi", (s) => lineEnd(dlines(), s.caret));
+        break;
+      case "Up":
+      case "Down": {
+        if (!goalSticky) {
+          goalX = caretPx();
+          goalSticky = true;
+        }
+        const next = moveVertical(doc(), dlines(), caret(), k === "Up" ? -1 : 1, goalX, measure);
+        setCaret(Math.max(0, Math.min(next, doc().length)));
+        setAnchor(caret());
+        revealCaret();
+        break;
+      }
+      case "PageUp":
+        setCaret(0);
+        setAnchor(0);
+        revealCaret();
+        break;
+      case "PageDown":
+        setCaret(doc().length);
+        setAnchor(doc().length);
+        revealCaret();
+        break;
+    }
+  };
+
+  // ---- pointer gestures (svc mouse stream) --------------------------------
+  const editPosAt = (x: number, y: number): number => {
+    const line = Math.floor((y - HEADER_H + scrollE() - EDGE_PAD) / BODY_LINE_H);
+    return caretFromX(doc(), dlines(), line, x - EDGE_PAD, measure);
+  };
+
+  const pointerDown = (x: number, y: number, shift: boolean) => {
+    press = { x, y, dragged: false };
+    if (y < HEADER_H || preedit()) return;
+    const pos = editPosAt(x, y);
+    setCaret(pos);
+    if (!shift) setAnchor(pos);
+    goalSticky = false;
+  };
+  const pointerMove = (x: number, y: number, down: boolean) => {
+    if (!down || !press) return;
+    if (!press.dragged && Math.abs(x - press.x) + Math.abs(y - press.y) < DRAG_SLOP) return;
+    press.dragged = true;
+    setCaret(editPosAt(x, y));
+    revealCaret();
+  };
+  const pointerUp = () => {
+    press = null;
+  };
+
+  const handleEvent = (ev: HostEvent) => {
+    switch (ev.t) {
+      case "hello":
+      case "resize":
+        setVp({ w: ev.w ?? 480, h: ev.h ?? 272 });
+        resizeViewport(ev.w ?? 480, ev.h ?? 272);
+        setScrollE(Math.max(0, Math.min(maxScrollE(), scrollE())));
+        break;
+      case "load":
+        setDoc(ev.text ?? "");
+        setCaret(0);
+        setAnchor(0);
+        setPreedit(null);
+        break;
+      case "ch":
+        if (canEdit && ev.s) {
+          setPreedit(null); // a commit replaces the preedit it finalizes
+          mutate((s) => typeText(s, ev.s!));
+        }
+        break;
+      case "paste":
+        if (canEdit && ev.text) mutate((s) => typeText(s, ev.text!));
+        break;
+      case "ime": {
+        if (!canEdit) break;
+        const text = ev.s ?? "";
+        if (text === "") {
+          setPreedit(null);
+          break;
+        }
+        if (editSel()) mutate((s) => typeText(s, ""));
+        setPreedit({ text, cursor: Math.min(ev.c ?? text.length, text.length) });
+        revealCaret();
+        break;
+      }
+      case "key":
+        if (ev.k) handleKey(ev.k, ev.sh ?? false);
+        break;
+      case "mouse": {
+        const p = { x: ev.x ?? -1, y: ev.y ?? -1 };
+        const down = ev.d ?? false;
+        if (down && !prevDown) pointerDown(p.x, p.y, ev.sh ?? false);
+        else if (down) pointerMove(p.x, p.y, true);
+        if (!down && prevDown) pointerUp();
+        prevDown = down;
+        const n = hitFocusable(p.x, p.y);
+        if (n && n !== lastHover) focusNode(n);
+        lastHover = n;
+        break;
+      }
+      case "scroll": {
+        const dy = ev.dy ?? 0;
+        setScrollE(Math.max(0, Math.min(maxScrollE(), scrollE() - dy)));
+        break;
+      }
+    }
+  };
+
+  let lastCaretRect = { x: -1, y: -1, h: -1 };
+  onFrame(() => {
+    if (!svc) return;
+    for (const ev of svc.poll()) handleEvent(ev);
+    const rect = {
+      x: Math.round(EDGE_PAD + caretPx()),
+      y: Math.round(HEADER_H + EDGE_PAD + caretRow() * BODY_LINE_H - scrollE()),
+      h: BODY_LINE_H,
+    };
+    if (rect.x !== lastCaretRect.x || rect.y !== lastCaretRect.y) {
+      lastCaretRect = rect;
+      svc.send({ t: "caret", ...rect });
+    }
+  });
+
+  // ---- render ------------------------------------------------------------
+  const lineSelRect = (line: { index: number; start: number; end: number }) => {
+    const sel = editSel();
+    if (!sel) return null;
+    const lo = Math.max(sel.lo, line.start);
+    const hi = Math.min(sel.hi, line.end);
+    if (hi < lo) return null;
+    if (hi === lo && !(sel.lo < line.start && sel.hi > line.end)) return null;
+    return {
+      x0: mSlot(displayDoc().slice(line.start, lo)),
+      x1: mSlot(displayDoc().slice(line.start, hi)),
+    };
+  };
+  const preeditRect = (line: { index: number; start: number; end: number }) => {
+    const p = preedit();
+    if (!p) return null;
+    const lo = Math.max(caret(), line.start);
+    const hi = Math.min(caret() + p.text.length, line.end);
+    if (hi <= lo) return null;
+    return {
+      x0: mSlot(displayDoc().slice(line.start, lo)),
+      x1: mSlot(displayDoc().slice(line.start, hi)),
+    };
+  };
+  const thumbH = (total: number) => Math.max(24, (viewH() * viewH()) / total);
+  const scrollbar = (scroll: number, total: number) => (
+    <Show when={total > viewH()}>
+      <View
+        class="absolute rounded-sm"
+        style={{
+          width: 3,
+          insetR: 3,
+          insetT: (scroll / (total - viewH())) * (viewH() - thumbH(total) - 8) + 4,
+          height: thumbH(total),
+          bgColor: INK.thumb,
+        }}
+      />
+    </Show>
+  );
+  const fmtChip = (label: string, active: boolean, onPress: () => void) => (
+    <Focusable
+      class={active ? "px-2 rounded-md focus:bg-[#1d242e] bg-[#1d242e]" : "px-2 rounded-md focus:bg-[#1d242e]"}
+      onPress={onPress}
+    >
+      <Text class="text-xs font-bold" style={{ textColor: active ? INK.accent : INK.dim }}>
+        {label}
+      </Text>
+    </Focusable>
+  );
+
+  return (
+    <View class="flex-col w-full h-full bg-[#11151b]">
+      <View class="flex-row items-center gap-2 px-3" style={{ height: HEADER_H }}>
+        <Text class="text-xs font-bold tracking-wide" style={{ textColor: INK.header }}>
+          POCKET ACCEPTANCE
+        </Text>
+        <View class="flex-1" />
+        <Show when={canEdit}>
+          {fmtChip("B", fmt().bold, () => setFmt((f) => ({ ...f, bold: !f.bold })))}
+          {fmtChip("I", fmt().italic, () => setFmt((f) => ({ ...f, italic: !f.italic })))}
+          {fmtChip("U", fmt().underline, () => setFmt((f) => ({ ...f, underline: !f.underline })))}
+        </Show>
+        <Text class="text-xs" style={{ textColor: INK.dim }}>
+          {doc().length}
+        </Text>
+      </View>
+
+      <Focusable class="relative flex-1 overflow-hidden">
+        <View
+          class="absolute"
+          style={{
+            insetL: EDGE_PAD,
+            width: contentW(),
+            insetT: 0,
+            height: editTotal(),
+            translateY: -scrollE(),
+          }}
+        >
+          <For each={visibleLines()}>
+            {(line) => (
+              <View
+                class="absolute left-0 right-0"
+                style={{ insetT: EDGE_PAD + line.index * BODY_LINE_H, height: BODY_LINE_H }}
+              >
+                <Show when={lineSelRect(line) != null}>
+                  <View
+                    class="absolute rounded-sm"
+                    style={{
+                      insetL: lineSelRect(line)?.x0 ?? 0,
+                      insetT: 1,
+                      width: Math.max(2, (lineSelRect(line)?.x1 ?? 0) - (lineSelRect(line)?.x0 ?? 0)),
+                      height: BODY_LINE_H - 2,
+                      bgColor: INK.sel,
+                    }}
+                  />
+                </Show>
+                <Show when={fmt().underline}>
+                  <View
+                    class="absolute rounded-sm"
+                    style={{ insetL: 0, insetR: 0, insetB: 2, height: 2, bgColor: INK.dim }}
+                  />
+                </Show>
+                <Show when={preeditRect(line) != null}>
+                  <View
+                    class="absolute rounded-sm"
+                    style={{
+                      insetL: preeditRect(line)?.x0 ?? 0,
+                      insetT: BODY_LINE_H - 3,
+                      width: Math.max(2, (preeditRect(line)?.x1 ?? 0) - (preeditRect(line)?.x0 ?? 0)),
+                      height: 2,
+                      bgColor: INK.accent,
+                    }}
+                  />
+                </Show>
+                <Text
+                  class={fmt().bold ? "absolute text-sm font-bold" : "absolute text-sm"}
+                  style={{
+                    insetL: 0,
+                    insetT: 0,
+                    height: BODY_LINE_H,
+                    lineHeight: BODY_LINE_H,
+                    textColor: INK.body,
+                  }}
+                >
+                  {displayDoc().slice(line.start, line.end)}
+                </Text>
+              </View>
+            )}
+          </For>
+          <Show when={!editSel() && !preedit()}>
+            <View
+              class="absolute animate-pulse rounded-sm"
+              style={{
+                width: 2,
+                insetL: caretPx() - 1,
+                insetT: EDGE_PAD + caretRow() * BODY_LINE_H + (BODY_LINE_H - CARET_H) / 2,
+                height: CARET_H,
+                bgColor: INK.accent,
+              }}
+            />
+          </Show>
+        </View>
+        {scrollbar(scrollE(), editTotal())}
+      </Focusable>
+    </View>
+  );
+}

--- a/apps/acceptance/main.tsx
+++ b/apps/acceptance/main.tsx
@@ -1,0 +1,18 @@
+// @title Pocket Acceptance
+//
+// The generic-text acceptance app: the plain-text editing surface the flat
+// host exercises on a real Windows machine. No markdown, no undo stack, no
+// menu — just caret, selection, typing, word-dance, copy/paste, basic
+// formatting and IME over one plain document. Build for the desktop host:
+//
+//   bun tools/build.ts acceptance-main --density=2
+//   cargo run -p note-widget -- --app acceptance-main --identity windows-app \
+//     --host-abi 3 --width 1000 --height 700
+//
+// Same bundle boots on any ui host; without the widget host's svc channel
+// it renders the sample document read-only.
+
+import Acceptance from "./app.tsx";
+import { mount } from "@pocketjs/framework";
+
+mount(() => <Acceptance />);

--- a/apps/acceptance/main.tsx
+++ b/apps/acceptance/main.tsx
@@ -1,13 +1,13 @@
 // @title Pocket Acceptance
 //
 // The generic-text acceptance app: the plain-text editing surface the flat
-// host exercises on a real Windows machine. No markdown, no undo stack, no
-// menu — just caret, selection, typing, word-dance, copy/paste, basic
-// formatting and IME over one plain document. Build for the desktop host:
+// host exercises on a real Windows machine. No markdown, no rich text, no
+// undo stack, no menu — just caret, selection, typing, word-dance,
+// copy/paste and IME over one plain document. Build for the desktop host:
 //
 //   bun tools/build.ts acceptance-main --density=2
-//   cargo run -p note-widget -- --app acceptance-main --identity windows-app \
-//     --host-abi 3 --width 1000 --height 700
+//   cargo run -p note-widget -- --app acceptance-main --form window \
+//     --identity windows-app --host-abi 3 --width 1000 --height 700
 //
 // Same bundle boots on any ui host; without the widget host's svc channel
 // it renders the sample document read-only.

--- a/apps/acceptance/pocket.json
+++ b/apps/acceptance/pocket.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://pocketjs.dev/schema/pocket-2.json",
+  "pocket": 2,
+  "id": "dev.pocket-stack.acceptance",
+  "name": "pocket-acceptance",
+  "title": "Pocket Acceptance",
+  "version": "0.1.0",
+  "engine": {
+    "capabilities": {
+      "requires": [
+        "text.glyphs.baked",
+        "input.buttons"
+      ],
+      "enhances": [
+        "input.text",
+        "input.pointer",
+        "input.ime",
+        "host.clipboard",
+        "display.viewport.live",
+        "text.glyphs.runtime"
+      ]
+    }
+  },
+  "app": {
+    "entry": "apps/acceptance/main.tsx",
+    "output": "acceptance-main",
+    "framework": "solid",
+    "viewport": {
+      "dynamic": {
+        "default": [
+          1000,
+          700
+        ],
+        "min": [
+          240,
+          180
+        ]
+      }
+    }
+  }
+}

--- a/apps/note/svc.ts
+++ b/apps/note/svc.ts
@@ -15,7 +15,9 @@
 //   {t:"ch", s}                typed characters (batched, layout applied)
 //   {t:"key", k}               named key: Backspace Delete Enter Tab Left
 //                              Right Up Down Home End PageUp PageDown Escape
-//                              Copy Cut Undo Redo (⌘-chords arrive as keys)
+//                              Copy Cut Undo Redo WordLeft WordRight
+//                              (primary-modifier chords arrive as keys:
+//                              ⌘C/⌘X/⌘Z/⇧⌘Z/⌘V and ⌘/Ctrl+arrow word-dance)
 //   {t:"paste", text}          insert the system clipboard (⌘V — the host
 //                              reads it and pushes the text)
 //   {t:"ime", s, c}            IME composition: preedit text + caret char

--- a/docs/windows-desktop-w1-report.md
+++ b/docs/windows-desktop-w1-report.md
@@ -1,6 +1,19 @@
 # W1 — PocketJS Windows Desktop Enablement: Final Report
 
-Fork: `jnhu76/pocketjs` · Branch: `feat/windows-desktop` · Status: **FOUNDATION BOUNDARY CLOSED** (real-Windows evidence pending)
+Fork: `jnhu76/pocketjs` · Branch: `feat/windows-desktop`
+
+```text
+W1 IMPLEMENTATION:       CODE_COMPLETE_PENDING_VALIDATION
+POCKETJS_WINDOWS_DESKTOP: NOT_PROVEN
+MARKIT PRODUCT WORK:     UNBLOCKED_TO_START_IN_PARALLEL
+```
+
+Code-complete means every W1 mechanism is implemented and green on the
+Linux dry-run host. NOT_PROVEN stands until the PLATFORM_INTEGRATION
+acceptance run executes on a real Windows machine — that is the hard gate.
+These two verdicts coexist on purpose: Markit P0 can start in parallel
+(no foundation blocker surfaced), but starting product work is not evidence
+that the Windows gate closed.
 
 ## 16.1 Baseline
 
@@ -28,18 +41,26 @@ Fork: `jnhu76/pocketjs` · Branch: `feat/windows-desktop` · Status: **FOUNDATIO
 | `db80888` | `test(desktop): reproducible acceptance proof run for the generic text surface` |
 | `8058657` | `fix(tools): make filesystem URL conversion Windows-safe` |
 | `0b41e4b` | `fix(widget): fall back to an opaque surface when alpha is unsupported` |
+| `4d877b4` | `feat(host): explicit --form window posture for the flat desktop host` |
+| `b9e28f2` | `feat(acceptance): pair the rig on a provisional windows-app target` |
+| `2e4e5b8` | `refactor(acceptance): drop rich-text formatting from the gate surface` |
 
 ## 16.2 Capability matrix
 
 Evidence levels: `AUTOMATED_PASS` (bun test / headless dry-run), `MANUAL_PASS`, `NOT_TESTED`, `DEFERRED` (mechanism in place, real-Windows evidence pending).
 
+Evidence classes — a headless screenshot and a windowed OS run prove different things and are labeled differently:
+
+- `DESKTOP_WIRE_ACCEPTANCE` (automated, `bun tools/acceptance.ts`): scripted `--type/--paste/--key` inject **svc lines directly**. This proves the svc protocol, the guest editing surface and DrawList rendering. It does NOT exercise the OS input stack (winit → Input → `forward_edits`/`forward_ime` → primary chords), and `--paste` is injected text, not a system clipboard read.
+- `PLATFORM_INTEGRATION_ACCEPTANCE` (windowed, on the target OS): the real keyboard/IME/clipboard path through `--form window`. Nothing below claims this on Windows yet.
+
 | Capability | Status | Automated | Manual | Evidence |
 | --- | --- | --- | --- | --- |
-| Opaque desktop window | PROVEN (Linux) | `acceptance-proof.png` @2x, opaque fill verified | Windows: DEFERRED | Linux headless screenshot (vision-verified) |
+| Opaque desktop window | fill PROVEN (headless); posture CODE (`--form window`) | opaque fill in `acceptance-proof.png` @2x; posture config: `transparent:false, decorations:true, always_on_top:false` | Windows: DEFERRED | headless render proves the opaque FILL only — no OS window exists headless; posture awaits the windowed run |
 | Resize (live re-wrap) | code path in place | headless is fixed-size | Windows: DEFERRED | host `{"t":"resize"}` → `resizeViewport` → `layoutDoc` re-wrap |
 | Pointer (click/drag selection) | code path in place | — | Windows: DEFERRED | svc mouse stream → `caretFromX` drag selection |
-| Keyboard | PROVEN (Linux, svc-injected) | scripted `--type` landed at caret (doc 374→393) | Windows: DEFERRED | acceptance-proof.png |
-| Text input | PROVEN (Linux, svc-injected) | typed chars + paste inserted | Windows: DEFERRED | acceptance-proof.png (length + content) |
+| Keyboard | DESKTOP_WIRE (svc-injected) | scripted `--type` landed at caret | Windows: DEFERRED | acceptance-proof.png — wire-level, not the OS keyboard path |
+| Text input | DESKTOP_WIRE (svc-injected) | typed chars + paste inserted | Windows: DEFERRED | acceptance-proof.png (length + content) — wire-level |
 | Primary modifier | PROVEN (unit) | `primary_modifier_is_control_off_macos` + host chord remap | — | `cargo test -p pocket3d --lib input` (5 pass) |
 | Clipboard | PROVEN (typecheck Win32 + platform gate test) | `pocket-clipboard` tests on Linux (gate) + `--target x86_64-pc-windows-msvc` check | Windows round-trip: DEFERRED | `cargo check -p pocket-clipboard --target x86_64-pc-windows-msvc` |
 | CJK runtime glyphs | PROVEN (mechanism + discovery) | Linux dry-run shows tofu (expected — no Linux CJK face) | Windows: DEFERRED | cjk.rs `%WINDIR%` discovery, msyh.ttc first |
@@ -82,7 +103,8 @@ KEEP_DOWNSTREAM (not touched, not planned): Markit LineIndex, Markdown BlockInde
 - **IME** not hand-verified anywhere; code path + scripted svc path only. Microsoft Pinyin specifically cannot be simulated in CI.
 - **CJK glyph bake** not seen rendering on a real font; Linux host has no CJK candidate (tofu expected and observed).
 - **Clipboard Win32** typechecked only (`cargo check --target x86_64-pc-windows-msvc`); round-trip tests are `#[cfg(windows)]`-gated and will run on a Windows machine.
-- **Temporary target naming**: the acceptance app builds against the registered `macos-widget` contract; `windows-app` is a proposal, not a registered target. Host identity is a CLI parameter, not a contract.
+- **`windows-app` is provisional by design**: the formal `POCKET_TARGETS` registry is unchanged; the acceptance rig resolves against a test-local profile (`tools/acceptance-target.ts`) so the bundle and the windowed host pair on one identity (`windows-app`, hostAbi 3). Promoting it to a registered contract — and whether it keeps hostAbi 3 — is the W1-G upstream discussion.
+- **Unicode indexing seam (recorded follow-up)**: the Rust IME path converts winit's preedit cursor from byte offset to **Unicode scalar count**, while the guest editor positions its caret in **UTF-16 code units** (JS `string.length`/`slice`). BMP text — ASCII + BMP CJK, the W1 validation charset — is unaffected. Astral codepoints (emoji, CJK Extension B) occupy two JS code units and can land a caret/backspace/IME cursor inside a surrogate pair. W1 validation is scoped to **ASCII + BMP CJK**; unified indexing is a follow-up, not deferred silently.
 - **Font candidates** are a fixed reference list (msyh/simsun/simhei/DengXian under %WINDIR%); a registry-based discovery (registry queries / enumeration) is the follow-up seam.
 - Linux/macOS desktop implementation is out of scope for this round (mechanisms are platform-neutral by construction).
 
@@ -100,6 +122,13 @@ observed capabilities (what the W1 mechanisms actually deliver):
   text.glyphs.baked, text.glyphs.runtime
 ```
 
+The acceptance rig already runs against this profile as a test-local
+provisional registry (`tools/acceptance-target.ts`: POCKET_TARGETS +
+`windows-app`, hostAbi 3) so the bundle and the windowed host pair on one
+identity today. Promoting the profile — its id, its hostAbi, its capability
+set — into `contracts/spec/platforms.ts` is the upstream decision; until
+then the formal registry stays untouched.
+
 Open questions for upstream discussion:
 
 1. **`windows-app` vs a shared desktop abstraction**: `macos-widget` is borderless/always-on-top/widget-form; a decorated resizable window is a different posture. `form=window` should likely become a generic form, with `macos-widget` staying widget-form.
@@ -110,20 +139,24 @@ Open questions for upstream discussion:
 ## 16.6 Verdicts
 
 ```text
+W1 IMPLEMENTATION: CODE_COMPLETE_PENDING_VALIDATION
+  — every mechanism implemented; Linux dry-run green (DESKTOP_WIRE
+    acceptance). The windowed --form window host and the paired
+    windows-app bundle are ready for the real machine.
+
 POCKETJS_WINDOWS_DESKTOP: NOT_PROVEN
-  — all mechanisms implemented and Linux dry-run green, but real-Windows
-    evidence is the hard gate and no Windows machine was available.
-    Validation commands are prepared (below).
+  — PLATFORM_INTEGRATION evidence is the hard gate; no Windows machine
+    was available. Validation commands are prepared (below).
 
 UPSTREAM_READINESS: READY_FOR_INCREMENTAL_UPSTREAMING
   — the four UPSTREAM_NOW units (portability, primary modifier,
     clipboard, alpha fallback) are small, independent, tested, and have
     no Markit dependency.
 
-MARKIT: READY_FOR_PRODUCT_P0
+MARKIT: UNBLOCKED_TO_START_IN_PARALLEL
   — no foundation blocker surfaced that blocks Markit product work.
-    W1 closes the foundation boundary; Markit P0 can start. Real-Windows
-    validation of the substrate runs alongside, not ahead of, P0.
+    Markit P0 starting is NOT W1 closing; real-Windows validation of the
+    substrate runs alongside, not ahead of, P0.
 ```
 
 ## W1-E/B validation commands (for a Windows machine, in order)
@@ -131,14 +164,14 @@ MARKIT: READY_FOR_PRODUCT_P0
 ```text
 # 1. build the acceptance rig (Windows PowerShell, repo root)
 bun install
-bun run acceptance          # builds plan bundle + host + headless proof
-                            #   -> dist/acceptance-proof.png
+bun tools/acceptance.ts       # windows-app plan bundle + host + DESKTOP_WIRE
+                              #   headless proof -> dist/acceptance-proof.png
 
-# 2. windowed manual acceptance (the NOT_EXECUTED list)
-cargo run -p note-widget -- --app acceptance-main --identity windows-app ^
-  --host-abi 3 --width 1000 --height 700
+# 2. windowed PLATFORM_INTEGRATION acceptance (the NOT_EXECUTED list)
+cargo run -p note-widget -- --app acceptance-main --form window ^
+  --identity windows-app --host-abi 3 --width 1000 --height 700
   # manual: type, click-drag select, Ctrl+C/V/X, Ctrl+Left/Right word-dance,
-  # Ctrl+B/I/U, resize (re-wrap), Microsoft Pinyin preedit + commit,
+  # resize (re-wrap), Microsoft Pinyin preedit + commit,
   # CJK 汉字 visible (msyh.ttc), clean close
 
 # 3. clipboard round-trip (real Windows)
@@ -149,5 +182,5 @@ bun tools/test.ts
 cargo test -p pocket3d -p pocket-clipboard -p pocket-widget
 
 # 5. file evidence
-dist/acceptance-proof.png     # opaque window + typed/pasted text
+dist/acceptance-proof.png     # opaque surface + typed/pasted text (wire-level)
 ```

--- a/docs/windows-desktop-w1-report.md
+++ b/docs/windows-desktop-w1-report.md
@@ -1,0 +1,153 @@
+# W1 — PocketJS Windows Desktop Enablement: Final Report
+
+Fork: `jnhu76/pocketjs` · Branch: `feat/windows-desktop` · Status: **FOUNDATION BOUNDARY CLOSED** (real-Windows evidence pending)
+
+## 16.1 Baseline
+
+| Item | Value |
+| --- | --- |
+| Upstream base | `cadffef50b0359e1a069586b9dc5574d65d7fb05` (upstream/main, `docs(blog): derive the embedded agent-native runtime (#281)`) |
+| Fork branch | `feat/windows-desktop` |
+| Branch HEAD | see `git log --oneline -10` |
+| Toolchain | rustc/cargo (Linux x64), Bun 1.3.14, wgpu via llvmpipe (software Vulkan) |
+| Dev host | Linux (headless) — no Windows machine attached |
+| Old archive | `archive/windows-desktop-wip` @ `1ac09d51` — reference/evidence only; nothing cherry-picked wholesale |
+
+## Commit ledger (this W1 round)
+
+| Commit | Change |
+| --- | --- |
+| `2c32e80` | `feat(input): primary shortcut modifier — Command on macOS, Control elsewhere` |
+| `bc89435` | `feat(clipboard): portable system clipboard with a hardened Win32 backend` |
+| `e62c68c` | `feat(cjk): resolve Windows fallback fonts through %WINDIR%/SystemRoot` |
+| `c4e7906` | `fix(host): resolve the home directory through USERPROFILE on Windows` |
+| `66b2eca` | `feat(host): make the flat host's platform identity configurable` |
+| `5bc5674` | `fix(host): drive editing chords off the primary modifier, not super` |
+| `b8a8cfc` | `feat(host): word-dance — primary+arrow forwards as WordLeft/WordRight` |
+| `f3464a4` | `feat(acceptance): generic text acceptance app for the desktop host` |
+| `db80888` | `test(desktop): reproducible acceptance proof run for the generic text surface` |
+| `8058657` | `fix(tools): make filesystem URL conversion Windows-safe` |
+| `0b41e4b` | `fix(widget): fall back to an opaque surface when alpha is unsupported` |
+
+## 16.2 Capability matrix
+
+Evidence levels: `AUTOMATED_PASS` (bun test / headless dry-run), `MANUAL_PASS`, `NOT_TESTED`, `DEFERRED` (mechanism in place, real-Windows evidence pending).
+
+| Capability | Status | Automated | Manual | Evidence |
+| --- | --- | --- | --- | --- |
+| Opaque desktop window | PROVEN (Linux) | `acceptance-proof.png` @2x, opaque fill verified | Windows: DEFERRED | Linux headless screenshot (vision-verified) |
+| Resize (live re-wrap) | code path in place | headless is fixed-size | Windows: DEFERRED | host `{"t":"resize"}` → `resizeViewport` → `layoutDoc` re-wrap |
+| Pointer (click/drag selection) | code path in place | — | Windows: DEFERRED | svc mouse stream → `caretFromX` drag selection |
+| Keyboard | PROVEN (Linux, svc-injected) | scripted `--type` landed at caret (doc 374→393) | Windows: DEFERRED | acceptance-proof.png |
+| Text input | PROVEN (Linux, svc-injected) | typed chars + paste inserted | Windows: DEFERRED | acceptance-proof.png (length + content) |
+| Primary modifier | PROVEN (unit) | `primary_modifier_is_control_off_macos` + host chord remap | — | `cargo test -p pocket3d --lib input` (5 pass) |
+| Clipboard | PROVEN (typecheck Win32 + platform gate test) | `pocket-clipboard` tests on Linux (gate) + `--target x86_64-pc-windows-msvc` check | Windows round-trip: DEFERRED | `cargo check -p pocket-clipboard --target x86_64-pc-windows-msvc` |
+| CJK runtime glyphs | PROVEN (mechanism + discovery) | Linux dry-run shows tofu (expected — no Linux CJK face) | Windows: DEFERRED | cjk.rs `%WINDIR%` discovery, msyh.ttc first |
+| IME preedit | code path in place | — | Windows: DEFERRED | host `forward_ime` + app preedit underline |
+| IME commit | code path in place | — | Windows: DEFERRED | commits arrive as `{"t":"ch"}` |
+| Demand rendering | stock mechanism | — | Windows: DEFERRED | governor receipt on windowed exit (note-widget) |
+| Clean start/shutdown | PROVEN (Linux headless) | 90-frame run exits cleanly | Windows: DEFERRED | acceptance tool run |
+
+## Path portability audit (bounded)
+
+| Site class | Audited | Changed | Intentionally unchanged |
+| --- | --- | --- | --- |
+| `tools/*.ts` root/path via `new URL(..).pathname` | 24 files | 24 (→ `tools/fs-url.ts` `fsPath` = `fileURLToPath`) | — |
+| `framework/compiler/jsx-plugin.ts` fs paths | 11 consts | 11 | `COMPILER_DIR` (URL-prefix semantics, line 87) |
+| `framework/compiler/jsx-plugin.ts` URL objects | lines 104-111 | — | URL-object matching/resolution (`url.pathname` prefix, `new URL(path, url)`) |
+| Regression coverage | — | `tests/path-portability.test.ts` (5 tests) | — |
+
+Windows-shaped URLs yield `/C:/…` from `.pathname` and keep `%20`; `fileURLToPath` decodes and strips the drive-letter slash. Tests pin both shapes.
+
+## 16.3 Upstream extraction matrix
+
+| Change | Ownership | Upstream action |
+| --- | --- | --- |
+| URL/path portability (`tools/fs-url.ts` + 24 sites + tests) | PocketJS | UPSTREAM_NOW — small, tested, no Markit dependency |
+| Primary modifier (`Input::primary_down`, host chords, word-dance) | PocketJS | UPSTREAM_NOW — unit-tested, Ctrl/Cmd semantic |
+| Portable clipboard (`pocket-clipboard` crate) | PocketJS | UPSTREAM_NOW — hardened Win32 + pbcopy/pbpaste, standalone crate |
+| Alpha fallback (opaque when alpha unsupported) | PocketJS | UPSTREAM_NOW — boot resilience, no product dependency |
+| Windows CJK font discovery (`%WINDIR%` + candidate list) | PocketJS | UPSTREAM_AFTER_ALIGNMENT — mechanism generic; a `FontProvider` seam is a follow-up, not a W1 blocker |
+| `windows-app` desktop target / form / hostAbi | PocketJS architecture | DISCUSSION FIRST — proposal below, no contract file changed |
+| Acceptance host identity flag (`--identity/--host-abi`) | PocketJS | UPSTREAM_AFTER_ALIGNMENT — flat host generalization; naming with target discussion |
+| Generic acceptance app (`apps/acceptance`) | PocketJS test/example | EVALUATE — demo-shelf admission matrix updated (`acceptance: [false,false,true]`) |
+| USERPROFILE fallback (host home dir) | PocketJS | UPSTREAM_NOW (small, with portability commit family) |
+| Windows CI | PocketJS | UPSTREAM_AFTER_ALIGNMENT — depends on target contract |
+
+KEEP_DOWNSTREAM (not touched, not planned): Markit LineIndex, Markdown BlockIndex, incremental Markdown parser, Markit view model, benchmark harness, product editor behavior.
+
+## 16.4 Known limitations (honest)
+
+- **Real Windows validation NOT EXECUTED**: no Windows machine on this host. All real-platform cells above are DEFERRED; nothing is claimed PASS on Windows without evidence.
+- **IME** not hand-verified anywhere; code path + scripted svc path only. Microsoft Pinyin specifically cannot be simulated in CI.
+- **CJK glyph bake** not seen rendering on a real font; Linux host has no CJK candidate (tofu expected and observed).
+- **Clipboard Win32** typechecked only (`cargo check --target x86_64-pc-windows-msvc`); round-trip tests are `#[cfg(windows)]`-gated and will run on a Windows machine.
+- **Temporary target naming**: the acceptance app builds against the registered `macos-widget` contract; `windows-app` is a proposal, not a registered target. Host identity is a CLI parameter, not a contract.
+- **Font candidates** are a fixed reference list (msyh/simsun/simhei/DengXian under %WINDIR%); a registry-based discovery (registry queries / enumeration) is the follow-up seam.
+- Linux/macOS desktop implementation is out of scope for this round (mechanisms are platform-neutral by construction).
+
+## 16.5 W1-G — TARGET PROFILE PROPOSAL (PROVISIONAL — NOT YET AN UPSTREAM CONTRACT DECISION)
+
+```text
+candidate:  windows-app
+platform:   windows
+form:       window          (proposed new generic form; distinct from widget)
+hostAbi:    TBD by upstream (new number or shared wire generation — discussion)
+observed capabilities (what the W1 mechanisms actually deliver):
+  display.viewport.live
+  input.buttons, input.pointer, input.text, input.ime
+  host.clipboard
+  text.glyphs.baked, text.glyphs.runtime
+```
+
+Open questions for upstream discussion:
+
+1. **`windows-app` vs a shared desktop abstraction**: `macos-widget` is borderless/always-on-top/widget-form; a decorated resizable window is a different posture. `form=window` should likely become a generic form, with `macos-widget` staying widget-form.
+2. **hostAbi**: new number vs reusing the wire generation macos-widget uses (the flat host is the same wire). Registry convention says hosts with the same observable semantics share — but hostAbi is also a wire-generation marker; upstream decides.
+3. **Transparent/widget semantics**: separate from normal desktop window. The alpha fallback (opaque) makes transparency an optional capability, not a boot requirement.
+4. **Capability truth**: the registry should record what the acceptance rig proved, not product wishes. The acceptance surface is the proof tool.
+
+## 16.6 Verdicts
+
+```text
+POCKETJS_WINDOWS_DESKTOP: NOT_PROVEN
+  — all mechanisms implemented and Linux dry-run green, but real-Windows
+    evidence is the hard gate and no Windows machine was available.
+    Validation commands are prepared (below).
+
+UPSTREAM_READINESS: READY_FOR_INCREMENTAL_UPSTREAMING
+  — the four UPSTREAM_NOW units (portability, primary modifier,
+    clipboard, alpha fallback) are small, independent, tested, and have
+    no Markit dependency.
+
+MARKIT: READY_FOR_PRODUCT_P0
+  — no foundation blocker surfaced that blocks Markit product work.
+    W1 closes the foundation boundary; Markit P0 can start. Real-Windows
+    validation of the substrate runs alongside, not ahead of, P0.
+```
+
+## W1-E/B validation commands (for a Windows machine, in order)
+
+```text
+# 1. build the acceptance rig (Windows PowerShell, repo root)
+bun install
+bun run acceptance          # builds plan bundle + host + headless proof
+                            #   -> dist/acceptance-proof.png
+
+# 2. windowed manual acceptance (the NOT_EXECUTED list)
+cargo run -p note-widget -- --app acceptance-main --identity windows-app ^
+  --host-abi 3 --width 1000 --height 700
+  # manual: type, click-drag select, Ctrl+C/V/X, Ctrl+Left/Right word-dance,
+  # Ctrl+B/I/U, resize (re-wrap), Microsoft Pinyin preedit + commit,
+  # CJK 汉字 visible (msyh.ttc), clean close
+
+# 3. clipboard round-trip (real Windows)
+cargo test -p pocket-clipboard --target x86_64-pc-windows-msvc
+
+# 4. CI-capable subset (windows-latest)
+bun tools/test.ts
+cargo test -p pocket3d -p pocket-clipboard -p pocket-widget
+
+# 5. file evidence
+dist/acceptance-proof.png     # opaque window + typed/pasted text
+```

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1354,6 +1354,7 @@ dependencies = [
  "glam",
  "log",
  "memmap2",
+ "pocket-clipboard",
  "pocket-mod",
  "pocket-ui-wgpu",
  "pocket-widget",
@@ -1742,6 +1743,14 @@ dependencies = [
  "pocket-ui-surface",
  "pocketjs-core",
  "rquickjs",
+]
+
+[[package]]
+name = "pocket-clipboard"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "windows",
 ]
 
 [[package]]

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/pocket-fs",
     "crates/pocket-mod",
     "crates/pocket-net",
+    "crates/pocket-clipboard",
     "crates/pocket-ui-surface",
     "crates/pocket-ui-wgpu",
     "crates/pocket-vrm",
@@ -52,6 +53,7 @@ pocket-db = { path = "crates/pocket-db" }
 pocket-fs = { path = "crates/pocket-fs" }
 pocket-mod = { path = "crates/pocket-mod" }
 pocket-net = { path = "crates/pocket-net" }
+pocket-clipboard = { path = "crates/pocket-clipboard" }
 pocket-ui-surface = { path = "crates/pocket-ui-surface" }
 pocket-ui-wgpu = { path = "crates/pocket-ui-wgpu" }
 pocket-vrm = { path = "crates/pocket-vrm" }

--- a/engine/crates/pocket-clipboard/Cargo.toml
+++ b/engine/crates/pocket-clipboard/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "pocket-clipboard"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "OS clipboard as a platform abstraction: copy/paste Unicode text on macOS (pbcopy/pbpaste) and Windows (Win32 CF_UNICODETEXT), unsupported elsewhere"
+
+[dependencies]
+log = { workspace = true }
+
+[target.'cfg(windows)'.dependencies]
+windows = { version = "0.58", features = [
+    "Win32_Foundation",
+    "Win32_System_DataExchange",
+    "Win32_System_Memory",
+] }

--- a/engine/crates/pocket-clipboard/src/lib.rs
+++ b/engine/crates/pocket-clipboard/src/lib.rs
@@ -1,0 +1,256 @@
+//! OS clipboard as a platform abstraction.
+//!
+//! The desktop host previously talked to `pbcopy`/`pbpaste` directly
+//! (macOS-only, warning on other platforms). This crate owns the system
+//! boundary instead:
+//!
+//! - macOS: `pbcopy`/`pbpaste` (unchanged behavior — the zero-dependency
+//!   road stays the macOS road).
+//! - Windows: the Win32 clipboard (CF_UNICODETEXT, so UTF-16; all Unicode
+//!   round-trips, including CJK and multiline).
+//! - other platforms: unsupported — callers get a clear result instead of
+//!   a silent log line.
+//!
+//! The API is deliberately the smallest thing a text editor needs: put
+//! text on, take text off. A future Linux backend slots in behind the same
+//! two functions.
+
+use std::io;
+
+/// Copy `text` to the system clipboard. Returns Ok when the platform has a
+/// backend and the copy succeeded. An empty string is a no-op that leaves
+/// the clipboard untouched.
+pub fn copy(text: &str) -> io::Result<()> {
+    if text.is_empty() {
+        return Ok(());
+    }
+    #[cfg(target_os = "macos")]
+    {
+        use std::io::Write;
+        let mut child = std::process::Command::new("pbcopy")
+            .stdin(std::process::Stdio::piped())
+            .spawn()?;
+        child.stdin.as_mut().unwrap().write_all(text.as_bytes())?;
+        child.wait()?;
+        Ok(())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows::copy(text)
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "clipboard copy unsupported on this platform",
+        ))
+    }
+}
+
+/// Read the system clipboard as a UTF-8 string. `None` when the clipboard
+/// holds no text (or the platform has no backend).
+pub fn paste() -> Option<String> {
+    #[cfg(target_os = "macos")]
+    {
+        let out = std::process::Command::new("pbpaste").output().ok()?;
+        Some(String::from_utf8_lossy(&out.stdout).into_owned())
+    }
+    #[cfg(target_os = "windows")]
+    {
+        windows::paste()
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+    {
+        None
+    }
+}
+
+#[cfg(target_os = "windows")]
+mod windows {
+    use std::io;
+    use std::time::Duration;
+
+    use windows::Win32::Foundation::{GlobalFree, HANDLE, HGLOBAL};
+    use windows::Win32::System::DataExchange::{
+        CloseClipboard, EmptyClipboard, GetClipboardData, OpenClipboard, SetClipboardData,
+    };
+    use windows::Win32::System::Memory::{
+        GlobalAlloc, GlobalLock, GlobalSize, GlobalUnlock, GMEM_MOVEABLE,
+    };
+
+    /// CF_UNICODETEXT — clipboard data as UTF-16, NUL-terminated.
+    const CF_UNICODETEXT: u32 = 13;
+
+    fn to_io(e: windows::core::Error) -> io::Error {
+        io::Error::other(e.message())
+    }
+
+    /// OpenClipboard fails while another process owns the clipboard; the
+    /// docs recommend retrying. Bounded so a wedged peer cannot hang a
+    /// paste.
+    fn open_clipboard_with_retry() -> io::Result<()> {
+        for _ in 0..8 {
+            if unsafe { OpenClipboard(None) }.is_ok() {
+                return Ok(());
+            }
+            std::thread::sleep(Duration::from_millis(15));
+        }
+        Err(io::Error::other("clipboard is busy"))
+    }
+
+    pub(super) fn copy(text: &str) -> io::Result<()> {
+        // The clipboard is a process-shared resource; every step that can
+        // fail must be checked or the window could hold the lock forever.
+        unsafe {
+            open_clipboard_with_retry()?;
+            let result = (|| -> io::Result<()> {
+                EmptyClipboard().map_err(to_io)?;
+                // UTF-16 including the NUL terminator, in bytes.
+                let mut units: Vec<u16> = text.encode_utf16().collect();
+                units.push(0);
+                let bytes = units.len() * 2;
+                let mem = GlobalAlloc(GMEM_MOVEABLE, bytes).map_err(to_io)?;
+                let ptr = GlobalLock(mem);
+                if ptr.is_null() {
+                    let _ = GlobalFree(mem);
+                    return Err(io::Error::other("GlobalLock failed"));
+                }
+                std::ptr::copy_nonoverlapping(units.as_ptr() as *const u8, ptr.cast(), bytes);
+                // GlobalUnlock's BOOL is FALSE exactly when the object
+                // becomes fully unlocked — the success case — so windows-rs
+                // turns the normal path into an Err(ERROR_SUCCESS). The
+                // handle is ours (or the system's, after SetClipboardData),
+                // so the return is meaningless here.
+                let _ = GlobalUnlock(mem);
+                match SetClipboardData(CF_UNICODETEXT, HANDLE(mem.0)) {
+                    // Success: the system owns `mem` now.
+                    Ok(_) => Ok(()),
+                    // Failure: the transfer never happened; reclaim the
+                    // allocation so it cannot leak.
+                    Err(e) => {
+                        let _ = GlobalFree(mem);
+                        Err(to_io(e))
+                    }
+                }
+            })();
+            let close = CloseClipboard();
+            match (result, close) {
+                (Err(e), _) => Err(e),
+                (Ok(()), Err(e)) => Err(to_io(e)),
+                (Ok(()), Ok(())) => Ok(()),
+            }
+        }
+    }
+
+    pub(super) fn paste() -> Option<String> {
+        unsafe {
+            open_clipboard_with_retry().ok()?;
+            let handle = match GetClipboardData(CF_UNICODETEXT) {
+                Ok(h) if !h.is_invalid() => h,
+                _ => {
+                    let _ = CloseClipboard();
+                    return None;
+                }
+            };
+            let mem = HGLOBAL(handle.0);
+            let ptr = GlobalLock(mem);
+            if ptr.is_null() {
+                let _ = CloseClipboard();
+                return None;
+            }
+            // Bound the read by the allocation size — never walk past the
+            // clipboard block, whatever its contents claim.
+            let units = GlobalSize(mem) / 2;
+            let slice = std::slice::from_raw_parts(ptr.cast::<u16>(), units);
+            let end = slice.iter().position(|&u| u == 0).unwrap_or(slice.len());
+            let text = String::from_utf16(&slice[..end]).ok();
+            let _ = GlobalUnlock(mem);
+            let _ = CloseClipboard();
+            text
+        }
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use std::sync::Mutex;
+
+        /// The clipboard is process-global — the harness runs tests in
+        /// parallel threads, so every test serializes through this lock.
+        static CLIP: Mutex<()> = Mutex::new(());
+
+        fn clear() {
+            unsafe {
+                let _ = OpenClipboard(None);
+                let _ = EmptyClipboard();
+                let _ = CloseClipboard();
+            }
+        }
+
+        #[test]
+        fn copy_paste_round_trips_ascii() {
+            let _guard = CLIP.lock().unwrap();
+            clear();
+            copy("hello clipboard").unwrap();
+            assert_eq!(paste().as_deref(), Some("hello clipboard"));
+        }
+
+        #[test]
+        fn copy_paste_round_trips_cjk() {
+            let _guard = CLIP.lock().unwrap();
+            clear();
+            copy("你好，世界").unwrap();
+            assert_eq!(paste().as_deref(), Some("你好，世界"));
+        }
+
+        #[test]
+        fn copy_paste_round_trips_multiline() {
+            let _guard = CLIP.lock().unwrap();
+            clear();
+            copy("line one\nline two\n中文行").unwrap();
+            assert_eq!(paste().as_deref(), Some("line one\nline two\n中文行"));
+        }
+
+        #[test]
+        fn empty_clipboard_pastes_none() {
+            let _guard = CLIP.lock().unwrap();
+            clear();
+            assert_eq!(paste(), None);
+        }
+
+        #[test]
+        fn empty_copy_leaves_clipboard_alone() {
+            let _guard = CLIP.lock().unwrap();
+            clear();
+            copy("hello clipboard").unwrap();
+            copy("").unwrap();
+            assert_eq!(paste().as_deref(), Some("hello clipboard"));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_copy_is_a_noop_everywhere() {
+        assert!(copy("").is_ok());
+    }
+
+    #[test]
+    fn unsupported_platforms_report_clearly() {
+        // On platforms without a backend the gate must say so — the macOS
+        // note host previously swallowed this as a bare warning.
+        #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+        {
+            let err = copy("x").unwrap_err();
+            assert_eq!(err.kind(), std::io::ErrorKind::Unsupported);
+            assert_eq!(paste(), None);
+        }
+        #[cfg(any(target_os = "macos", target_os = "windows"))]
+        {
+            let _ = copy("x");
+        }
+    }
+}

--- a/engine/crates/pocket-widget/src/shell.rs
+++ b/engine/crates/pocket-widget/src/shell.rs
@@ -393,7 +393,20 @@ impl<D: Driver> WidgetApp<D> {
             .ok_or_else(|| anyhow::anyhow!("surface not supported by adapter"))?;
         surface_config.present_mode = wgpu::PresentMode::AutoVsync;
         if self.config.transparent {
-            surface_config.alpha_mode = pick_alpha_mode(&surface, &gpu.adapter)?;
+            surface_config.alpha_mode = match pick_alpha_mode(&surface, &gpu.adapter) {
+                Some(mode) => mode,
+                None => {
+                    // Truthful fallback: a backend without alpha support
+                    // (non-composited sessions, some remote desktops) must
+                    // not kill the boot — the window degrades to the app's
+                    // own opaque background, with a diagnostic.
+                    log::warn!(
+                        "transparent window requested but surface supports no alpha mode — \
+                         falling back to an opaque surface"
+                    );
+                    wgpu::CompositeAlphaMode::Opaque
+                }
+            };
         }
         surface.configure(&gpu.device, &surface_config);
 

--- a/engine/pocket3d/crates/pocket3d/src/app.rs
+++ b/engine/pocket3d/crates/pocket3d/src/app.rs
@@ -153,7 +153,16 @@ impl<G: Game> WinitApp<G> {
             .ok_or_else(|| anyhow::anyhow!("surface not supported by adapter"))?;
         surface_config.present_mode = wgpu::PresentMode::AutoVsync;
         if self.config.transparent {
-            surface_config.alpha_mode = pick_alpha_mode(&surface, &gpu.adapter)?;
+            surface_config.alpha_mode = match pick_alpha_mode(&surface, &gpu.adapter) {
+                Some(mode) => mode,
+                None => {
+                    log::warn!(
+                        "transparent window requested but surface supports no alpha mode — \
+                         falling back to an opaque surface"
+                    );
+                    wgpu::CompositeAlphaMode::Opaque
+                }
+            };
         }
         surface.configure(&gpu.device, &surface_config);
 
@@ -243,7 +252,7 @@ impl<G: Game> WinitApp<G> {
 pub fn pick_alpha_mode(
     surface: &wgpu::Surface<'_>,
     adapter: &wgpu::Adapter,
-) -> Result<wgpu::CompositeAlphaMode> {
+) -> Option<wgpu::CompositeAlphaMode> {
     let caps = surface.get_capabilities(adapter);
     for want in [
         wgpu::CompositeAlphaMode::PreMultiplied,
@@ -251,13 +260,13 @@ pub fn pick_alpha_mode(
         wgpu::CompositeAlphaMode::Inherit,
     ] {
         if caps.alpha_modes.contains(&want) {
-            return Ok(want);
+            return Some(want);
         }
     }
-    anyhow::bail!(
-        "transparent window requested but surface only supports {:?}",
-        caps.alpha_modes
-    )
+    // No alpha-capable mode (non-composited sessions, some remote
+    // desktops): callers fall back to an Opaque surface rather than
+    // failing the whole boot.
+    None
 }
 
 fn set_mouse_capture(state: &mut WindowState, captured: bool) {

--- a/engine/pocket3d/crates/pocket3d/src/input.rs
+++ b/engine/pocket3d/crates/pocket3d/src/input.rs
@@ -69,6 +69,8 @@ pub struct Input {
     /// A super/command chord is held — edit consumers usually skip
     /// `Char` events while true (they are shortcuts, not typing).
     super_down: bool,
+    /// The control key is held — the primary shortcut modifier off macOS.
+    control_down: bool,
 }
 
 fn button_id(b: MouseButton) -> u8 {
@@ -118,6 +120,10 @@ impl Input {
                             self.super_down = true;
                             None
                         }
+                        Key::Named(NamedKey::Control) => {
+                            self.control_down = true;
+                            None
+                        }
                         _ => None,
                     };
                     if let Some(k) = named {
@@ -129,6 +135,8 @@ impl Input {
                     }
                 } else if matches!(&event.logical_key, Key::Named(NamedKey::Super)) {
                     self.super_down = false;
+                } else if matches!(&event.logical_key, Key::Named(NamedKey::Control)) {
+                    self.control_down = false;
                 }
             }
             WindowEvent::Ime(ime) => {
@@ -198,6 +206,7 @@ impl Input {
         self.scroll_ended = true;
         self.interaction_cancelled = true;
         self.super_down = false;
+        self.control_down = false;
     }
 
     /// Call once per simulation turn, after game logic consumed edge state.
@@ -254,6 +263,26 @@ impl Input {
         self.super_down
     }
 
+    /// A control key is currently held.
+    pub fn control_down(&self) -> bool {
+        self.control_down
+    }
+
+    /// The platform's PRIMARY shortcut modifier is held: Command on macOS,
+    /// Control everywhere else. Shortcut chords (quit, copy, paste, undo,
+    /// select-all, …) must key off this — never `super_down` — or Windows
+    /// and Linux bind the chords to the Windows/OS key instead of Ctrl.
+    pub fn primary_down(&self) -> bool {
+        #[cfg(target_os = "macos")]
+        {
+            self.super_down
+        }
+        #[cfg(not(target_os = "macos"))]
+        {
+            self.control_down
+        }
+    }
+
     pub fn key_down(&self, code: KeyCode) -> bool {
         self.down.contains(&code)
     }
@@ -273,6 +302,14 @@ impl Input {
     // --- synthetic injection (headless scripting/tests) -------------------
 
     pub fn inject_key(&mut self, code: KeyCode, down: bool) {
+        // Modifier logical state mirrors the real event path: super/control
+        // keys set their held flag (on_window_event does the same from the
+        // logical key).
+        match code {
+            KeyCode::SuperLeft | KeyCode::SuperRight => self.super_down = down,
+            KeyCode::ControlLeft | KeyCode::ControlRight => self.control_down = down,
+            _ => {}
+        }
         if down {
             if self.down.insert(code) {
                 self.pressed.insert(code);
@@ -321,6 +358,26 @@ impl Input {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn primary_modifier_is_control_off_macos() {
+        let mut input = Input::default();
+        input.inject_key(KeyCode::ControlLeft, true);
+        assert!(input.control_down());
+        assert_eq!(input.primary_down(), cfg!(not(target_os = "macos")));
+
+        // A held modifier produces no edit stream entries by itself.
+        assert!(input.edits().is_empty());
+
+        input.inject_key(KeyCode::ControlLeft, false);
+        assert!(!input.control_down());
+        assert!(!input.primary_down());
+
+        // clear() drops held modifiers too.
+        input.inject_key(KeyCode::ControlLeft, true);
+        input.clear();
+        assert!(!input.primary_down());
+    }
 
     #[test]
     fn end_frame_consumes_edges_but_preserves_held_state() {

--- a/engine/pocket3d/examples/note-widget/Cargo.toml
+++ b/engine/pocket3d/examples/note-widget/Cargo.toml
@@ -11,6 +11,7 @@ pocket3d = { workspace = true }
 pocket-mod = { workspace = true }
 pocket-ui-wgpu = { workspace = true }
 pocket-widget = { workspace = true }
+pocket-clipboard = { workspace = true }
 wgpu = { workspace = true }
 winit = { workspace = true }
 glam = { workspace = true, features = ["std"] }

--- a/engine/pocket3d/examples/note-widget/src/cjk.rs
+++ b/engine/pocket3d/examples/note-widget/src/cjk.rs
@@ -10,7 +10,6 @@
 //! baked Inter forms — only unseen codepoints go through the fallback.
 
 use std::collections::HashSet;
-use std::path::Path;
 
 use ab_glyph::{Font, FontRef, PxScale, ScaleFont, point};
 
@@ -31,6 +30,14 @@ fn slot_px(slot: u8) -> f32 {
 /// System fonts that cover CJK, tried in order; the first whose face maps
 /// '中' wins. The file is mmapped — resident memory stays at the pages the
 /// rasterizer actually touches, not the collection's tens of MB.
+///
+/// The list is per-substrate: Windows ships its CJK faces under
+/// %WINDIR%\Fonts (Microsoft YaHei first — the modern UI face;
+/// SimSun/SimHei/DengXian as the classic fallbacks), macOS under
+/// /System/Library/Fonts. Windows candidates are resolved through the
+/// WINDIR/SystemRoot environment variable so the discovery survives
+/// non-C: installs — never a hardcoded drive letter.
+#[cfg(target_os = "macos")]
 const FONT_CANDIDATES: &[&str] = &[
     "/System/Library/Fonts/PingFang.ttc",
     "/System/Library/Fonts/Hiragino Sans GB.ttc",
@@ -39,6 +46,45 @@ const FONT_CANDIDATES: &[&str] = &[
     "/Library/Fonts/Arial Unicode.ttf",
 ];
 
+/// The Windows CJK faces, in priority order, resolved under %WINDIR%.
+#[cfg(target_os = "windows")]
+fn font_candidates() -> Vec<std::path::PathBuf> {
+    use std::path::PathBuf;
+    // WINDIR is the canonical variable; SystemRoot is its legacy name.
+    // Neither is set in exotic launchers, so fall back to the default
+    // install location rather than failing open.
+    let windir = std::env::var("WINDIR")
+        .or_else(|_| std::env::var("SystemRoot"))
+        .unwrap_or_else(|_| "C:\\Windows".to_string());
+    let fonts = PathBuf::from(windir).join("Fonts");
+    [
+        "msyh.ttc",   // Microsoft YaHei — the modern UI face
+        "msyhbd.ttc", // YaHei bold
+        "simsun.ttc", // SimSun
+        "simhei.ttf", // SimHei
+        "Deng.ttf",   // DengXian
+        "Dengb.ttf",  // DengXian bold
+        "msyhl.ttc",  // YaHei light
+    ]
+    .into_iter()
+    .map(|f| fonts.join(f))
+    .collect()
+}
+
+/// Non-Windows substrates: the macOS system faces (or nothing, on hosts
+/// without a CJK system font — the host then warns and tofu appears).
+#[cfg(target_os = "macos")]
+fn font_candidates() -> Vec<std::path::PathBuf> {
+    FONT_CANDIDATES.iter().map(Into::into).collect()
+}
+
+/// Hosts with no defined CJK face (e.g. Linux): no candidates, the host
+/// warns and tofu appears.
+#[cfg(not(any(target_os = "windows", target_os = "macos")))]
+fn font_candidates() -> Vec<std::path::PathBuf> {
+    Vec::new()
+}
+
 struct GlyphSource {
     map: memmap2::Mmap,
     index: u32,
@@ -46,11 +92,11 @@ struct GlyphSource {
 
 impl GlyphSource {
     fn find() -> Option<(GlyphSource, String)> {
-        for path in FONT_CANDIDATES {
-            if !Path::new(path).exists() {
+        for path in font_candidates() {
+            if !path.exists() {
                 continue;
             }
-            let Ok(file) = std::fs::File::open(path) else {
+            let Ok(file) = std::fs::File::open(&path) else {
                 continue;
             };
             let Ok(map) = (unsafe { memmap2::Mmap::map(&file) }) else {
@@ -61,7 +107,10 @@ impl GlyphSource {
                     break;
                 };
                 if font.glyph_id('中').0 != 0 {
-                    return Some((GlyphSource { map, index }, format!("{path}#{index}")));
+                    return Some((
+                        GlyphSource { map, index },
+                        format!("{}#{index}", path.display()),
+                    ));
                 }
             }
         }

--- a/engine/pocket3d/examples/note-widget/src/main.rs
+++ b/engine/pocket3d/examples/note-widget/src/main.rs
@@ -177,7 +177,7 @@ impl NoteGame {
         for key in input.edits() {
             let named = match key {
                 EditKey::Char(c) => {
-                    if !input.super_down() {
+                    if !input.primary_down() {
                         chars.push(*c);
                     }
                     continue;
@@ -299,25 +299,29 @@ impl FlatWidget for NoteGame {
             self.send_hello();
         }
 
-        // ⌘Q / ⌘W quit (the widget has no titlebar close button).
+        // ⌘Q / ⌘W quit — the macOS widget has no titlebar close button; a
+        // decorated window quits through its own close control.
         if input.super_down()
             && (input.key_pressed(KeyCode::KeyQ) || input.key_pressed(KeyCode::KeyW))
         {
             self.exit = true;
         }
-        // ⌘Z / ⇧⌘Z / ⌘C → guest editing chords (chars are suppressed
-        // under ⌘, so chords travel as named keys).
-        if input.super_down() && input.key_pressed(KeyCode::KeyZ) {
+        // Primary+Z / +C / +X / +V → guest editing chords (chars are
+        // suppressed under the primary modifier, so chords travel as named
+        // keys). primary_down() is Command on macOS and Control elsewhere —
+        // super (Command on macOS, the Windows key on Windows) would leave
+        // Ctrl+C/V dead on non-Apple hosts.
+        if input.primary_down() && input.key_pressed(KeyCode::KeyZ) {
             let redo = input.key_down(KeyCode::ShiftLeft) || input.key_down(KeyCode::ShiftRight);
             self.svc(serde_json::json!({"t": "key", "k": if redo { "Redo" } else { "Undo" }}));
         }
-        if input.super_down() && input.key_pressed(KeyCode::KeyC) {
+        if input.primary_down() && input.key_pressed(KeyCode::KeyC) {
             self.svc(serde_json::json!({"t": "key", "k": "Copy"}));
         }
-        if input.super_down() && input.key_pressed(KeyCode::KeyX) {
+        if input.primary_down() && input.key_pressed(KeyCode::KeyX) {
             self.svc(serde_json::json!({"t": "key", "k": "Cut"}));
         }
-        if input.super_down()
+        if input.primary_down()
             && input.key_pressed(KeyCode::KeyV)
             && let Some(text) = clipboard_paste()
             && !text.is_empty()

--- a/engine/pocket3d/examples/note-widget/src/main.rs
+++ b/engine/pocket3d/examples/note-widget/src/main.rs
@@ -170,8 +170,8 @@ impl NoteGame {
     }
 
     fn forward_edits(&mut self, input: &Input) {
-        // Batch runs of typed chars into one line; ⌘-chords are shortcuts,
-        // not text.
+        // Batch runs of typed chars into one line; primary-modifier chords
+        // are shortcuts, not text.
         let shift = input.key_down(KeyCode::ShiftLeft) || input.key_down(KeyCode::ShiftRight);
         let mut chars = String::new();
         for key in input.edits() {
@@ -186,6 +186,11 @@ impl NoteGame {
                 EditKey::Delete => "Delete",
                 EditKey::Enter => "Enter",
                 EditKey::Tab => "Tab",
+                // Primary+Left/Right word-dance (Command/Control+arrow): the
+                // chord is a named key like Copy/Cut — the plain Left/Right
+                // under the primary modifier is the shortcut, not a move.
+                EditKey::Left if input.primary_down() => "WordLeft",
+                EditKey::Right if input.primary_down() => "WordRight",
                 EditKey::Left => "Left",
                 EditKey::Right => "Right",
                 EditKey::Up => "Up",

--- a/engine/pocket3d/examples/note-widget/src/main.rs
+++ b/engine/pocket3d/examples/note-widget/src/main.rs
@@ -507,48 +507,23 @@ impl FlatWidget for NoteGame {
     }
 }
 
-/// Put text on the system clipboard. pbcopy is the zero-dependency macOS
-/// road; other platforms just log (the widget shell is macOS-first).
+/// Put text on the system clipboard (pocket-clipboard owns the platform
+/// backends: pbcopy on macOS, the Win32 clipboard on Windows).
 fn clipboard_copy(text: &str) {
-    if text.is_empty() {
-        return;
+    match pocket_clipboard::copy(text) {
+        Ok(()) => log::info!("note-widget: copied {} bytes", text.len()),
+        Err(e) => log::warn!("note-widget: clipboard copy failed: {e}"),
     }
-    #[cfg(target_os = "macos")]
-    {
-        use std::io::Write;
-        use std::process::{Command, Stdio};
-        let child = Command::new("pbcopy").stdin(Stdio::piped()).spawn();
-        match child {
-            Ok(mut child) => {
-                if let Some(stdin) = child.stdin.as_mut() {
-                    let _ = stdin.write_all(text.as_bytes());
-                }
-                let _ = child.wait();
-                log::info!("note-widget: copied {} bytes", text.len());
-            }
-            Err(e) => log::warn!("note-widget: pbcopy failed: {e}"),
-        }
-    }
-    #[cfg(not(target_os = "macos"))]
-    log::warn!("note-widget: clipboard copy unsupported on this platform");
 }
 
-/// Read the system clipboard (pbpaste — the macOS counterpart of copy).
+/// Read the system clipboard (pocket-clipboard owns the platform backends).
 fn clipboard_paste() -> Option<String> {
-    #[cfg(target_os = "macos")]
-    {
-        match std::process::Command::new("pbpaste").output() {
-            Ok(out) => Some(String::from_utf8_lossy(&out.stdout).into_owned()),
-            Err(e) => {
-                log::warn!("note-widget: pbpaste failed: {e}");
-                None
-            }
+    match pocket_clipboard::paste() {
+        Some(text) => Some(text),
+        None => {
+            log::warn!("note-widget: clipboard paste returned nothing");
+            None
         }
-    }
-    #[cfg(not(target_os = "macos"))]
-    {
-        log::warn!("note-widget: clipboard paste unsupported on this platform");
-        None
     }
 }
 

--- a/engine/pocket3d/examples/note-widget/src/main.rs
+++ b/engine/pocket3d/examples/note-widget/src/main.rs
@@ -10,6 +10,13 @@
 //!   bun tools/build.ts note-main --density=2
 //!   cargo run -p note-widget
 //!   cargo run -p note-widget -- --file ~/notes/todo.md --width 380 --height 520
+//!   cargo run -p note-widget -- --app acceptance-main --form window
+//!
+//! `--form` picks the posture explicitly (never inferred from the app id):
+//! the default `widget` is the Pocket Note sticky note; `window` is the
+//! generic desktop acceptance host — an opaque, decorated, normal-level
+//! window with every note product behavior off (no note file, no save, no
+//! ••• menu state, no header drag, no resize grip). See docs/WIDGET.md.
 //!
 //! The host is the guest's companion process over the spec svc channel
 //! (ops 30..32): real keyboard/mouse/wheel/resize go in as JSON lines,
@@ -42,7 +49,22 @@ const BTN_CIRCLE: u32 = 0x2000;
 /// Ticks a scripted drag takes from press to its final position.
 const DRAG_TICKS: u64 = 8;
 
+/// Host posture — an explicit CLI choice, never derived from the app id.
+///
+/// `Widget` is the Pocket Note product: borderless, transparent,
+/// always-on-top, header-drag move, grip resize, a note file it loads and
+/// saves. `Window` is the generic desktop acceptance host: a normal opaque
+/// decorated OS window with all of that product behavior off — if the
+/// acceptance surface fails, the failure is PocketJS or the platform, never
+/// Pocket Note behavior (the W1-F rule).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum HostForm {
+    Widget,
+    Window,
+}
+
 struct NoteGame {
+    form: HostForm,
     surface: UiSurface,
     guest: Guest,
     renderer: Option<UiRenderer>,
@@ -95,6 +117,7 @@ enum ScriptEvent {
 
 impl NoteGame {
     fn new(
+        form: HostForm,
         surface: UiSurface,
         guest: Guest,
         atlases: cjk::CjkAtlases,
@@ -102,6 +125,7 @@ impl NoteGame {
         logical: (u32, u32),
     ) -> Self {
         NoteGame {
+            form,
             surface,
             guest,
             renderer: None,
@@ -143,20 +167,25 @@ impl NoteGame {
         }
     }
 
-    /// The svc hello: viewport first, then the document (order matters — the
-    /// app lays text out against the viewport it was just told about).
+    /// The svc hello: viewport first, then (widget form only) the note
+    /// document — order matters, the app lays text out against the viewport
+    /// it was just told about. The window form sends the viewport alone so
+    /// the guest boots its own initial document: a local ~/.pocket-note.md
+    /// must never leak into (or get overwritten by) an acceptance run.
     fn send_hello(&mut self) {
         self.svc(serde_json::json!({"t": "hello", "w": self.logical.0, "h": self.logical.1}));
-        let text = std::fs::read_to_string(&self.file).unwrap_or_default();
-        if !text.is_empty() {
-            self.ensure_text(&text);
-            self.svc(serde_json::json!({"t": "load", "text": text}));
+        if self.form == HostForm::Widget {
+            let text = std::fs::read_to_string(&self.file).unwrap_or_default();
+            if !text.is_empty() {
+                self.ensure_text(&text);
+                self.svc(serde_json::json!({"t": "load", "text": text}));
+            }
+            log::info!(
+                "note-widget: {} ({} bytes)",
+                self.file.display(),
+                text.len()
+            );
         }
-        log::info!(
-            "note-widget: {} ({} bytes)",
-            self.file.display(),
-            text.len()
-        );
     }
 
     fn save(&self, text: &str) {
@@ -305,8 +334,10 @@ impl FlatWidget for NoteGame {
         }
 
         // ⌘Q / ⌘W quit — the macOS widget has no titlebar close button; a
-        // decorated window quits through its own close control.
-        if input.super_down()
+        // decorated window (and every other window-form host) quits through
+        // its own close control.
+        if self.form == HostForm::Widget
+            && input.super_down()
             && (input.key_pressed(KeyCode::KeyQ) || input.key_pressed(KeyCode::KeyW))
         {
             self.exit = true;
@@ -420,7 +451,14 @@ impl FlatWidget for NoteGame {
         for line in self.surface.svc_drain() {
             match serde_json::from_str::<serde_json::Value>(&line) {
                 Ok(v) => match v["t"].as_str() {
-                    Some("save") => self.save(v["text"].as_str().unwrap_or_default()),
+                    // Saving is Pocket Note product behavior; the window form
+                    // is a generic host and persists nothing.
+                    Some("save") if self.form == HostForm::Widget => {
+                        self.save(v["text"].as_str().unwrap_or_default())
+                    }
+                    Some("save") => {
+                        log::debug!("note-widget: save intent ignored in window form")
+                    }
                     Some("quit") => self.exit = true,
                     Some("menu") => self.guest_menu_open = v["open"].as_bool().unwrap_or(false),
                     Some("copy") => clipboard_copy(v["text"].as_str().unwrap_or_default()),
@@ -489,9 +527,10 @@ impl FlatWidget for NoteGame {
 
     fn drag_at(&mut self, cursor: Vec2) -> bool {
         // The header is the move handle, minus the buttons on its right.
+        // Window form: a decorated window moves through its own titlebar.
         // While the guest's menu is up, nothing is a drag region — clicks
         // must reach the backdrop so it can close.
-        if self.guest_menu_open {
+        if self.form == HostForm::Window || self.guest_menu_open {
             return false;
         }
         let (x, y) = (cursor.x / self.scale as f32, cursor.y / self.scale as f32);
@@ -499,7 +538,8 @@ impl FlatWidget for NoteGame {
     }
 
     fn resize_at(&mut self, cursor: Vec2) -> bool {
-        if self.guest_menu_open {
+        // Window form: the OS resize border owns resizing — no custom grip.
+        if self.form == HostForm::Window || self.guest_menu_open {
             return false;
         }
         let (x, y) = (cursor.x / self.scale as f32, cursor.y / self.scale as f32);
@@ -554,6 +594,7 @@ fn fnv1a64(words: &[u32]) -> u64 {
 
 struct Args {
     app: String,
+    form: HostForm,
     js: Option<PathBuf>,
     pak: Option<PathBuf>,
     file: Option<PathBuf>,
@@ -570,6 +611,7 @@ struct Args {
 fn parse_args() -> Result<Args> {
     let mut args = Args {
         app: "note-main".into(),
+        form: HostForm::Widget,
         js: None,
         pak: None,
         file: None,
@@ -596,6 +638,13 @@ fn parse_args() -> Result<Args> {
         }
         match a.as_str() {
             "--app" => args.app = val("--app")?,
+            "--form" => {
+                args.form = match val("--form")?.as_str() {
+                    "widget" => HostForm::Widget,
+                    "window" => HostForm::Window,
+                    other => return Err(anyhow!("unknown form {other} (widget or window)")),
+                };
+            }
             "--js" => args.js = Some(PathBuf::from(val("--js")?)),
             "--pak" => args.pak = Some(PathBuf::from(val("--pak")?)),
             "--file" => args.file = Some(PathBuf::from(val("--file")?)),
@@ -731,11 +780,12 @@ fn boot(args: &Args) -> Result<(Guest, UiSurface)> {
         (args.size.0 as f32, args.size.1 as f32),
         args.density,
     );
-    // The platform-contract identity plan-built bundles assert
-    // (contracts/spec/platforms.ts POCKET_TARGETS). The flat host is
-    // generic: the acceptance rig declares itself as its own target
-    // (e.g. --identity windows-app --host-abi 3) while note-widget keeps
-    // its default macos-widget identity.
+    // The platform-contract identity plan-built bundles assert: the host's
+    // (--identity, --host-abi) must equal the plan's target id and hostAbi
+    // (framework/src/host.ts rejects any mismatch). The flat host is
+    // generic: note-widget keeps its default macos-widget identity, while
+    // the acceptance rig pairs --identity windows-app/--host-abi 3 with the
+    // bundle tools/acceptance.ts builds against the same provisional target.
     surface.set_identity(&args.identity, args.host_abi);
     surface.feed_pak(&pak);
     let guest = Guest::new()?;
@@ -756,15 +806,24 @@ fn main() -> Result<()> {
     let atlases = cjk::CjkAtlases::from_pak(&std::fs::read(
         resolve_asset(args.pak.clone(), &args.app, "pak")?,
     )?);
-    let mut game = NoteGame::new(surface, guest, atlases, note_file(args.file.clone()), args.size);
+    let mut game = NoteGame::new(
+        args.form,
+        surface,
+        guest,
+        atlases,
+        note_file(args.file.clone()),
+        args.size,
+    );
     game.script = std::mem::take(&mut args.script);
     game.quit_after = args.auto_quit.map(|s| (s * 60.0) as u64);
 
     if let Some(out) = args.screenshot.clone() {
         headless(game, args, &out)
     } else {
-        pocket_widget::run_flat(
-            WidgetConfig {
+        let config = match args.form {
+            // The Pocket Note widget: borderless, transparent, always-on-top
+            // — the posture WidgetConfig::default() describes.
+            HostForm::Widget => WidgetConfig {
                 title: "Pocket Note".into(),
                 size: args.size,
                 resizable: true,
@@ -772,8 +831,23 @@ fn main() -> Result<()> {
                 ime: true,
                 ..Default::default()
             },
-            game,
-        )
+            // The generic desktop window: opaque, decorated, normal window
+            // level — winit's own defaults. Anything a plain OS window gives
+            // for free (titlebar move/close, native resize borders) is left
+            // to the OS; the host adds no product chrome.
+            HostForm::Window => WidgetConfig {
+                title: format!("Pocket — {}", args.app),
+                size: args.size,
+                transparent: false,
+                decorations: true,
+                always_on_top: false,
+                resizable: true,
+                min_size: (240, 180),
+                ime: true,
+                ..Default::default()
+            },
+        };
+        pocket_widget::run_flat(config, game)
     }
 }
 

--- a/engine/pocket3d/examples/note-widget/src/main.rs
+++ b/engine/pocket3d/examples/note-widget/src/main.rs
@@ -550,6 +550,8 @@ struct Args {
     file: Option<PathBuf>,
     size: (u32, u32),
     density: u32,
+    identity: String,
+    host_abi: u32,
     screenshot: Option<PathBuf>,
     frames: u64,
     script: Vec<(u64, ScriptEvent)>,
@@ -564,6 +566,8 @@ fn parse_args() -> Result<Args> {
         file: None,
         size: (420, 560),
         density: 2,
+        identity: "macos-widget".into(),
+        host_abi: 3,
         screenshot: None,
         frames: 40,
         script: Vec::new(),
@@ -589,6 +593,8 @@ fn parse_args() -> Result<Args> {
             "--width" => args.size.0 = val("--width")?.parse()?,
             "--height" => args.size.1 = val("--height")?.parse()?,
             "--density" => args.density = val("--density")?.parse()?,
+            "--identity" => args.identity = val("--identity")?,
+            "--host-abi" => args.host_abi = val("--host-abi")?.parse()?,
             "--screenshot" => args.screenshot = Some(PathBuf::from(val("--screenshot")?)),
             "--frames" => args.frames = val("--frames")?.parse()?,
             "--click" => {
@@ -717,8 +723,11 @@ fn boot(args: &Args) -> Result<(Guest, UiSurface)> {
         args.density,
     );
     // The platform-contract identity plan-built bundles assert
-    // (contracts/spec/platforms.ts POCKET_TARGETS["macos-widget"]).
-    surface.set_identity("macos-widget", 3);
+    // (contracts/spec/platforms.ts POCKET_TARGETS). The flat host is
+    // generic: the acceptance rig declares itself as its own target
+    // (e.g. --identity windows-app --host-abi 3) while note-widget keeps
+    // its default macos-widget identity.
+    surface.set_identity(&args.identity, args.host_abi);
     surface.feed_pak(&pak);
     let guest = Guest::new()?;
     surface.mount(&guest)?;

--- a/engine/pocket3d/examples/note-widget/src/main.rs
+++ b/engine/pocket3d/examples/note-widget/src/main.rs
@@ -694,7 +694,11 @@ fn resolve_asset(explicit: Option<PathBuf>, app: &str, ext: &str) -> Result<Path
 
 fn note_file(explicit: Option<PathBuf>) -> PathBuf {
     explicit.unwrap_or_else(|| {
-        let home = std::env::var("HOME").unwrap_or_else(|_| ".".into());
+        // HOME is canonical on POSIX; Windows shells often leave it unset,
+        // so fall through to USERPROFILE (the real Windows home).
+        let home = std::env::var("HOME")
+            .or_else(|_| std::env::var("USERPROFILE"))
+            .unwrap_or_else(|_| ".".into());
         Path::new(&home).join(".pocket-note.md")
     })
 }

--- a/framework/compiler/jsx-plugin.ts
+++ b/framework/compiler/jsx-plugin.ts
@@ -28,13 +28,18 @@ import babelCorePkg from "@babel/core/package.json";
 import tsPresetPkg from "@babel/preset-typescript/package.json";
 import type { PocketFramework } from "../src/config.ts";
 import { POCKET_FRAMEWORKS, SUBPATHS } from "./subpaths.ts";
+import { fileURLToPath } from "node:url";
 
 export type { PocketFramework };
 
-export const RENDERER_PATH = new URL("../src/renderer.ts", import.meta.url).pathname;
-export const RENDERER_SOLID_PATH = new URL("../src/renderer-solid.ts", import.meta.url).pathname;
-export const RENDERER_VUE_VAPOR_PATH = new URL("../src/renderer-vue-vapor.ts", import.meta.url).pathname;
-export const RENDERER_OCTANE_PATH = new URL("../src/renderer-octane.ts", import.meta.url).pathname;
+// Every path below feeds node:fs / Bun.file — these are FILESYSTEM paths,
+// so they convert with fileURLToPath, never URL.pathname (which yields
+// "/C:/…" on Windows and breaks every fs API).
+
+export const RENDERER_PATH = fileURLToPath(new URL("../src/renderer.ts", import.meta.url));
+export const RENDERER_SOLID_PATH = fileURLToPath(new URL("../src/renderer-solid.ts", import.meta.url));
+export const RENDERER_VUE_VAPOR_PATH = fileURLToPath(new URL("../src/renderer-vue-vapor.ts", import.meta.url));
+export const RENDERER_OCTANE_PATH = fileURLToPath(new URL("../src/renderer-octane.ts", import.meta.url));
 
 /**
  * subpath -> absolute module file, per framework — derived once from the
@@ -53,35 +58,32 @@ const RESOLVED: Record<PocketFramework, Record<string, string>> = (() => {
   for (const [name, decl] of Object.entries(SUBPATHS)) {
     for (const fw of POCKET_FRAMEWORKS) {
       const rel = typeof decl.file === "string" ? decl.file : decl.file[fw];
-      if (rel) out[fw][name] = new URL(rel, root).pathname;
+      if (rel) out[fw][name] = fileURLToPath(new URL(rel, root));
     }
   }
   return out;
 })();
-const OCTANE_PROFILING_STUB_PATH = new URL(
-  "../src/octane-profiling-stub.ts",
-  import.meta.url,
-).pathname;
-const GENERATED_STYLES_PATH = new URL(
-  "../src/styles.generated.ts",
-  import.meta.url,
-).pathname;
-const VUE_VAPOR_RUNTIME_PATH = new URL(
-  "../../node_modules/vue/dist/vue.runtime-with-vapor.esm-browser.prod.js",
-  import.meta.url,
-).pathname;
-const SOLID_RUNTIME_PATH = new URL(
-  "../../node_modules/solid-js/dist/solid.js",
-  import.meta.url,
-).pathname;
-const SOLID_UNIVERSAL_RUNTIME_PATH = new URL(
-  "../../node_modules/solid-js/universal/dist/universal.js",
-  import.meta.url,
-).pathname;
+const OCTANE_PROFILING_STUB_PATH = fileURLToPath(
+  new URL("../src/octane-profiling-stub.ts", import.meta.url),
+);
+const GENERATED_STYLES_PATH = fileURLToPath(
+  new URL("../src/styles.generated.ts", import.meta.url),
+);
+const VUE_VAPOR_RUNTIME_PATH = fileURLToPath(
+  new URL("../../node_modules/vue/dist/vue.runtime-with-vapor.esm-browser.prod.js", import.meta.url),
+);
+const SOLID_RUNTIME_PATH = fileURLToPath(
+  new URL("../../node_modules/solid-js/dist/solid.js", import.meta.url),
+);
+const SOLID_UNIVERSAL_RUNTIME_PATH = fileURLToPath(
+  new URL("../../node_modules/solid-js/universal/dist/universal.js", import.meta.url),
+);
 
 const PACKAGE_NAME = "@pocketjs/framework";
-const CACHE_DIR = new URL("../../.cache/transforms/", import.meta.url).pathname;
+const CACHE_DIR = fileURLToPath(new URL("../../.cache/transforms/", import.meta.url));
 const CACHE_VERSION = "2"; // manual backstop; compiler sources are hashed in below
+// URL semantics on purpose: COMPILER_DIR prefix-matches url.pathname below,
+// so it must stay a pathname, not a filesystem path.
 const COMPILER_DIR = new URL("./", import.meta.url).pathname;
 
 /**

--- a/tests/acceptance-target.test.ts
+++ b/tests/acceptance-target.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "bun:test";
+import { POCKET_TARGETS } from "../contracts/spec/platforms.ts";
+import { validateAndResolveBuildPlan } from "../framework/src/manifest/resolve.ts";
+import {
+  ACCEPTANCE_HOST_ABI,
+  ACCEPTANCE_REGISTRY,
+  ACCEPTANCE_TARGET_ID,
+} from "../tools/acceptance-target.ts";
+
+// The acceptance rig's provisional windows-app target: it exists ONLY so
+// the acceptance bundle and the runtime host pair on one identity
+// (plan target.id === host --identity). It must never leak into the formal
+// registry while W1-G is still a proposal.
+const manifest: unknown = await Bun.file(
+  new URL("../apps/acceptance/pocket.json", import.meta.url),
+).json();
+
+describe("acceptance provisional windows-app target", () => {
+  test("stays out of the formal registry while W1-G is a proposal", () => {
+    expect(ACCEPTANCE_TARGET_ID).toBe("windows-app");
+    expect(Object.keys(POCKET_TARGETS)).not.toContain(ACCEPTANCE_TARGET_ID);
+  });
+
+  test("resolves the acceptance app to a plan identity the host can pair on", () => {
+    const result = validateAndResolveBuildPlan(
+      manifest,
+      { target: ACCEPTANCE_TARGET_ID },
+      ACCEPTANCE_REGISTRY,
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    // Exactly what note-widget announces via --identity/--host-abi: a
+    // bundle built as macos-widget here would fail pairing at boot.
+    expect(result.plan.target).toEqual({ id: ACCEPTANCE_TARGET_ID, hostAbi: ACCEPTANCE_HOST_ABI });
+    // Every capability the acceptance surface enhances is available.
+    for (const capability of ["input.ime", "input.pointer", "host.clipboard", "text.glyphs.runtime"]) {
+      expect(result.plan.features[capability]).toBe(true);
+    }
+  });
+
+  test("keeps the formal targets resolvable unchanged alongside it", () => {
+    expect(
+      validateAndResolveBuildPlan(manifest, { target: "macos-widget" }, ACCEPTANCE_REGISTRY).ok,
+    ).toBe(true);
+  });
+});

--- a/tests/path-portability.test.ts
+++ b/tests/path-portability.test.ts
@@ -1,0 +1,56 @@
+// tests/path-portability.test.ts — Windows-safe filesystem URL conversion.
+//
+// Regression for the pattern in Issue #1: `new URL(...).pathname` on a
+// Windows file URL yields "/C:/…" (leading slash + drive letter), which
+// every fs API rejects. The fix is node:url fileURLToPath, exposed to tool
+// scripts as tools/fs-url.ts fsPath. These tests pin the Windows URL shape
+// and the conversion rule so nobody reverts to `.pathname`.
+
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+import { fsPath } from "../tools/fs-url.ts";
+
+// A Windows-style absolute file URL, as import.meta.url would be on a
+// Windows checkout (C:\ repo).
+const WINDOWS_URL = "file:///C:/PocketJS/pocketjs/tools/site-build.ts";
+
+describe("Windows filesystem URL conversion", () => {
+  test(".pathname keeps the drive-letter shape that breaks fs APIs", () => {
+    // The directory of a Windows file URL, URL-encoded: the pathname starts
+    // with "/C:/" — a leading slash before the drive letter. Passing this
+    // string to fs/Bun.file on Windows fails (ENOENT/ENOTDIR).
+    const pathname = new URL("../", WINDOWS_URL).pathname;
+    expect(pathname.startsWith("/C:/")).toBe(true);
+    expect(pathname.endsWith("PocketJS/pocketjs/")).toBe(true);
+  });
+
+  test("fsPath defers to fileURLToPath — the canonical conversion", () => {
+    const viaFsPath = fsPath("..", WINDOWS_URL);
+    const viaNode = fileURLToPath(new URL("..", WINDOWS_URL));
+    expect(viaFsPath).toBe(viaNode);
+    // The parent directory, whatever the host's separators.
+    expect(viaFsPath).toMatch(/[/\\]pocketjs[/\\]?$/);
+  });
+
+  test("fsPath decodes percent-encoding; .pathname does not", () => {
+    // A repo under a directory with a space (e.g. "Program Files"): the
+    // URL pathname keeps %20, fileURLToPath decodes it to the real path —
+    // passing the encoded string to fs fails even on POSIX.
+    const url = "file:///C:/PocketJS/My%20Repo/tools/site-build.ts";
+    expect(new URL("../", url).pathname).toBe("/C:/PocketJS/My%20Repo/");
+    const root = fsPath("../", url);
+    expect(root).not.toContain("%20");
+    expect(root).toContain("My Repo");
+    expect(fsPath("../", url)).toBe(fileURLToPath(new URL("../", url)));
+  });
+
+  test("fsPath handles a file (package.json) URL", () => {
+    const p = fsPath("../package.json", WINDOWS_URL);
+    expect(p.endsWith("package.json")).toBe(true);
+  });
+
+  test("fsPath handles a directory URL", () => {
+    const p = fsPath("../dist", WINDOWS_URL);
+    expect(p.endsWith("dist")).toBe(true);
+  });
+});

--- a/tests/platform-contracts.test.ts
+++ b/tests/platform-contracts.test.ts
@@ -360,6 +360,7 @@ describe("semantic resolution", () => {
       stats: [true, true, false],
       "vue-sfc-lab": [true, true, false],
       zoomlab: [true, true, false],
+      acceptance: [false, false, true], // the generic desktop acceptance app — a macos-widget-only surface
     };
     const targets = ["psp", "vita", "macos-widget"] as const;
     for (const demo of readdirSync(new URL("../apps/", import.meta.url)).sort()) {

--- a/tools/acceptance-target.ts
+++ b/tools/acceptance-target.ts
@@ -1,0 +1,56 @@
+// The acceptance rig's test-local provisional target profile for W1-G.
+//
+// `windows-app` is a PROPOSAL (docs/windows-desktop-w1-report.md §16.5), not
+// a registered contract: POCKET_TARGETS inventories real, golden-tested
+// stock hosts only, and nothing here may leak into it. This registry exists
+// for one reason — pairing. A plan-built bundle asserts its plan's
+// (target.id, hostAbi) against the host's --identity/--host-abi
+// (framework/src/host.ts rejects any mismatch), so the acceptance bundle
+// and the runtime host must agree on ONE identity. Building the bundle as
+// `macos-widget` and running the host as `windows-app` is not a legal
+// validation setup; this profile makes both sides `windows-app`.
+//
+// hostAbi 3 is provisional — the flat host speaks the same wire generation
+// as macos-widget; whether windows-app gets its own number is the upstream
+// W1-G discussion. Capabilities are the measured candidate set the W1
+// mechanisms actually deliver, not product wishes.
+import {
+  POCKET_CAPABILITIES,
+  POCKET_TARGETS,
+  definePlatformContractRegistry,
+  type PocketCapabilityId,
+  type TargetProfile,
+} from "../contracts/spec/platforms.ts";
+
+export const ACCEPTANCE_TARGET_ID = "windows-app";
+export const ACCEPTANCE_HOST_ABI = 3;
+
+const WINDOWS_APP: TargetProfile<PocketCapabilityId> = {
+  hostAbi: ACCEPTANCE_HOST_ABI,
+  platform: "windows",
+  form: "window",
+  display: {
+    physicalViewport: [2000, 1400],
+    logicalViewports: [[1000, 700]],
+    dynamicViewport: { min: [240, 180], max: [4096, 4096] },
+    presentations: ["native"],
+    rasterDensity: 2,
+  },
+  capabilities: [
+    "input.buttons",
+    "input.ime",
+    "input.pointer",
+    "input.text",
+    "host.clipboard",
+    "display.viewport.live",
+    "text.glyphs.baked",
+    "text.glyphs.runtime",
+  ],
+};
+
+/** POCKET_TARGETS plus the provisional windows-app profile — acceptance
+ *  builds only; never a substitute for the formal registry. */
+export const ACCEPTANCE_REGISTRY = definePlatformContractRegistry(POCKET_CAPABILITIES, {
+  ...POCKET_TARGETS,
+  [ACCEPTANCE_TARGET_ID]: WINDOWS_APP,
+});

--- a/tools/acceptance.ts
+++ b/tools/acceptance.ts
@@ -8,18 +8,28 @@
 //   bun run acceptance                        # build + headless proof
 //   bun run acceptance -- --width 900 --height 600
 //
-// The proof drives scripted input through the real host input path:
-//   --type "…@10"   typed chars  → svc ch line
-//   --paste "…@20"  paste        → host reads clipboard (pocket-clipboard)
-//   --key "Copy@30" named key    → app sends {t:"copy"} → host logs it
-// The screenshot lands in dist/acceptance-proof.png.
+// Identity pairing: the bundle builds against the provisional windows-app
+// target (tools/acceptance-target.ts) so its plan asserts exactly what the
+// windowed host announces (--identity windows-app --host-abi 3). Building
+// against macos-widget while running as windows-app would fail pairing.
 //
-// The bundle builds against the macos-widget target profile (the only
-// desktop contract registered today) so plan features (input.text,
-// input.ime, host.clipboard, text.glyphs.runtime, …) are baked. A
-// provisional windows-app profile is the W1-G proposal, not yet a
-// registered contract — see the W1 report.
+// Evidence semantics — what this headless run is and is not:
+//
+//   DESKTOP_WIRE_ACCEPTANCE (this run): --type/--paste/--key inject svc
+//     lines directly. This proves the svc protocol, the guest editing
+//     surface and DrawList rendering. It does NOT exercise the OS input
+//     stack (winit → Input → forward_edits/forward_ime → primary chords),
+//     and --paste is injected text, not a system clipboard read.
+//   PLATFORM_INTEGRATION_ACCEPTANCE (windowed, on the target OS): the real
+//     keyboard/IME/clipboard path — docs/windows-desktop-w1-report.md.
+//
+// The W1 validation charset is ASCII + BMP CJK; astral codepoints (emoji,
+// CJK Extension B) hit the known UTF-16/scalar indexing seam and are a
+// recorded follow-up, not part of this proof.
+//
+// The screenshot lands in dist/acceptance-proof.png.
 import { fsPath } from "./fs-url.ts";
+import { ACCEPTANCE_HOST_ABI, ACCEPTANCE_REGISTRY, ACCEPTANCE_TARGET_ID } from "./acceptance-target.ts";
 import { mkdirSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import { $ } from "bun";
@@ -30,7 +40,11 @@ const args = process.argv.slice(2).filter((a) => a !== "--");
 const pass = args;
 
 const manifest = await Bun.file(`${root}apps/acceptance/pocket.json`).json();
-const resolution = validateAndResolveBuildPlan(manifest, { target: "macos-widget" });
+const resolution = validateAndResolveBuildPlan(
+  manifest,
+  { target: ACCEPTANCE_TARGET_ID },
+  ACCEPTANCE_REGISTRY,
+);
 if (!resolution.ok) {
   throw new Error(
     `pocket-acceptance: manifest did not resolve: ${resolution.diagnostics
@@ -38,7 +52,8 @@ if (!resolution.ok) {
       .join("; ")}`,
   );
 }
-const planPath = `${root}.pocket/desktop-widget/acceptance-main.plan.json`;
+
+const planPath = `${root}.pocket/windows-app/acceptance-main.plan.json`;
 mkdirSync(resolvePath(planPath, ".."), { recursive: true });
 await Bun.write(planPath, JSON.stringify(resolution.plan, null, 2) + "\n");
 
@@ -50,12 +65,19 @@ const env = { ...process.env, RUST_LOG: process.env.RUST_LOG ?? "info" };
 const shot = `${root}dist/acceptance-proof.png`;
 
 await $`rm -f ${shot}`;
-await $`${bin} --app acceptance-main --width 1000 --height 700 --screenshot ${shot} --frames 90 --type "ACCEPT-RUN-OK@10" --paste "PASTED@20" --key "Copy@30" ${pass}`.env(
+// --form window: the generic desktop host posture (opaque, decorated,
+// normal level, no note file/save/menu/drag/grip), so even headless the
+// wire behavior is the acceptance one — no ~/.pocket-note.md can leak in.
+// --identity/--host-abi pair the host with the plan target the bundle was
+// built for; any drift fails boot by design (framework/src/host.ts).
+await $`${bin} --app acceptance-main --form window --identity ${ACCEPTANCE_TARGET_ID} --host-abi ${ACCEPTANCE_HOST_ABI} --width 1000 --height 700 --screenshot ${shot} --frames 90 --type "ACCEPT-RUN-OK@10" --paste "PASTED@20" --key "Copy@30" ${pass}`.env(
   env,
 );
 
 console.log(
-  "\nacceptance: plan-built generic text surface booted headless; scripted" +
-    "\ntype + paste + copy ran through the host input path." +
+  "\nDESKTOP_WIRE_ACCEPTANCE: plan-built generic text surface (windows-app," +
+    `\n  hostAbi ${ACCEPTANCE_HOST_ABI}) booted headless; scripted type + paste +` +
+    "\n  copy ran through the svc wire. OS keyboard/IME/clipboard remain" +
+    "\n  PLATFORM_INTEGRATION_ACCEPTANCE (windowed run on the target OS)." +
     `\n${shot}`,
 );

--- a/tools/acceptance.ts
+++ b/tools/acceptance.ts
@@ -19,12 +19,13 @@
 // input.ime, host.clipboard, text.glyphs.runtime, …) are baked. A
 // provisional windows-app profile is the W1-G proposal, not yet a
 // registered contract — see the W1 report.
+import { fsPath } from "./fs-url.ts";
 import { mkdirSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import { $ } from "bun";
 import { validateAndResolveBuildPlan } from "../framework/src/manifest/resolve.ts";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fsPath("..", import.meta.url);
 const args = process.argv.slice(2).filter((a) => a !== "--");
 const pass = args;
 

--- a/tools/acceptance.ts
+++ b/tools/acceptance.ts
@@ -1,0 +1,60 @@
+// bun run acceptance [flags…] — build + headless-prove the generic desktop
+// acceptance surface (apps/acceptance over the flat pocket-widget host).
+//
+// The acceptance app is the W1 gate surface: a deliberately plain text
+// editor with no Markit/markdown product logic. If it fails, PocketJS or
+// the platform substrate failed — not a product parser.
+//
+//   bun run acceptance                        # build + headless proof
+//   bun run acceptance -- --width 900 --height 600
+//
+// The proof drives scripted input through the real host input path:
+//   --type "…@10"   typed chars  → svc ch line
+//   --paste "…@20"  paste        → host reads clipboard (pocket-clipboard)
+//   --key "Copy@30" named key    → app sends {t:"copy"} → host logs it
+// The screenshot lands in dist/acceptance-proof.png.
+//
+// The bundle builds against the macos-widget target profile (the only
+// desktop contract registered today) so plan features (input.text,
+// input.ime, host.clipboard, text.glyphs.runtime, …) are baked. A
+// provisional windows-app profile is the W1-G proposal, not yet a
+// registered contract — see the W1 report.
+import { mkdirSync } from "node:fs";
+import { resolve as resolvePath } from "node:path";
+import { $ } from "bun";
+import { validateAndResolveBuildPlan } from "../framework/src/manifest/resolve.ts";
+
+const root = new URL("..", import.meta.url).pathname;
+const args = process.argv.slice(2).filter((a) => a !== "--");
+const pass = args;
+
+const manifest = await Bun.file(`${root}apps/acceptance/pocket.json`).json();
+const resolution = validateAndResolveBuildPlan(manifest, { target: "macos-widget" });
+if (!resolution.ok) {
+  throw new Error(
+    `pocket-acceptance: manifest did not resolve: ${resolution.diagnostics
+      .map((d) => `${d.path || "/"}: ${d.message}`)
+      .join("; ")}`,
+  );
+}
+const planPath = `${root}.pocket/desktop-widget/acceptance-main.plan.json`;
+mkdirSync(resolvePath(planPath, ".."), { recursive: true });
+await Bun.write(planPath, JSON.stringify(resolution.plan, null, 2) + "\n");
+
+await $`bun tools/build.ts --plan=${planPath} --project-root=${root}`.cwd(root);
+await $`cargo build -p note-widget`.cwd(`${root}engine`);
+
+const bin = `${root}engine/target/debug/note-widget`;
+const env = { ...process.env, RUST_LOG: process.env.RUST_LOG ?? "info" };
+const shot = `${root}dist/acceptance-proof.png`;
+
+await $`rm -f ${shot}`;
+await $`${bin} --app acceptance-main --width 1000 --height 700 --screenshot ${shot} --frames 90 --type "ACCEPT-RUN-OK@10" --paste "PASTED@20" --key "Copy@30" ${pass}`.env(
+  env,
+);
+
+console.log(
+  "\nacceptance: plan-built generic text surface booted headless; scripted" +
+    "\ntype + paste + copy ran through the host input path." +
+    `\n${shot}`,
+);

--- a/tools/bench-ppsspp.ts
+++ b/tools/bench-ppsspp.ts
@@ -9,6 +9,7 @@
 //   PSP_SDK=/path/to/mipsel-sony-psp bun tools/bench-ppsspp.ts --apps=all --samples=3 --memory-scan
 //   bun tools/bench-ppsspp.ts --apps=all --frameworks=solid,vue-vapor,octane --samples=7 --bootstrap=5000
 
+import { fsPath } from "./fs-url.ts";
 import { $ } from "bun";
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -99,7 +100,7 @@ const SPECS: Spec[] = [
   },
 ];
 
-const pspUiDir = new URL("..", import.meta.url).pathname;
+const pspUiDir = fsPath("..", import.meta.url);
 const argv = Bun.argv.slice(2);
 let samples = 5;
 let apps = ["stats"];

--- a/tools/bootstrap.ts
+++ b/tools/bootstrap.ts
@@ -1,6 +1,7 @@
 // PocketJS-owned, idempotent PSP setup. A fresh clone must not need DreamCart,
 // sibling source checkouts, or unpinned tools to produce an EBOOT.
 
+import { fsPath } from "./fs-url.ts";
 import { $ } from "bun";
 import { createHash } from "node:crypto";
 import {
@@ -30,7 +31,7 @@ import {
   writePinnedCargoPspReceipt,
 } from "./psp-toolchain.ts";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fsPath("..", import.meta.url);
 const home = process.env.HOME ?? "";
 const cacheRoot = pocketStackCacheRoot();
 const cachedSdk = cachedPspSdk();

--- a/tools/devtools-bridge.ts
+++ b/tools/devtools-bridge.ts
@@ -19,6 +19,7 @@ import {
   statSync,
   writeFileSync,
 } from "node:fs";
+import { fsPath } from "./fs-url.ts";
 import { join } from "node:path";
 import { bundleHash, launcherBundleHash } from "./bundle-hash.ts";
 import { encodePNG } from "../tests/png.ts";
@@ -114,7 +115,7 @@ export function startBridge(opts: BridgeOptions): Bridge {
     return "data:image/png;base64," + encodePNG(rgba, w, h).toString("base64");
   }
 
-  const distDir = opts.dist ?? new URL("../dist", import.meta.url).pathname;
+  const distDir = opts.dist ?? fsPath("../dist", import.meta.url);
 
   /** Stale-embed tripwire: the device's stats reply carries the FNV-1a64 of
    *  the js+pak baked into the PRX (hosts/psp/build.rs); compare it with the

--- a/tools/devtools-psp.ts
+++ b/tools/devtools-psp.ts
@@ -8,11 +8,12 @@
 //                   for `bun run hw` pass hosts/psp/target/mipsel-sony-psp/release)
 //   --port <n>     dev-server port (default 8130 / PORT env)
 
+import { fsPath } from "./fs-url.ts";
 import { existsSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { startBridge } from "./devtools-bridge.ts";
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fsPath("..", import.meta.url);
 
 function argValue(flag: string): string | undefined {
   const i = process.argv.indexOf(flag);

--- a/tools/devtools.ts
+++ b/tools/devtools.ts
@@ -15,6 +15,7 @@
 //
 // Shortcuts while running:  o open panel · r rebuild + relaunch · q quit
 
+import { fsPath } from "./fs-url.ts";
 import { $ } from "bun";
 import { existsSync } from "node:fs";
 import { createServer } from "node:net";
@@ -22,7 +23,7 @@ import { join } from "node:path";
 import { startDevServer, demoManifest } from "../hosts/web/server.ts";
 import { startBridge, type Bridge } from "./devtools-bridge.ts";
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fsPath("..", import.meta.url);
 
 // ---- args -------------------------------------------------------------------
 

--- a/tools/flake-lab.ts
+++ b/tools/flake-lab.ts
@@ -23,12 +23,13 @@
 // assertion sometimes fails; V's delivery frame is one number, every run.
 // Same code. The only difference is what "time" means.
 
+import { fsPath } from "./fs-url.ts";
 import { writeFileSync } from "node:fs";
 import { bootWorld, runScenario } from "../hosts/sim/sim.ts";
 import { BTN } from "../contracts/spec/spec.ts";
 
 const RUNS = Number(argValue("--runs") ?? 60);
-const OUT = argValue("--out") ?? new URL("../dist/flake-lab.json", import.meta.url).pathname;
+const OUT = argValue("--out") ?? fsPath("../dist/flake-lab.json", import.meta.url);
 
 function argValue(flag: string): string | undefined {
   const i = process.argv.indexOf(flag);

--- a/tools/fs-url.ts
+++ b/tools/fs-url.ts
@@ -1,0 +1,16 @@
+// tools/fs-url.ts — filesystem path conversion for tool scripts.
+//
+// Never use `new URL(...).pathname` as a filesystem path: on Windows the
+// pathname of a file URL is "/C:/…" — a leading slash plus the drive
+// letter — which every fs API rejects (ENOENT, ENOTDIR). This is the
+// canonical conversion (node:url fileURLToPath); a regression test pins
+// the Windows shape in tests/path-portability.test.ts.
+
+import { fileURLToPath } from "node:url";
+
+/** The filesystem path of `relative` resolved against `metaUrl`
+ *  (pass `import.meta.url`). POSIX result is identical to `.pathname`;
+ *  on Windows the drive letter is handled correctly. */
+export function fsPath(relative: string, metaUrl: string): string {
+  return fileURLToPath(new URL(relative, metaUrl));
+}

--- a/tools/gen-demo-covers.ts
+++ b/tools/gen-demo-covers.ts
@@ -18,13 +18,14 @@
 //   bun tools/gen-demo-covers.ts hero music           (a subset)
 //   bun tools/gen-demo-covers.ts --framework=octane   (the Octane twins)
 
+import { fsPath } from "./fs-url.ts";
 import { createCanvas, GlobalFonts, type SKRSContext2D } from "@napi-rs/canvas";
 import { mkdirSync } from "node:fs";
 import { runScenario } from "../hosts/sim/sim.ts";
 import { BTN } from "../contracts/spec/spec.ts";
 import { FRAMEWORKS, parseFramework } from "../framework/compiler/jsx-plugin.ts";
 
-const ROOT = new URL("../", import.meta.url).pathname;
+const ROOT = fsPath("../", import.meta.url);
 GlobalFonts.registerFromPath(ROOT + "assets/fonts/Inter-Bold.ttf", "Inter");
 
 interface DemoCover {

--- a/tools/gen-exports.ts
+++ b/tools/gen-exports.ts
@@ -9,6 +9,7 @@
 // applied to the second generated artifact. Only the exports block is
 // touched; the rest of package.json is never rewritten.
 
+import { fsPath } from "./fs-url.ts";
 import { npmExports } from "../framework/compiler/subpaths.ts";
 
 /** The exact `"exports": { … }` block text, at package.json's indentation. */
@@ -32,7 +33,7 @@ export function withGeneratedExports(pkgText: string): string {
 }
 
 if (import.meta.main) {
-  const path = new URL("../package.json", import.meta.url).pathname;
+  const path = fsPath("../package.json", import.meta.url);
   const before = await Bun.file(path).text();
   const after = withGeneratedExports(before);
   if (after !== before) {

--- a/tools/gu-demo.ts
+++ b/tools/gu-demo.ts
@@ -10,11 +10,12 @@
 // Maps root (maps/*.bsp + support/*.wad): POCKET3D_TEST_MAPS or the local
 // default below. Output PNGs land in dist/gu-demo/.
 
+import { fsPath } from "./fs-url.ts";
 import { $ } from "bun";
 import { existsSync, mkdirSync, readdirSync, rmSync } from "node:fs";
 import { resolvePspBuildToolchain } from "./psp-toolchain.ts";
 
-const repo = new URL("..", import.meta.url).pathname;
+const repo = fsPath("..", import.meta.url);
 const home = process.env.HOME ?? "";
 const pocket3d = `${repo}engine/pocket3d/`;
 const demoDir = `${pocket3d}crates/gu-demo/`;

--- a/tools/hw.ts
+++ b/tools/hw.ts
@@ -9,12 +9,13 @@
 //
 // It serves hosts/psp/target/... as host0: through usbhostfs_pc, then ldstart's
 // the raw PRX through PSPLINK. Each reload is reset + ldstart.
+import { fsPath } from "./fs-url.ts";
 import { $ } from "bun";
 import { existsSync, readFileSync, readdirSync, statSync, unlinkSync } from "node:fs";
 import { createServer } from "node:net";
 import { createInterface } from "node:readline";
 
-const pspUiDir = new URL("..", import.meta.url).pathname;
+const pspUiDir = fsPath("..", import.meta.url);
 const PRX = "host0:/pocketjs-psp.prx";
 const MAIN_SUFFIX = "-main.tsx";
 

--- a/tools/ios.ts
+++ b/tools/ios.ts
@@ -12,6 +12,7 @@
 //   pocket ios play  nsengine [--external-guest] [--device=<name|udid>] [flags]
 //
 // `play` is also reachable as `pocket play ios <app>`.
+import { fsPath } from "./fs-url.ts";
 import { cpSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { demoManifestFor } from "./demo-identity.ts";
@@ -23,7 +24,7 @@ import {
   resolveIOSDevBuildPlan,
 } from "./ios-profile.ts";
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fsPath("..", import.meta.url);
 const DEFAULT_SHELL = resolve(ROOT, "hosts/apple/ns-shell");
 const XCFRAMEWORK_SCRIPT = resolve(ROOT, "engine/apple/build-xcframework.sh");
 const XCFRAMEWORK_DIST = resolve(ROOT, "engine/apple/dist/PocketApple.xcframework");

--- a/tools/launcher.ts
+++ b/tools/launcher.ts
@@ -23,6 +23,7 @@ import {
   rmSync,
   writeFileSync,
 } from "node:fs";
+import { fsPath } from "./fs-url.ts";
 import { dirname, isAbsolute, join, relative, resolve } from "node:path";
 import { validateAndResolveBuildPlan } from "../framework/src/manifest/resolve.ts";
 import type { ResolvedBuildPlan } from "../framework/src/manifest/plan.ts";
@@ -48,7 +49,7 @@ import {
   withArtifactLock,
 } from "./psp-toolchain.ts";
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fsPath("..", import.meta.url);
 const APPS_DIR = join(ROOT, "apps");
 const LAUNCHER_DIR = join(APPS_DIR, "launcher");
 const COVERS_DIR = join(LAUNCHER_DIR, "covers");

--- a/tools/note.ts
+++ b/tools/note.ts
@@ -13,12 +13,13 @@
 // here). On exit the shell prints its governor receipt:
 // "pocket-widget: N ticks, M frames rendered" — a settled note should show
 // M ≪ N (measured: 2 frames over 481 ticks).
+import { fsPath } from "./fs-url.ts";
 import { mkdirSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
 import { $ } from "bun";
 import { validateAndResolveBuildPlan } from "../framework/src/manifest/resolve.ts";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fsPath("..", import.meta.url);
 const args = process.argv.slice(2).filter((a) => a !== "--");
 const proof = args.includes("--proof");
 const pass = args.filter((f) => f !== "--proof");

--- a/tools/pocket-pack.ts
+++ b/tools/pocket-pack.ts
@@ -16,6 +16,7 @@
 // with a log under --all-targets): a package can never carry a variant its
 // own manifest disowns.
 
+import { fsPath } from "./fs-url.ts";
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
 import { POCKET_TARGETS } from "../contracts/spec/platforms.ts";
@@ -33,7 +34,7 @@ import {
   type PocketPackageVariant,
 } from "../contracts/spec/pocket-package.ts";
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fsPath("..", import.meta.url);
 
 function usage(message?: string): never {
   if (message) console.error(`pocket-pack: ${message}`);

--- a/tools/psp.ts
+++ b/tools/psp.ts
@@ -16,6 +16,7 @@
 // --bench additionally enables native microsecond timing output to
 // ms0:/PocketJS-bench.jsonl and implies --capture.
 
+import { fsPath } from "./fs-url.ts";
 import { $ } from "bun";
 import { existsSync, statSync, unlinkSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
@@ -33,7 +34,7 @@ import {
 import { verifyPlanHash, type ResolvedBuildPlan } from "../framework/src/manifest/plan.ts";
 import { resolvePspBuildToolchain } from "./psp-toolchain.ts";
 
-const pspUiDir = new URL("..", import.meta.url).pathname; // PocketJS/
+const pspUiDir = fsPath("..", import.meta.url); // PocketJS/
 const nativeDir = pspUiDir + "hosts/psp/";
 const pspTarget = nativeDir + "targets/mipsel-sony-psp.json";
 

--- a/tools/psplink.ts
+++ b/tools/psplink.ts
@@ -3,6 +3,7 @@
 // Interactive real-PSP switcher over PSPLINK. The Mac terminal owns the game
 // picker; the PSP only runs the selected PRX.
 
+import { fsPath } from "./fs-url.ts";
 import { $ } from "bun";
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync } from "node:fs";
 import { basename, join } from "node:path";
@@ -25,7 +26,7 @@ type Options = {
   basePort?: number;
 };
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fsPath("..", import.meta.url);
 const DEMOS_DIR = join(ROOT, "apps");
 const OUT_ROOT = join(ROOT, "dist/psplink");
 const MAIN_SUFFIX = "-main.tsx";

--- a/tools/site-build.ts
+++ b/tools/site-build.ts
@@ -1,8 +1,9 @@
 // Reproducible pocketjs.dev build from a fresh checkout. Keep local preview,
 // main deploys, and tag releases on the same prerequisite chain.
+import { fsPath } from "./fs-url.ts";
 import { existsSync, writeFileSync } from "node:fs";
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fsPath("..", import.meta.url);
 const generatedStyles = ROOT + "framework/src/styles.generated.ts";
 
 // tools/build.ts imports this gitignored module during its first pass. Seed a

--- a/tools/symbian-bootstrap.ts
+++ b/tools/symbian-bootstrap.ts
@@ -1,3 +1,4 @@
+import { fsPath } from "./fs-url.ts";
 import { createHash } from "node:crypto";
 import {
   createReadStream,
@@ -19,7 +20,7 @@ import {
 } from "./symbian-toolchain.ts";
 import { pocketStackCacheRoot, withArtifactLock } from "./psp-toolchain.ts";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fsPath("..", import.meta.url);
 
 async function sha256File(path: string): Promise<string> {
   const hash = createHash("sha256");

--- a/tools/symbian.ts
+++ b/tools/symbian.ts
@@ -1,3 +1,4 @@
+import { fsPath } from "./fs-url.ts";
 import { createHash } from "node:crypto";
 import {
   createReadStream,
@@ -44,7 +45,7 @@ import {
   stageSymbianMassStorageData,
 } from "./symbian-data.ts";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fsPath("..", import.meta.url);
 
 async function spawn(
   command: string,

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -1,3 +1,4 @@
+import { fsPath } from "./fs-url.ts";
 // tools/test.ts — the test suite, as data. `bun run test` runs every stage
 // in order and fails fast; the package.json one-liner it replaces had grown
 // to nineteen &&-chained segments nobody could read or partially re-run.
@@ -177,7 +178,7 @@ if (stageFilter && selected.length === 0) {
   process.exit(1);
 }
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fsPath("..", import.meta.url);
 
 function fail(stage: string, cmd: readonly string[], captured?: string): never {
   if (captured) process.stderr.write(captured);

--- a/tools/vita.ts
+++ b/tools/vita.ts
@@ -1,3 +1,4 @@
+import { fsPath } from "./fs-url.ts";
 import { $ } from "bun";
 import { cpSync, existsSync, mkdirSync, statSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
@@ -22,7 +23,7 @@ import { validateAndResolveBuildPlan } from "../framework/src/manifest/resolve.t
 import { demoIdentity, demoManifestFor } from "./demo-identity.ts";
 import { packageVitaVpk } from "./vita-package.ts";
 
-const pspUiDir = new URL("..", import.meta.url).pathname; // PocketJS/
+const pspUiDir = fsPath("..", import.meta.url); // PocketJS/
 const nativeDir = pspUiDir + "hosts/vita/";
 const home = process.env.HOME ?? "";
 

--- a/tools/widget.ts
+++ b/tools/widget.ts
@@ -14,6 +14,7 @@
 // Ctrl-C). On exit the shell prints its governor receipt:
 // "pocket-widget: N ticks, M frames rendered" — a settled app should show
 // M ≪ N.
+import { fsPath } from "./fs-url.ts";
 import { $ } from "bun";
 import { mkdirSync, readFileSync } from "node:fs";
 import { resolve as resolvePath } from "node:path";
@@ -26,7 +27,7 @@ import {
 import { validateAndResolveBuildPlan } from "../framework/src/manifest/resolve.ts";
 import type { ResolvedBuildPlan } from "../framework/src/manifest/plan.ts";
 
-const root = new URL("..", import.meta.url).pathname;
+const root = fsPath("..", import.meta.url);
 
 /** Transitional embedded target shared by the bundled PSP and iPod stages. */
 export const STAGE_TARGET_ID = "macos-embedded";


### PR DESCRIPTION
## What

W1 Windows desktop enablement, now with the review findings addressed. The substrate work (path portability, primary modifier, portable clipboard, CJK discovery, alpha fallback, 12 commits) landed earlier on this branch; this round fixes the three P1s and two P2s from the W1 closeout review:

- **`--form window` host posture** (`4d877b4`) — the acceptance host is a normal desktop window (opaque, decorated, normal level) with all Pocket Note product behavior off: no note file, no load/save, no ••• menu state, no header drag, no resize grip. Explicit CLI flag — never inferred from the app id. `WidgetConfig::default()` keeps the macOS widget semantics unchanged.
- **Provisional `windows-app` pairing** (`b9e28f2`) — a plan bundle asserts its plan's `(target.id, hostAbi)` against the host identity, so building the acceptance bundle as `macos-widget` while the host announces `windows-app` was not a legal validation setup. `tools/acceptance-target.ts` registers `windows-app` (hostAbi 3) in a test-local registry layered over `POCKET_TARGETS`; the formal registry is untouched while W1-G is a proposal. The rig now builds and boots the surface as `windows-app` end to end.
- **Honest evidence semantics** (`49c852d`) — the headless proof is labeled `DESKTOP_WIRE_ACCEPTANCE` (svc protocol + guest editing surface + DrawList; it bypasses winit/Input/IME and never touches the system clipboard); the OS input stack is `PLATFORM_INTEGRATION_ACCEPTANCE`, pending the windowed run on a real Windows machine. The headless screenshot is no longer cited as proof of window posture.
- **B/I/U removed** (`2e4e5b8`) — advertised but never implemented; rich text is not something W1 needs to prove. The app also stops handling the `load` svc channel so no host-side file can make a proof run nondeterministic.
- **Report status split** — `W1 IMPLEMENTATION: CODE_COMPLETE_PENDING_VALIDATION`, `POCKETJS_WINDOWS_DESKTOP: NOT_PROVEN`, `MARKIT PRODUCT WORK: UNBLOCKED_TO_START_IN_PARALLEL`. Markit P0 may start in parallel; that is not W1 closing. Also records the Unicode indexing seam (IME cursor in scalar counts vs JS UTF-16 units) and scopes the W1 charset to ASCII + BMP CJK.

## Verification

- `bun tools/acceptance.ts` — windows-app plan bundle + host + headless proof green; screenshot vision-verified (no B/I/U chips, opaque background, `ACCEPT-RUN-OK`/`PASTED` inserted at caret).
- `cargo build -p note-widget`, `cargo test -p pocket-widget -p pocket-clipboard` — green.
- `bun tools/test.ts` — every stage green except `tests/npm-package.test.ts` "framework tarball resolves the Apple native workspace", which fails identically at the branch baseline `49decea` (pre-existing, unrelated).
- New `tests/acceptance-target.test.ts` pins the pairing (bundle plan target == host identity) and that `windows-app` stays out of `POCKET_TARGETS`.

## Notes for review

- `POCKET_TARGETS` is intentionally unchanged; promoting `windows-app` (id, hostAbi, capability set) is the W1-G upstream discussion.
- Real-Windows validation is still the hard gate — commands prepared in `docs/windows-desktop-w1-report.md`.