### PR TITLE
ci: add pull-request workflow with release test gates (#182)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,167 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+# Cancel superseded runs on the same PR to save minutes.
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  # ── JavaScript: install, test, typecheck ──────────────────────────
+  js:
+    name: JavaScript & TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build wasm core (required by tests)
+        run: bun tools/wasm.ts
+
+      - name: Test JavaScript and package contracts
+        run: bun run test
+
+      - name: Typecheck
+        run: bunx tsc --noEmit
+
+  # ── Rust: core, workspace, Symbian bridge ─────────────────────────
+  rust:
+    name: Rust (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: core
+            manifest: engine/core/Cargo.toml
+            workspace: false
+          - label: workspace
+            manifest: engine/Cargo.toml
+            workspace: true
+          - label: symbian
+            manifest: engine/symbian/Cargo.toml
+            workspace: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ matrix.workspace == 'true' && 'engine/target' || format('{0}/target', matrix.manifest == 'engine/core/Cargo.toml' && 'engine/core' || 'engine/symbian') }}
+          key: ${{ runner.os }}-rust-${{ matrix.label }}-${{ hashFiles('engine/**/Cargo.toml', 'engine/**/Cargo.lock', 'engine/**/src/**') }}
+          restore-keys: ${{ runner.os }}-rust-${{ matrix.label }}-
+
+      - name: Test Rust (${{ matrix.label }})
+        run: cargo test --locked --manifest-path ${{ matrix.manifest }}${{ matrix.workspace == 'true' && ' --workspace' || '' }}
+
+  # ── Renderer golden image comparison ──────────────────────────────
+  goldens:
+    name: Renderer goldens
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [js]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build wasm core
+        run: bun tools/wasm.ts
+
+      - name: Test renderer goldens
+        run: bun tests/golden.ts
+
+  # ── Deterministic tape replay ─────────────────────────────────────
+  tape:
+    name: Tape replay
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [js]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build wasm core
+        run: bun tools/wasm.ts
+
+      - name: Test deterministic tape replay
+        run: bun run tape:check
+
+  # ── Documentation & schema parity ─────────────────────────────────
+  docs:
+    name: Docs & schema
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [js]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v4
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build documentation and verify schema parity
+        run: |
+          bun run site:build
+          cmp contracts/schema/pocket-2.json site/dist/schema/pocket-2.json


### PR DESCRIPTION
## Summary

- Add `.github/workflows/ci.yml` that runs on every PR targeting `main`
- Mirror all hermetic test gates from `release.yml`:
  - `bun run test` (JavaScript & package contracts)
  - `bunx tsc --noEmit` (TypeScript typecheck)
  - `cargo test` for core, workspace, and Symbian bridge
  - `bun tests/golden.ts` (renderer golden comparison)
  - `bun run tape:check` (deterministic tape replay)
  - `bun run site:build` + schema parity check
- Cache Bun and Cargo inputs with lockfile-based keys; enforce `--frozen-lockfile` and `--locked`
- Use `concurrency` to cancel superseded runs on the same PR

## Not included (by design)

- PSP EBOOT / Vita VPK / Symbian E7 builds — require proprietary toolchains and physical devices
- These remain validated only through the release workflow and manual evidence

## Next step

- Once stable, mark the CI checks as required branch protection rules

Closes #182.