### PR TITLE
feat(contracts): companion adapters and viewport policy in the manifest and plan

### DIFF
--- a/apps/note/pocket.json
+++ b/apps/note/pocket.json
@@ -26,6 +26,9 @@
     "entry": "apps/note/main.tsx",
     "output": "note-main",
     "framework": "solid",
+    "companions": [
+      "note"
+    ],
     "viewport": {
       "dynamic": {
         "default": [

--- a/contracts/schema/pocket-2.json
+++ b/contracts/schema/pocket-2.json
@@ -123,6 +123,16 @@
             "octane"
           ]
         },
+        "companions": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 64,
+            "pattern": "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$"
+          },
+          "uniqueItems": true
+        },
         "viewport": {
           "anyOf": [
             {

--- a/contracts/spec/pocket-manifest.ts
+++ b/contracts/spec/pocket-manifest.ts
@@ -66,6 +66,14 @@ export interface PocketManifestV2 {
     readonly output?: string;
     readonly framework: "solid" | "vue-vapor" | "octane";
     readonly viewport: ManifestViewport;
+    /**
+     * Companion service names the app's svc adapters speak (the exact
+     * strings it passes to `svcOpen`). Hosts derive their svc allowlist
+     * and adapter wiring from the resolved plan's copy of this list —
+     * never from app-name conventions (issue #295). Absent = the app
+     * runs standalone everywhere; svcOpen answers false by default.
+     */
+    readonly companions?: readonly string[];
   };
 }
 
@@ -182,6 +190,16 @@ export const pocketManifestV2Schema = {
           pattern: "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
         },
         framework: { enum: ["solid", "vue-vapor", "octane"] },
+        companions: {
+          type: "array",
+          items: {
+            type: "string",
+            minLength: 1,
+            maxLength: 64,
+            pattern: "^[a-z][a-z0-9]*(?:-[a-z0-9]+)*$",
+          },
+          uniqueItems: true,
+        },
         viewport: {
           anyOf: [
             // Shorthand: a bare fixed viewport (format-2 compatibility).

--- a/engine/apple/include/pocket_apple.h
+++ b/engine/apple/include/pocket_apple.h
@@ -58,6 +58,12 @@ int32_t pocket_apple_set_identity(PocketApple *handle, const char *host_id,
 // must be driven at the same rate.
 int32_t pocket_apple_set_tick_rate(PocketApple *handle, uint32_t hz);
 
+/* Declare the exact companion service names this host serves (comma-
+ * separated svcOpen names). Deny-by-default: never calling this means
+ * svcOpen answers false for every service. Before eval_bundle. */
+int32_t pocket_apple_set_svc_allowlist(PocketApple *handle,
+                                       const char *comma_separated);
+
 int32_t pocket_apple_load_pak(PocketApple *handle, const uint8_t *bytes,
                               size_t length);
 

--- a/engine/apple/src/lib.rs
+++ b/engine/apple/src/lib.rs
@@ -185,6 +185,36 @@ pub extern "C" fn pocket_apple_set_identity(
     })
 }
 
+/// Declare the exact companion service names this host serves (comma-
+/// separated; svcOpen answers false for everything else — and for
+/// everything when this is never called, per the surface's deny-by-default
+/// contract). Must be called before `eval_bundle`, like `set_identity`.
+#[unsafe(no_mangle)]
+pub extern "C" fn pocket_apple_set_svc_allowlist(
+    handle: *mut PocketApple,
+    comma_separated: *const c_char,
+) -> i32 {
+    with_handle(handle, ERR_PANIC, |state| {
+        if state.mounted {
+            set_last_error("svc allowlist must be set before eval_bundle");
+            return ERR_BAD_STATE;
+        }
+        if comma_separated.is_null() {
+            return ERR_BAD_ARGUMENT;
+        }
+        let names = unsafe { std::ffi::CStr::from_ptr(comma_separated) };
+        match names.to_str() {
+            Ok(names) => {
+                state
+                    .surface
+                    .set_svc_allowlist(names.split(',').filter(|s| !s.is_empty()));
+                OK
+            }
+            Err(_) => ERR_BAD_ARGUMENT,
+        }
+    })
+}
+
 /// Ticks (and therefore `pocket_apple_frame` calls) per second of guest
 /// virtual time. 1..=240; the guest bundle must be built for the same rate.
 /// Rejected after `eval_bundle`, like `set_identity`: the mount publishes

--- a/framework/src/manifest/plan.ts
+++ b/framework/src/manifest/plan.ts
@@ -17,9 +17,16 @@ export interface ResolvedBuildPlanContent {
     readonly presentation: PresentationMode;
     /** Target-owned raster samples per logical pixel; layout stays logical. */
     readonly rasterDensity: number;
+    /** Which manifest viewport variant the target resolved — hosts derive
+     *  size-locking from the plan, never by re-reading the manifest. */
+    readonly policy: "fixed" | "dynamic";
   };
   /** Required APIs are true; enhancements reflect target availability. */
   readonly features: Readonly<Record<string, boolean>>;
+  /** Companion service names from the manifest (app.companions): the exact
+   *  svcOpen strings the app's adapters speak. Hosts build their svc
+   *  allowlist from this list (issue #295). */
+  readonly companions: readonly string[];
 }
 
 export interface ResolvedBuildPlan extends ResolvedBuildPlanContent {

--- a/framework/src/manifest/resolve.ts
+++ b/framework/src/manifest/resolve.ts
@@ -56,7 +56,12 @@ function resolveViewport(
   manifest: PocketManifestV2,
   profile: TargetProfile,
   diagnostics: ContractDiagnostic[],
-): { logical: Viewport; presentation: PresentationMode; physical: Viewport } | null {
+): {
+  logical: Viewport;
+  presentation: PresentationMode;
+  physical: Viewport;
+  policy: "fixed" | "dynamic";
+} | null {
   const viewport = normalizeViewport(manifest.app.viewport);
   const { physicalViewport, logicalViewports, dynamicViewport, presentations, rasterDensity } =
     profile.display;
@@ -82,6 +87,7 @@ function resolveViewport(
         logical: size,
         presentation: "native",
         physical: [size[0] * rasterDensity, size[1] * rasterDensity],
+        policy: "dynamic",
       };
     }
     if (viewport.fixed) {
@@ -107,6 +113,7 @@ function resolveViewport(
         logical: size,
         presentation: "native",
         physical: [size[0] * rasterDensity, size[1] * rasterDensity],
+        policy: "fixed",
       };
     }
     diagnostics.push({
@@ -168,7 +175,14 @@ function resolveViewport(
       ok = false;
     }
   }
-  return ok ? { logical, presentation, physical: [physicalViewport[0], physicalViewport[1]] } : null;
+  return ok
+    ? {
+        logical,
+        presentation,
+        physical: [physicalViewport[0], physicalViewport[1]],
+        policy: "fixed",
+      }
+    : null;
 }
 
 /** Validate framework-owned registry data before trusting it in resolution. */
@@ -361,8 +375,10 @@ export function resolveBuildPlan(
       physical,
       presentation: resolvedViewport.presentation,
       rasterDensity: profile.display.rasterDensity,
+      policy: resolvedViewport.policy,
     },
     features,
+    companions: manifest.app.companions ?? [],
   };
   return { ok: true, plan: finalizeBuildPlan(content) };
 }

--- a/hosts/macos/src/main.rs
+++ b/hosts/macos/src/main.rs
@@ -90,6 +90,8 @@ struct Args {
     native_text: bool,
     /// svc editor protocol instead of console buttons.
     editor: bool,
+    /// Companion service names from the plan (svcOpen allowlist).
+    companions: Vec<String>,
     density: u32,
     script: Vec<ScriptEvent>,
     quit_after_ticks: Option<u64>,
@@ -112,6 +114,7 @@ fn parse_args() -> Result<Args> {
         fixed: false,
         native_text: false,
         editor: false,
+        companions: Vec::new(),
         density: 2,
         script: Vec::new(),
         quit_after_ticks: None,
@@ -137,6 +140,13 @@ fn parse_args() -> Result<Args> {
             "--fixed" => args.fixed = true,
             "--native-text" => args.native_text = true,
             "--editor" => args.editor = true,
+            "--companions" => {
+                args.companions = val("--companions")?
+                    .split(',')
+                    .filter(|s| !s.is_empty())
+                    .map(str::to_string)
+                    .collect();
+            }
             "--density" => args.density = val("--density")?.parse::<u32>()?.clamp(1, 4),
             "--type" => {
                 // --type TEXT@TICK
@@ -297,10 +307,11 @@ impl PocketRoot {
             args.density,
         );
         surface.set_identity(HOST_ID, HOST_ABI);
-        // svcOpen denies by default (pocket-ui-surface); the adapter being
-        // on is the one companion this host declares.
-        if args.editor {
-            surface.set_svc_allowlist(["note"]);
+        // svcOpen denies by default (pocket-ui-surface); the allowlist is
+        // exactly the plan's companion list (tools/macos.ts --companions,
+        // issue #295) — never an app-name convention.
+        if !args.companions.is_empty() {
+            surface.set_svc_allowlist(args.companions.iter().map(String::as_str));
         }
         surface.feed_pak(&pak);
         let cfg = TextConfig::new("Inter");

--- a/tests/fixtures/plans/portable-psp.plan.json
+++ b/tests/fixtures/plans/portable-psp.plan.json
@@ -20,12 +20,14 @@
       272
     ],
     "presentation": "integer-fit",
-    "rasterDensity": 1
+    "rasterDensity": 1,
+    "policy": "fixed"
   },
   "features": {
     "input.analog.left": true,
     "input.buttons": true,
     "text.glyphs.baked": true
   },
-  "planHash": "sha256:b8224b08498af9535f31343a15fd769f1dfba05868f46cc4db94d174200ba1ad"
+  "companions": [],
+  "planHash": "sha256:e3a257d89114161e6faecb37249f3cba37f444034a951c80a8ffcaed5a593ddf"
 }

--- a/tests/fixtures/plans/portable-vita.plan.json
+++ b/tests/fixtures/plans/portable-vita.plan.json
@@ -20,12 +20,14 @@
       544
     ],
     "presentation": "integer-fit",
-    "rasterDensity": 2
+    "rasterDensity": 2,
+    "policy": "fixed"
   },
   "features": {
     "input.analog.left": true,
     "input.buttons": true,
     "text.glyphs.baked": true
   },
-  "planHash": "sha256:c763eee7c84f6ac5101bb82c75b21706b691279c8043e0561d2a193b71fc9deb"
+  "companions": [],
+  "planHash": "sha256:5b2ab23a3d3b54e0ef54bdd706092cd8350561d978f6cb1280a0c72afa647e96"
 }

