### PR TITLE
feat(site): a Beyond 2D UI chapter, and plainer landing copy

### DIFF
--- a/site/assets/landing.css
+++ b/site/assets/landing.css
@@ -235,6 +235,70 @@ img,video{max-width:100%;display:block}
   4%{border-color:rgba(176,125,28,.9);color:#e8b752;background:rgba(176,125,28,.18)}
   12%,100%{border-color:rgba(176,125,28,.4);color:var(--c3);background:rgba(176,125,28,.05)}}
 
+/* Beyond 2D UI: one guest, a rotating set of native cores. A single 10.5s
+   cycle drives the composition name, which cores are mounted, and the screen,
+   so the three read as one machine being reassembled. */
+.mods{border:1px solid var(--line);background:var(--panel);padding:1.1rem 1.2rem 1.2rem}
+.mods-head{display:flex;justify-content:space-between;align-items:baseline;gap:1rem;margin-bottom:1rem}
+.mods-head .lb{font-family:var(--mono);font-size:.64rem;letter-spacing:.12em;text-transform:uppercase;color:var(--ph)}
+.mods-now{position:relative;font-family:var(--px);font-size:1.3rem;line-height:1;min-width:9rem;text-align:right}
+.mods-now i{position:absolute;right:0;top:0;font-style:normal;white-space:nowrap;opacity:0;
+  background:var(--metal-ph);-webkit-background-clip:text;background-clip:text;color:transparent}
+.mods-guest{border:1px solid rgba(78,240,138,.35);background:linear-gradient(180deg,rgba(78,240,138,.07),transparent);
+  padding:.6rem .8rem;text-align:center;animation:guestbeat 3.5s ease-in-out infinite}
+.mods-guest b{display:block;font-family:var(--mono);font-size:.72rem;letter-spacing:.06em;color:var(--ink)}
+.mods-guest span{display:block;margin-top:.15rem;font-family:var(--mono);font-size:.58rem;letter-spacing:.06em;
+  text-transform:uppercase;color:var(--muted)}
+@keyframes guestbeat{0%,100%{box-shadow:0 0 0 rgba(78,240,138,0)}50%{box-shadow:0 0 22px rgba(78,240,138,.10) inset}}
+/* the op vocabulary crossing between guest and cores */
+.mods-bus{position:relative;height:1.5rem;margin:0 auto;width:1px;background:linear-gradient(180deg,rgba(78,240,138,.5),rgba(78,240,138,.15));overflow:visible}
+.mods-bus .spark{position:absolute;left:-2px;width:5px;height:5px;border-radius:50%;background:var(--ph);
+  box-shadow:0 0 9px rgba(78,240,138,.9);animation:busdrop 3.5s cubic-bezier(.4,0,.6,1) infinite}
+@keyframes busdrop{0%{top:0;opacity:0}12%{opacity:1}70%{top:1.2rem;opacity:1}88%,100%{top:1.2rem;opacity:0}}
+.mods-row{display:flex;flex-wrap:wrap;gap:.4rem;justify-content:center;margin-top:.4rem}
+.mods-row.four{display:grid;grid-template-columns:repeat(4,minmax(0,1fr))}
+.mod.wide{width:100%}
+.mod{font-family:var(--mono);font-size:.62rem;line-height:1.3;border:1px solid var(--line);background:var(--bg);
+  padding:.35rem .45rem;color:var(--muted);text-align:center}
+.mod em{display:block;font-style:normal;font-size:.54rem;letter-spacing:.05em;text-transform:uppercase;
+  color:var(--steel-3);margin-top:.15rem}
+.mod.always{border-color:rgba(78,240,138,.45);color:var(--ink-2)}
+.mod.always em{color:var(--ph-2)}
+/* mounted windows inside the shared cycle: 1 = 0-33%, 2 = 33-66%, 3 = 66-100% */
+.mod.m1,.mod.m2,.mod.m3,.mod.m23{animation-duration:10.5s;animation-timing-function:linear;animation-iteration-count:infinite}
+.mod.m1{animation-name:mount1} .mod.m2{animation-name:mount2}
+.mod.m3{animation-name:mount3} .mod.m23{animation-name:mount23}
+@keyframes mount1{0%,31%{border-color:rgba(78,240,138,.45);color:var(--ink-2);background:rgba(78,240,138,.06)}
+  35%,100%{border-color:var(--line);color:var(--muted);background:var(--bg)}}
+@keyframes mount2{0%,32%{border-color:var(--line);color:var(--muted);background:var(--bg)}
+  36%,64%{border-color:rgba(78,240,138,.45);color:var(--ink-2);background:rgba(78,240,138,.06)}
+  68%,100%{border-color:var(--line);color:var(--muted);background:var(--bg)}}
+@keyframes mount3{0%,65%{border-color:var(--line);color:var(--muted);background:var(--bg)}
+  69%,98%{border-color:rgba(78,240,138,.45);color:var(--ink-2);background:rgba(78,240,138,.06)}
+  100%{border-color:var(--line);color:var(--muted);background:var(--bg)}}
+@keyframes mount23{0%,32%{border-color:var(--line);color:var(--muted);background:var(--bg)}
+  36%,98%{border-color:rgba(78,240,138,.45);color:var(--ink-2);background:rgba(78,240,138,.06)}
+  100%{border-color:var(--line);color:var(--muted);background:var(--bg)}}
+.mods .pnote{margin-top:.9rem;padding-top:.7rem;border-top:1px dashed var(--line);
+  font-family:var(--mono);font-size:.66rem;color:var(--muted);line-height:1.65}
+.mods .pnote b{color:var(--ink-2);font-weight:500}
+/* the screen crossfades with the composition */
+.screens .scr{aspect-ratio:16/9;position:relative}
+.screens img{position:absolute;inset:0;width:100%;height:100%;object-fit:cover;opacity:0}
+/* the name and the screen switch on a hard cut: a crossfade would overlap two
+   names into garbled text and two screenshots into a double exposure */
+.ph1,.ph2,.ph3{animation-duration:10.5s;animation-timing-function:steps(1,end);animation-iteration-count:infinite}
+.ph1{animation-name:phase1} .ph2{animation-name:phase2} .ph3{animation-name:phase3}
+@keyframes phase1{0%{opacity:1}33.34%{opacity:0}100%{opacity:0}}
+@keyframes phase2{0%{opacity:0}33.34%{opacity:1}66.67%{opacity:0}100%{opacity:0}}
+@keyframes phase3{0%{opacity:0}66.67%{opacity:1}100%{opacity:0}}
+@media (prefers-reduced-motion: reduce){
+  .mods-guest,.mods-bus .spark,.mod,.ph1,.ph2,.ph3{animation:none}
+  .mods-now i.ph1{opacity:1}
+  .screens img.ph3{opacity:1}
+  .mod.m1,.mod.m2,.mod.m3,.mod.m23{border-color:rgba(78,240,138,.3);color:var(--ink-2)}
+}
+
 /* frame + effect animation */
 .tl{border:1px solid var(--line);background:var(--panel);padding:1.1rem 1.2rem 1.2rem;overflow:hidden}
 .tl .lb{font-family:var(--mono);font-size:.64rem;letter-spacing:.12em;text-transform:uppercase;color:var(--ph);margin-bottom:1.1rem}
