### PR TITLE
fix(gpui): raster fallback — full-viewport rendering and transparent compositing

### DIFF
--- a/engine/backends/gpui/src/render.rs
+++ b/engine/backends/gpui/src/render.rs
@@ -606,6 +606,9 @@ impl GpuiRenderer {
         // asserts the pixel count), so raster the batch into a reusable
         // viewport-sized scratch at density and crop the bbox out. The
         // batch words are already viewport-space — no translation needed.
+        // The OVER variant leaves the zeroed scratch's uncovered pixels
+        // fully transparent (the clearing variant paints the full-frame
+        // opaque-black background — the ROOM-card black-edge bug).
         let (bw, bh) = ((max_x - min_x) as u32, (max_y - min_y) as u32);
         let scale = self.raster_scale;
         let (vw, vh) = ui.viewport();
@@ -616,7 +619,7 @@ impl GpuiRenderer {
         let full = (fw * fh * 4) as usize;
         self.raster_scratch.resize(full, 0);
         self.raster_scratch[..full].fill(0);
-        pocketjs_core::raster::render_scaled(ui, batch, &mut self.raster_scratch, scale);
+        pocketjs_core::raster::render_scaled_over(ui, batch, &mut self.raster_scratch, scale);
         let (pw, ph) = (bw * scale, bh * scale);
         let mut bgra = Vec::with_capacity((pw * ph * 4) as usize);
         let (ox_px, oy_px) = (min_x as u32 * scale, min_y as u32 * scale);

--- a/engine/backends/gpui/src/render.rs
+++ b/engine/backends/gpui/src/render.rs
@@ -41,10 +41,6 @@ fn decode_wh(word: u32) -> (f32, f32) {
     ((word & 0xffff) as f32, ((word >> 16) & 0xffff) as f32)
 }
 
-fn xy_word(x: i32, y: i32) -> u32 {
-    ((x as i16 as u16) as u32) | (((y as i16 as u16) as u32) << 16)
-}
-
 fn fnv64(words: &[u32]) -> u64 {
     let mut h: u64 = 0xcbf2_9ce4_8422_2325;
     for w in words {
@@ -116,6 +112,9 @@ pub struct GpuiRenderer {
     /// Tri-batch raster fallback cache, keyed by batch content hash.
     rasters: HashMap<u64, CachedRaster>,
     rasters_used: HashSet<u64>,
+    /// Reusable full-viewport RGBA scratch for the raster fallback (the
+    /// core rasterizer renders whole framebuffers).
+    raster_scratch: Vec<u8>,
     /// Shaped-line cache: an editor keystroke or caret blink repaints the
     /// whole window, but only the edited line's shape changes — everything
     /// else replays. Keyed by (text, slot, color) hash, text-verified
@@ -134,6 +133,7 @@ impl GpuiRenderer {
             images: HashMap::new(),
             rasters: HashMap::new(),
             rasters_used: HashSet::new(),
+            raster_scratch: Vec::new(),
             shaped: HashMap::new(),
             shaped_used: HashSet::new(),
         }
@@ -602,30 +602,28 @@ impl GpuiRenderer {
         if min_x >= max_x || min_y >= max_y {
             return;
         }
-        // Translate the batch to the bbox origin and raster at density.
-        let mut patched = batch.to_vec();
-        let mut j = 0usize;
-        while j < patched.len() {
-            let idxs: &[usize] = if patched[j] == spec::draw_op::TEX_TRI {
-                &[j + 2, j + 5, j + 8]
-            } else {
-                &[j + 1, j + 2, j + 3]
-            };
-            for &k in idxs {
-                let (x, y) = decode_xy(patched[k]);
-                patched[k] = xy_word(x as i32 - min_x, y as i32 - min_y);
-            }
-            j += if patched[j] == spec::draw_op::TEX_TRI {
-                12
-            } else {
-                7
-            };
-        }
+        // The core rasterizer renders full-viewport framebuffers (it
+        // asserts the pixel count), so raster the batch into a reusable
+        // viewport-sized scratch at density and crop the bbox out. The
+        // batch words are already viewport-space — no translation needed.
         let (bw, bh) = ((max_x - min_x) as u32, (max_y - min_y) as u32);
         let scale = self.raster_scale;
+        let (vw, vh) = ui.viewport();
+        let (fw, fh) = (
+            (vw.ceil() as u32).max(1) * scale,
+            (vh.ceil() as u32).max(1) * scale,
+        );
+        let full = (fw * fh * 4) as usize;
+        self.raster_scratch.resize(full, 0);
+        self.raster_scratch[..full].fill(0);
+        pocketjs_core::raster::render_scaled(ui, batch, &mut self.raster_scratch, scale);
         let (pw, ph) = (bw * scale, bh * scale);
-        let mut bgra = vec![0u8; (pw * ph * 4) as usize];
-        pocketjs_core::raster::render_scaled(ui, &patched, &mut bgra, scale);
+        let mut bgra = Vec::with_capacity((pw * ph * 4) as usize);
+        let (ox_px, oy_px) = (min_x as u32 * scale, min_y as u32 * scale);
+        for row in 0..ph {
+            let start = (((oy_px + row) * fw + ox_px) * 4) as usize;
+            bgra.extend_from_slice(&self.raster_scratch[start..start + (pw * 4) as usize]);
+        }
         rgba_to_bgra(&mut bgra);
         let Some(image) = render_image(pw, ph, bgra) else {
             return;

--- a/engine/core/src/raster.rs
+++ b/engine/core/src/raster.rs
@@ -371,6 +371,15 @@ pub fn render_scaled_rgb565(ui: &Ui, words: &[u32], fb: &mut [u16], scale: u32) 
     render_scaled_impl(ui, words, &mut target, scale, true);
 }
 
+/// Execute DrawList words over an existing RGBA8 framebuffer without
+/// clearing it. Render backends composite these into their own scene (the
+/// gpui tri-batch fallback keeps uncovered pixels transparent this way —
+/// the clearing variants paint the full-frame opaque-black background).
+pub fn render_scaled_over(ui: &Ui, words: &[u32], fb: &mut [u8], scale: u32) {
+    let mut target = RgbaTarget::<false> { bytes: fb };
+    render_scaled_impl(ui, words, &mut target, scale, false);
+}
+
 /// Execute DrawList words over an existing RGB565 framebuffer without
 /// clearing it. Hardware backends use this for ordered fallback segments.
 pub fn render_scaled_rgb565_over(ui: &Ui, words: &[u32], fb: &mut [u16], scale: u32) {
@@ -1316,6 +1325,31 @@ mod tests {
         let width = spec::SCREEN_W as usize * scale as usize;
         let offset = (y * width + x) * 4;
         fb[offset..offset + 4].try_into().unwrap()
+    }
+
+    #[test]
+    fn render_scaled_over_composites_without_clearing() {
+        // The OVER variant must leave untouched pixels exactly as supplied
+        // (a transparent scratch stays transparent outside the ops — the
+        // gpui tri-batch fallback's contract), while the clearing variant
+        // paints the opaque-black background everywhere.
+        let ui = Ui::new();
+        let words = [
+            spec::draw_op::RECT,
+            xy_word(10, 10),
+            wh_word(20, 20),
+            0xff00_00ff, // opaque red (ABGR)
+        ];
+        let mut over = framebuffer(1);
+        over.fill(7); // sentinel: pre-existing content
+        render_scaled_over(&ui, &words, &mut over, 1);
+        assert_eq!(rgba(&over, 1, 15, 15), [255, 0, 0, 255], "op painted");
+        assert_eq!(rgba(&over, 1, 5, 5), [7, 7, 7, 7], "untouched pixel preserved");
+
+        let mut cleared = framebuffer(1);
+        cleared.fill(7);
+        render_scaled(&ui, &words, &mut cleared, 1);
+        assert_eq!(rgba(&cleared, 1, 5, 5), [0, 0, 0, 255], "clearing variant blacks out");
     }
 
     #[test]

--- a/hosts/macos/src/main.rs
+++ b/hosts/macos/src/main.rs
@@ -71,6 +71,8 @@ enum ScriptEvent {
     Type(u64, String),
     /// Press-and-release the pointer at logical (x, y) at a tick.
     Click(u64, f32, f32),
+    /// Hold a console button for ~6 ticks starting at a tick.
+    Press(u64, u32),
 }
 
 struct Args {
@@ -159,6 +161,17 @@ fn parse_args() -> Result<Args> {
             }
             "--quit-after" => args.quit_after_ticks = Some(val("--quit-after")?.parse()?),
             "--announce-ready" => args.announce_ready = true,
+            "--press" => {
+                // --press NAME@TICK (console button script: up/down/left/
+                // right/cross/circle/square/triangle/l/r/start/select)
+                let v = val("--press")?;
+                let (name, t) = v
+                    .rsplit_once('@')
+                    .ok_or_else(|| anyhow!("--press NAME@TICK"))?;
+                let bit =
+                    button_for(name).ok_or_else(|| anyhow!("--press: unknown button {name}"))?;
+                args.script.push(ScriptEvent::Press(t.parse()?, bit));
+            }
             "--storm" => {
                 // --storm CPS@START+DUR (ticks)
                 let v = val("--storm")?;
@@ -258,6 +271,8 @@ struct PocketRoot {
 
     // console input
     buttons: u32,
+    /// Buttons currently held by the --press script.
+    script_buttons: u32,
     // editor input
     mouse_down: bool,
     click_edge: bool,
@@ -329,6 +344,7 @@ impl PocketRoot {
             pending_viewport: None,
             canvas_origin: Rc::new(Cell::new(point(px(0.0), px(0.0)))),
             buttons: 0,
+            script_buttons: 0,
             mouse_down: false,
             click_edge: false,
             last_mouse: None,
@@ -408,20 +424,24 @@ impl PocketRoot {
 
     fn run_script(&mut self) {
         let tick = self.ticks;
-        let events: Vec<ScriptEvent> = self
-            .script
-            .iter()
-            .filter(|e| matches!(e, ScriptEvent::Type(t, _) | ScriptEvent::Click(t, _, _) if *t == tick))
-            .cloned()
-            .collect();
-        for ev in events {
+        for ev in self.script.clone() {
             match ev {
-                ScriptEvent::Type(_, s) => self.svc(serde_json::json!({"t": "ch", "s": s})),
-                ScriptEvent::Click(_, x, y) => {
+                ScriptEvent::Type(t, s) if t == tick => {
+                    self.svc(serde_json::json!({"t": "ch", "s": s}))
+                }
+                ScriptEvent::Click(t, x, y) if t == tick => {
                     self.svc(serde_json::json!({"t": "mouse", "x": x, "y": y, "d": true}));
                     self.svc(serde_json::json!({"t": "mouse", "x": x, "y": y, "d": false}));
                     self.click_edge = true;
                 }
+                // Held for 6 ticks so edge-detected button handlers latch.
+                ScriptEvent::Press(t, bit) if tick >= t && tick < t + 6 => {
+                    self.script_buttons |= bit;
+                }
+                ScriptEvent::Press(t, bit) if tick == t + 6 => {
+                    self.script_buttons &= !bit;
+                }
+                _ => {}
             }
         }
     }
@@ -691,8 +711,8 @@ fn button_for(key: &str) -> Option<u32> {
         "x" | "backspace" => BTN_CIRCLE,
         "a" => BTN_SQUARE,
         "s" => BTN_TRIANGLE,
-        "q" => BTN_LTRIGGER,
-        "w" => BTN_RTRIGGER,
+        "q" | "l" => BTN_LTRIGGER,
+        "w" | "r" => BTN_RTRIGGER,
         "tab" => BTN_SELECT,
         "space" => BTN_START,
         _ => return None,


### PR DESCRIPTION
Follow-up to #293, both bugs found by running the motions demo — the first app whose DrawList exercises the rotated/3D raster-fallback path:

1. **Abort on boot**: the fallback handed `render_scaled` a bbox-sized buffer; the rasterizer renders whole viewports and asserts the pixel count. Now rasters into a reusable full-viewport scratch and crops the bbox (words stay untranslated — already viewport-space).
2. **Black edges mid-animation** (the ROOM card): `render_scaled` clears to OPAQUE BLACK (the PSP full-frame contract), so uncovered bbox pixels pasted black over the card. The core gains `render_scaled_over` — the RGBA sibling of `render_scaled_rgb565_over`, compositing over the existing framebuffer without clearing — and the fallback's zeroed scratch stays transparent outside the triangles. Pinned by `render_scaled_over_composites_without_clearing`.

Also adds `--press NAME@TICK` console-button scripting to the host (the pointer script's button sibling; l/r trigger aliases) so demos can be driven to a given page headlessly.

Verified: `bun run macos motions` runs the full keyframe gallery including the 3D page's perspective ROOM; core 121 tests, `--proof`, clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)