--- a/tests/ios-profile.test.ts
+++ b/tests/ios-profile.test.ts
@@ -65,6 +65,7 @@ describe("private iOS build profile", () => {
       physical: [480 * IOS_DEV_DEFAULT_DENSITY, 272 * IOS_DEV_DEFAULT_DENSITY],
       presentation: "integer-fit",
       rasterDensity: IOS_DEV_DEFAULT_DENSITY,
+      policy: "fixed",
     });
     expect(plan.features).toEqual({
       "input.touch": true,

--- a/tests/iphone2g-profile.test.ts
+++ b/tests/iphone2g-profile.test.ts
@@ -66,6 +66,7 @@ describe("private iPhone 2G build profile", () => {
       physical: IPHONE2G_VIEWPORT,
       presentation: "native",
       rasterDensity: 1,
+      policy: "fixed",
     });
     expect(plan.features).toEqual({
       "input.touch": true,

--- a/tests/iphone4s-profile.test.ts
+++ b/tests/iphone4s-profile.test.ts
@@ -57,6 +57,7 @@ describe("private iPhone 4S profile", () => {
       physical: IPHONE4S_PHYSICAL_VIEWPORT,
       presentation: "native",
       rasterDensity: IPHONE4S_RASTER_DENSITY,
+      policy: "fixed",
     });
     expect(plan.app.entry).toBe("apps/iphone4s-demo/main.tsx");
     expect(plan.app.output).toBe("iphone4s-demo-main");

--- a/tests/ipodtouch-profile.test.ts
+++ b/tests/ipodtouch-profile.test.ts
@@ -69,6 +69,7 @@ describe("private iPod touch 6 profile", () => {
       physical: IPODTOUCH_PHYSICAL_VIEWPORT,
       presentation: "native",
       rasterDensity: IPODTOUCH_RASTER_DENSITY,
+      policy: "fixed",
     });
     expect(plan.features).toEqual({ "input.touch": true, "text.glyphs.baked": true });
     expect(plan.app.entry).toBe("apps/ipodtouch-demo/main.tsx");

--- a/tests/meizu-m8-profile.test.ts
+++ b/tests/meizu-m8-profile.test.ts
@@ -66,6 +66,7 @@ describe("private Meizu M8 build profile", () => {
       physical: MEIZU_M8_PHYSICAL_VIEWPORT,
       presentation: "native",
       rasterDensity: 1,
+      policy: "fixed",
     });
     expect(plan.features).toEqual({
       "input.touch": true,

--- a/tests/platform-contracts.test.ts
+++ b/tests/platform-contracts.test.ts
@@ -270,6 +270,23 @@ describe("semantic resolution", () => {
     if (!onWidget.ok) return;
     expect(onWidget.plan.features["text.layout.native"]).toBe(false);
     expect(onWidget.plan.features["text.glyphs.runtime"]).toBe(true);
+
+    // The companion adapter is PLAN data now (issue #295): hosts build
+    // their svc allowlist and adapter wiring from this list, never from
+    // app-name conventions; the viewport policy rides along so hosts
+    // derive size-locking from the plan too.
+    expect(onApp.plan.companions).toEqual(["note"]);
+    expect(onApp.plan.viewport.policy).toBe("dynamic");
+    const hero = await Bun.file(new URL("../apps/hero/pocket.json", import.meta.url)).json();
+    const heroOnApp = validateAndResolveBuildPlan(hero, { target: "macos-app" });
+    expect(heroOnApp.ok).toBe(true);
+    if (!heroOnApp.ok) return;
+    expect(heroOnApp.plan.companions).toEqual([]);
+    expect(heroOnApp.plan.viewport.policy).toBe("dynamic");
+    const heroOnPsp = validateAndResolveBuildPlan(hero, { target: "psp" });
+    expect(heroOnPsp.ok).toBe(true);
+    if (!heroOnPsp.ok) return;
+    expect(heroOnPsp.plan.viewport.policy).toBe("fixed");
   });
 
   test("guest resolution honors the declared execution classes", () => {
@@ -306,6 +323,7 @@ describe("semantic resolution", () => {
       physical: [480, 272],
       presentation: "integer-fit",
       rasterDensity: 1,
+      policy: "fixed",
     });
     expect(result.plan.features).toEqual({
       "input.analog.left": true,
@@ -505,6 +523,7 @@ describe("semantic resolution", () => {
       physical: [960, 544],
       presentation: "integer-fit",
       rasterDensity: 2,
+      policy: "fixed",
     });
     expect(result.plan.features).toEqual({
       "input.analog.left": true,
@@ -564,6 +583,7 @@ describe("semantic resolution", () => {
       physical: [960, 544],
       presentation: "integer-fit",
       rasterDensity: 2,
+      policy: "fixed",
     });
     expect(Object.values(result.plan.features).every(Boolean)).toBe(true);
   });

--- a/tests/symbian-package.test.ts
+++ b/tests/symbian-package.test.ts
@@ -27,8 +27,10 @@ function plan(
       physical: [640, 360],
       presentation: "native",
       rasterDensity: 1,
+      policy: "dynamic",
     },
     features: {},
+    companions: [],
     planHash: `sha256:${"0".repeat(64)}`,
   };
 }

--- a/tests/symbian-runtime.test.ts
+++ b/tests/symbian-runtime.test.ts
@@ -146,8 +146,10 @@ describe("experimental Nokia E7 runtime profile", () => {
           physical: liveViewport ? [640, 360] : [480, 272],
           presentation: "native",
           rasterDensity: 1,
+          policy: liveViewport ? "dynamic" : "fixed",
         },
         features: {},
+        companions: [],
         planHash: `sha256:${"0".repeat(64)}`,
       },
       packageBytes: new Uint8Array(bytes),
@@ -334,6 +336,7 @@ describe("experimental Nokia E7 runtime profile", () => {
       physical: [640, 360],
       presentation: "native",
       rasterDensity: 1,
+      policy: "dynamic",
     });
     expect(plan.features["display.viewport.live"]).toBe(true);
     expect(plan.planHash).toMatch(/^sha256:[a-f0-9]{64}$/);
@@ -346,6 +349,7 @@ describe("experimental Nokia E7 runtime profile", () => {
       physical: [480, 272],
       presentation: "integer-fit",
       rasterDensity: 1,
+      policy: "fixed",
     });
     expect(psp.plan.features["display.viewport.live"]).toBe(false);
   });

--- a/tests/widget-args.test.ts
+++ b/tests/widget-args.test.ts
@@ -154,6 +154,7 @@ describe("Pocket Stage manifest admission", () => {
       physical: [480, 272],
       presentation: "integer-fit",
       rasterDensity: 1,
+      policy: "fixed",
     });
   });
 
@@ -180,6 +181,7 @@ describe("Pocket Stage manifest admission", () => {
       physical: [176, 132],
       presentation: "native",
       rasterDensity: 1,
+      policy: "fixed",
     });
   });
 });