@@ -265,9 +329,9 @@ img,video{max-width:100%;display:block}
   font-family:var(--mono);font-size:.6rem;color:var(--ph);white-space:nowrap;
   background:rgba(6,11,9,.95);border:1px solid rgba(78,240,138,.45);padding:.14rem .35rem}
 @keyframes deliver{0%,49%{opacity:0} 51%,66%{opacity:1} 70%,100%{opacity:0}}
-.tl .foot{margin-top:1rem;padding-top:.7rem;border-top:1px dashed var(--line);
+.tl .pnote{margin-top:1rem;padding-top:.7rem;border-top:1px dashed var(--line);
   font-family:var(--mono);font-size:.66rem;color:var(--muted);line-height:1.7}
-.tl .foot b{color:var(--ink-2);font-weight:500}
+.tl .pnote b{color:var(--ink-2);font-weight:500}
 @media (prefers-reduced-motion: reduce){
   .stack .pulse,.fanout i,.cells .c.tick,.cells .ph,.wallclock .arrive,.deliver,.cursor{animation:none}
   .wallclock .arrive,.deliver{opacity:1}

--- a/site/home.html
+++ b/site/home.html
@@ -180,8 +180,8 @@
           </div>
         </div>
         <div class="receipts"><span>Refs</span>
-          <a href="/docs/overview/architecture/">docs/architecture</a>
-          <a href="/docs/overview/frameworks/">docs/frameworks</a>
+          <a href="/docs/architecture/">docs/architecture</a>
+          <a href="/docs/frameworks/">docs/frameworks</a>
         </div>
       </div>
     </div>
@@ -364,7 +364,7 @@
               <span class="c tick"></span><span class="c tick"></span><span class="c tick"></span><span class="c tick"></span>
             </div>
           </div>
-          <p class="foot">A reply that arrives partway through frame +3 is <b>queued, not applied</b>. It is
+          <p class="pnote">A reply that arrives partway through frame +3 is <b>queued, not applied</b>. It is
             delivered at the start of frame +4, in FIFO order, before any app hook runs. Nothing lands halfway
             through a transaction: <b>no wall clock, no microtask races, no mid-frame callbacks</b>, and
             <b>after()</b> replaces setTimeout with a deadline measured in frames.</p>
@@ -446,15 +446,64 @@
   </div>
 </section>
 
+<section class="sect" id="beyond">
+  <div class="wrap">
+    <div class="shead">
+      <span class="vwrap"><span class="verb metal lit">Beyond 2D UI</span><span class="vrail"></span></span>
+      <span class="fill"></span><span class="hud">mount what the content needs</span>
+    </div>
+    <p class="slede">PocketJS is an application runtime with a game engine's architecture, so <b>a game and an
+      app are built the same way</b>.</p>
+    <div class="cols" style="grid-template-columns:minmax(0,1.05fr) minmax(0,1fr)">
+      <div class="mods">
+        <div class="mods-head">
+          <span class="lb">one guest, different cores</span>
+          <span class="mods-now">
+            <i class="ph1">Pocket Talk</i><i class="ph2">OpenStrike</i><i class="ph3">Pocket Voxel</i>
+          </span>
+        </div>
+        <div class="mods-guest">
+          <b>guest program</b><span>your JavaScript, one frame at a time</span>
+        </div>
+        <div class="mods-bus"><span class="spark"></span></div>
+        <div class="mods-row">
+          <span class="mod always wide">ui<em>tree, layout, draw, input, focus</em></span>
+        </div>
+        <div class="mods-row four">
+          <span class="mod m1">net<em>poll batches</em></span>
+          <span class="mod m23">audio<em>pcm mixer</em></span>
+          <span class="mod m2">strike<em>bsp, bots, hits</em></span>
+          <span class="mod m3">voxel<em>chunks, meshing</em></span>
+        </div>
+        <p class="pnote">Cores are <b>independent native modules, loaded the way a kernel loads drivers</b>. An
+          app takes the ones its content needs and the rest never enters the build. Adding one widens what your
+          program is allowed to ask for; it never changes how your program is written.</p>
+      </div>
+      <div>
+        <div class="frame screens">
+          <div class="scr">
+            <img class="ph1" src="/assets/wall/card-im.jpg" alt="Pocket Talk, a message thread with the system keyboard">
+            <img class="ph2" src="/assets/blog/openstrike-psp-fire.png" alt="OpenStrike, a muzzle flash over a crate with a Solid JSX HUD">
+            <img class="ph3" src="/assets/blog/voxel-psp-route-1.png" alt="Pocket Voxel, a route of extruded voxel grass and carved trees">
+          </div>
+        </div>
+        <div class="receipts"><span>Refs</span>
+          <a href="/blog/shipping-openstrike/">shipping openstrike</a>
+          <a href="/blog/pocket-voxel/">pocket voxel</a>
+          <a href="/docs/concepts/">docs/concepts</a>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
 <section class="sect" id="ecosystem">
   <div class="wrap">
     <div class="shead">
       <span class="vwrap"><span class="verb metal lit">Ecosystem</span><span class="vrail"></span></span>
       <span class="fill"></span><span class="hud">shipped on the runtime</span>
     </div>
-    <p class="slede">An app, a game and a mod are the same kind of artifact here: guest programs customizing native
-      cores through declared vocabularies. <b>ui was the first such core; the FPS core was the second; audio was the
-      third.</b> Everything below runs on the chapters above.</p>
+    <p class="slede">All of it runs on the chapters above, on the machines this runtime was built for.</p>
     <div class="eco">
       <article class="ecard">
         <div class="scr"><img src="/assets/blog/openstrike-psp-dust2.png" alt="OpenStrike on PSP with a Solid JSX HUD"></div>
@@ -514,9 +563,8 @@
     <div class="labband">
       <div>
         <span class="lb">the organization behind it</span>
-        <p><strong>Pocket Lab</strong> grew on top of this runtime: an open source organization with no venture
-          money, shipping systemic open worlds, voxel dioramas and digital humans.
-          <strong>The joy of creating should belong to everyone.</strong></p>
+        <p><strong>Pocket Lab</strong> is an independent, non-VC-backed organization built on this runtime, so
+          that <strong>the joy of creating belongs to everyone</strong>.</p>
       </div>
       <div class="labctas">
         <a class="btn btn--pri" href="https://pocketlab.build">Visit Pocket Lab</a>

--- a/tests/site-stage.test.ts
+++ b/tests/site-stage.test.ts
@@ -99,7 +99,7 @@ test("homepage ships the four-chapter landing", () => {
   // The two hand-drawn diagrams and the redrawn flake histogram.
   expect(home).toContain('class="vs-col vs-pocket"');
   expect(home).toContain('class="vs-col vs-web"');
-  // the browser column shows the cross-thread bookkeeping, not just more layers
+  // the browser column names the threads it hands work across
   expect(home).toContain("1 thread, 1 process");
   expect(home).toContain("4 threads, 2 processes");
   expect(home.match(/class="hop"/g)?.length).toBe(3);


### PR DESCRIPTION
Follow-up to #311 and #313.

## Beyond 2D UI

A new chapter between Architecture and Ecosystem, for the thing an application runtime is least expected to do. PocketJS is an application runtime with a game engine's architecture, so a game and an app are built the same way.

The visualization holds one guest program above a row of native cores, and a single 10.5s cycle rotates three compositions:

| composition | cores mounted |
|---|---|
| Pocket Talk | `ui` + `net` |
| OpenStrike | `ui` + `audio` + `strike` |
| Pocket Voxel | `ui` + `audio` + `voxel` |

The composition name, the lit cores and the screenshot switch together, so the three read as the same machine being reassembled rather than three separate diagrams. The name and the screen switch on a **hard cut**: a crossfade overlapped two names into garbled text and two screenshots into a double exposure.

Cores are described the way they behave: independent native modules, loaded the way a kernel loads drivers, and absent from the build when the content does not ask for them.

## Copy

Several passages narrated themselves instead of saying what they meant, so the ledes are statements now: Modern DX names QuickJS in one sentence, the Pocket Lab band is one sentence, and the ecosystem lede stops repeating the module vocabulary this chapter now explains.

## Two fixes

- `docs/architecture` and `docs/frameworks` in the Modern DX refs pointed under `/docs/overview/`, which does not exist. A pass over every internal link on the homepage confirms the rest resolve into `site/dist`.
- Panel notes used `class="foot"`, the site footer's class, so they inherited its padding and background. They are `pnote` now, which fixes the same problem in the Architecture and Modern DX panels.

A 3D version of the pipeline comparison was tried and reverted; the flat one reads better.

🤖 Generated with [Claude Code](https://claude.com/claude-code)