--- a/tools/macos.ts
+++ b/tools/macos.ts
@@ -59,22 +59,17 @@ await $`cargo build --release`.cwd(`${root}hosts/macos`);
 const bin = `${root}hosts/macos/target/release/pocket-macos`;
 const env = { ...process.env, RUST_LOG: process.env.RUST_LOG ?? "info" };
 
-// Host flags: the capability-shaped ones derive from the resolved plan;
-// --editor is the ONE name-convention exception (companion selection,
-// issue #295), and --fixed re-reads the manifest because the plan does not
-// yet carry the fixed/dynamic viewport policy (also #295):
-//   fixed        — the app declared only a fixed viewport (size-locked run)
+// Every host flag derives from the resolved plan (issue #295 landed the
+// companion list and viewport policy in it):
+//   fixed        — plan.viewport.policy (size-locked run)
 //   native-text  — text.layout.native resolved true (host installs the
 //                  CoreText measurer before mount)
-//   editor       — the NOTE COMPANION adapter (apps/note/svc.ts dialect):
-//                  an app protocol, NOT a capability. Capabilities resolve
-//                  independently of it — the live-viewport hook and the
-//                  button map are host-generic for every app; text/IME/
-//                  clipboard delivery rides the companion today (the same
-//                  stock-host bar as macos-widget, PR #129).
-const viewport = manifest.app.viewport;
-const fixed = !("dynamic" in viewport) || !viewport.dynamic;
-const editor = manifest.name === "pocket-note";
+//   companions   — plan.companions: the svc names the app speaks; the host
+//                  builds its svcOpen allowlist from exactly this list
+//   editor       — the NOTE companion dialect (apps/note/svc.ts) — wired
+//                  when the app declares the "note" companion
+const fixed = plan.viewport.policy === "fixed";
+const editor = plan.companions.includes("note");
 const flags: string[] = [
   "--app",
   plan.app.output,
@@ -87,6 +82,7 @@ const flags: string[] = [
 ];
 if (fixed) flags.push("--fixed");
 if (plan.features["text.layout.native"]) flags.push("--native-text");
+if (plan.companions.length > 0) flags.push("--companions", plan.companions.join(","));
 if (editor) flags.push("--editor");
 
 if (proof) {


### PR DESCRIPTION
Closes #295 (all three registered items):

1. **Companion metadata**: `app.companions` in pocket.json (schema-validated svcOpen names) → carried through the resolved plan → `tools/macos.ts` derives the adapter and the host's svc allowlist from the plan. The `manifest.name === "pocket-note"` convention is gone.
2. **Plan completeness**: `plan.viewport.policy` records which viewport variant the target resolved — hosts derive size-locking (`--fixed`) from the plan instead of re-reading the manifest. The plan is now the single host-boot truth.
3. **Apple sidecar allowlist**: `pocket_apple_set_svc_allowlist` (C ABI + header), the declaration surface the deny-by-default change left missing.

Contract-visible changes: manifest schema regenerated from TS (byte-compare test green), plan fixtures regenerated (planHash moves — self-checksum only), `ResolvedBuildPlanContent` gains two fields. Admission is untouched: companions are app protocol, not capabilities — the resolver just carries them.

Verified: `bun run test` 11/11, tsc, plan-driven `--proof` green (note edits via the companions-derived allowlist), host clippy/fmt clean, E7/device-profile expectations updated (E7 is a window form → dynamic policy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)