### PR TITLE
feat(site): one design system across the site, plus motion and compatibility

### DIFF
--- a/engine/pocket3d/examples/handheld/assets/dibad-psp/profile.json
+++ b/engine/pocket3d/examples/handheld/assets/dibad-psp/profile.json
@@ -14,7 +14,7 @@
     "window_size": [480, 260]
   },
   "view": {
-    "desk_position_mm": [0.0, 46.0, 190.0],
+    "desk_position_mm": [0.0, 0.0, 190.0],
     "desk_target_mm": [0.0, 0.0, 0.0],
     "focus_distance_mm": 98.0,
     "fov_y_degrees": 30.0

--- a/site/assets/base.css
+++ b/site/assets/base.css
@@ -1,0 +1,27 @@
+/* site/assets/base.css — reset and page ground for the homepage only.
+   Docs and playground pages get Tailwind's preflight plus the same ground in
+   tailwind.css's base layer; loading this unlayered beside Tailwind would let
+   its `*` reset outrank every @layer rule and flatten the prose. */
+*{box-sizing:border-box;margin:0;padding:0}
+html{scroll-behavior:smooth}
+body{background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:16px;line-height:1.6;
+  background-image:
+    radial-gradient(ellipse 55% 34% at 50% -6%, rgba(78,240,138,.10), transparent),
+    radial-gradient(ellipse 58% 40% at 50% -4%, rgba(216,225,236,.06), transparent),
+    radial-gradient(ellipse 40% 30% at 90% 14%, rgba(78,240,138,.05), transparent)}
+body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:100;
+  background:repeating-linear-gradient(0deg, rgba(3,18,11,.16) 0 1px, transparent 1px 3px)}
+body::after{content:"";position:fixed;inset:0;pointer-events:none;z-index:99;
+  background:radial-gradient(ellipse 92% 86% at 50% 50%, transparent 68%, rgba(2,5,4,.30) 100%)}
+.wrap{max-width:1160px;margin:0 auto;padding:0 clamp(1.25rem,4vw,2.5rem)}
+a{color:inherit;text-decoration:none}
+img,video{max-width:100%;display:block}
+.hud{font-family:var(--mono);font-size:.7rem;letter-spacing:.14em;text-transform:uppercase;color:var(--muted)}
+.metal{background:var(--metal);-webkit-background-clip:text;background-clip:text;color:transparent}
+.metal.lit{background:var(--metal-ph);-webkit-background-clip:text;background-clip:text}
+.lit{filter:drop-shadow(0 0 14px rgba(78,240,138,.42)) drop-shadow(0 0 34px rgba(78,240,138,.20))}
+.cursor{display:inline-block;width:.5em;height:.95em;background:var(--ph);vertical-align:-.1em;margin-left:.15em;
+  box-shadow:0 0 8px rgba(78,240,138,.55);animation:blink 1.1s steps(1) infinite}
+@keyframes blink{50%{opacity:0}}
+
+

--- a/site/assets/chrome.css
+++ b/site/assets/chrome.css
@@ -1,0 +1,193 @@
+/* site/assets/chrome.css — the shared shell: nav, resource menu, buttons and
+   footer. Loaded by the homepage and, through tailwind.css, by every other
+   page, so the chrome is one implementation rather than two. */
+
+/* shared text helpers */
+.hud{font-family:var(--mono);font-size:.7rem;letter-spacing:.14em;text-transform:uppercase;color:var(--muted)}
+.metal{background:var(--metal);-webkit-background-clip:text;background-clip:text;color:transparent}
+.metal.lit{background:var(--metal-ph);-webkit-background-clip:text;background-clip:text}
+.wrap{max-width:1160px;margin:0 auto;padding:0 clamp(1.25rem,4vw,2.5rem)}
+
+/* nav */
+.nav{position:sticky;top:0;z-index:50;border-bottom:1px solid var(--line);background:rgba(5,7,13,.88);backdrop-filter:blur(9px)}
+.nav .wrap{display:flex;align-items:center;justify-content:space-between;height:3.6rem}
+.mark{display:flex;align-items:center;gap:.55rem}
+.mark .nm{font-weight:700;font-size:1.05rem;letter-spacing:-.01em}
+.nav-links{display:flex;align-items:center;gap:1.5rem;font-family:var(--mono);font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-2)}
+.nav-links a:hover{color:var(--ph)}
+.nav-links .ico{display:flex;align-items:center;color:var(--ink-2)}
+.nav-links .ico svg{width:1.05rem;height:1.05rem;display:block}
+.nav-links .ico:hover{color:var(--ph)}
+.menu{position:relative}
+.menu-btn{appearance:none;background:none;border:none;cursor:pointer;color:var(--ink-2);
+  font:inherit;text-transform:uppercase;letter-spacing:.1em;display:flex;align-items:center;gap:.35rem;padding:0}
+.menu-btn svg{transition:transform .15s}
+.menu:hover .menu-btn,.menu:focus-within .menu-btn{color:var(--ph)}
+.menu:hover .menu-btn svg,.menu:focus-within .menu-btn svg{transform:rotate(180deg)}
+.menu-list{position:absolute;top:calc(100% + .75rem);left:50%;transform:translateX(-50%) translateY(-.35rem);
+  min-width:9.5rem;border:1px solid var(--line-2);background:rgba(8,11,19,.97);backdrop-filter:blur(9px);
+  display:flex;flex-direction:column;opacity:0;visibility:hidden;transition:opacity .14s,transform .14s,visibility .14s;
+  box-shadow:0 18px 44px rgba(0,0,0,.55)}
+.menu:hover .menu-list,.menu:focus-within .menu-list{opacity:1;visibility:visible;transform:translateX(-50%) translateY(0)}
+.menu-list::before{content:"";position:absolute;left:0;right:0;top:-.75rem;height:.75rem}
+.menu-list a{padding:.6rem .9rem;border-bottom:1px solid var(--line)}
+.menu-list a:last-child{border-bottom:none}
+.menu-list a:hover{background:var(--panel);color:var(--ph)}
+
+
+/* buttons */
+.btn{display:inline-flex;align-items:center;gap:.4rem;font-family:var(--mono);font-size:.78rem;letter-spacing:.1em;
+  text-transform:uppercase;padding:.72rem 1.25rem;border:1px solid var(--line-2);color:var(--ink-2);cursor:pointer;
+  background:transparent;transition:color .12s,border-color .12s,filter .12s}
+.btn:hover{color:var(--ph);border-color:rgba(78,240,138,.55)}
+/* --pri/--sec on the homepage, -primary/-ghost in the docs markup: one look */
+.btn--pri,.btn-primary{background:linear-gradient(180deg,#f4f8ff,#c9d5e4);color:#0b1220;border-color:transparent;
+  font-weight:600;box-shadow:0 1px 0 rgba(255,255,255,.35) inset, 0 0 18px rgba(216,225,236,.16)}
+.btn--pri:hover,.btn-primary:hover{filter:brightness(1.05);color:#0b1220}
+.btn--sec,.btn-ghost{background:transparent}
+
+
+/* footer */
+.foot{border-top:1px solid var(--line);padding:2.2rem 0 3rem;background:var(--bg-2)}
+.foot .wrap{display:flex;flex-wrap:wrap;gap:1.4rem;justify-content:space-between;align-items:center}
+.foot .cols2{display:flex;gap:1.8rem;flex-wrap:wrap;font-family:var(--mono);font-size:.72rem;color:var(--ink-2)}
+.foot .cols2 a:hover{color:var(--ph)}
+
+
+/* the interactive 3D stage: one implementation for the playground and the homepage */
+.pocket-frame {
+  width: 100%;
+  max-width: 440px;
+  padding: 14px;
+  border-radius: 22px;
+  border: 1px solid var(--color-line-2);
+  background:
+    linear-gradient(160deg, color-mix(in oklab, var(--color-surface-2) 90%, #fff 4%), var(--color-ink-2));
+  box-shadow:
+    0 1px 0 rgba(255, 255, 255, 0.05) inset,
+    0 30px 60px -30px rgba(0, 0, 0, 0.7),
+    0 0 0 1px rgba(56, 189, 248, 0.05);
+}
+.pocket-screen {
+  position: relative;
+  border-radius: 12px;
+  overflow: hidden;
+  background: #000;
+  border: 1px solid #05070d;
+  box-shadow: 0 0 0 6px #05070d, 0 0 18px -8px rgba(56, 189, 248, 0.22) inset;
+  aspect-ratio: 480 / 272;
+}
+.pocket-loading {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--color-slate-500);
+}
+.pg-stage {
+  width: 100%;
+  margin: 0;
+  outline: none;
+}
+.pg-stage__viewport {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  overflow: hidden;
+  outline: none;
+}
+.pg-stage__canvas {
+  display: block;
+  width: 100%;
+  height: 100%;
+  outline: none;
+  cursor: grab;
+  touch-action: none;
+}
+.pg-stage__canvas:active { cursor: grabbing; }
+.pg-stage__screen { display: none; }
+.pg-stage__status {
+  position: absolute;
+  left: 50%;
+  bottom: 0.7rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: calc(100% - 2rem);
+  padding: 0.45rem 0.75rem;
+  border: 1px solid rgba(85, 103, 133, 0.56);
+  border-radius: 999px;
+  color: var(--color-slate-300);
+  background: rgba(6, 10, 18, 0.82);
+  font-family: var(--font-mono);
+  font-size: 0.68rem;
+  line-height: 1.25;
+  text-align: center;
+  transform: translateX(-50%);
+  backdrop-filter: blur(8px);
+  transition: opacity 0.25s ease, transform 0.25s ease;
+}
+.pg-stage__status-dot {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  border-radius: 50%;
+  background: #9de5c7;
+  box-shadow: 0 0 10px rgba(157, 229, 199, 0.82);
+  animation: pg-stage-pulse 1.1s ease-in-out infinite alternate;
+}
+.pg-stage__credit {
+  padding: 0.35rem 0.35rem 0;
+  color: var(--color-slate-600);
+  font-size: 0.66rem;
+  line-height: 1.4;
+  text-align: right;
+}
+
+.pg-stage__viewport:focus-visible .pg-stage__canvas {
+  border-radius: 0.8rem;
+  box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--color-brand-2) 78%, white);
+}
+.pg-stage.is-ready .pg-stage__status {
+  opacity: 0;
+  transform: translate(-50%, 5px);
+  pointer-events: none;
+}
+.pg-stage.has-error .pg-stage__viewport { height: auto; }
+.pg-stage.has-error .pg-stage__canvas { display: none; }
+.pg-stage.has-error .pg-stage__screen {
+  display: block;
+  width: min(100%, 480px);
+  height: auto;
+  margin: 0 auto;
+  border-radius: 0.65rem;
+  background: #000;
+  image-rendering: pixelated;
+  box-shadow: 0 0 0 1px var(--color-line-2), 0 24px 54px -34px #000;
+}
+.pg-stage.has-error .pg-stage__viewport:focus-visible .pg-stage__screen {
+  box-shadow:
+    0 0 0 2px color-mix(in oklab, var(--color-brand-2) 78%, white),
+    0 24px 54px -34px #000;
+}
+.pg-stage.has-error .pg-stage__status {
+  color: #fecaca;
+  border-color: rgba(248, 113, 113, 0.44);
+}
+.pg-stage.has-error .pg-stage__status-dot {
+  background: #f87171;
+  box-shadow: none;
+  animation: none;
+}
+.pg-stage__credit a {
+  color: var(--color-slate-400);
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+.pg-stage__credit a:hover { color: var(--color-slate-200); }
+@keyframes pg-stage-pulse {
+  from { opacity: 0.35; transform: scale(0.78); }
+  to { opacity: 1; transform: scale(1); }
+}

--- a/site/assets/landing.css
+++ b/site/assets/landing.css
@@ -1,67 +1,4 @@
-/* pocketjs.dev landing page. Homepage only; the /for/ pages keep home.css. */
-:root{
-  --bg:#05070d; --bg-2:#080b13; --panel:#0d1220; --panel-2:#101828;
-  --line:rgba(43,58,85,.55); --line-2:rgba(74,94,130,.6);
-  --ink:#f3f7fd; --ink-2:#b9c3d4; --muted:#7b8aa1;
-  --steel-1:#d8e1ec; --steel-2:#a7b3c5; --steel-3:#66748a;
-  --metal:linear-gradient(100deg,#f4f8ff,#a7b3c5 55%,#d8e1ec);
-  --metal-ph:linear-gradient(100deg,#f2fbf5,#a9d8bd 42%,#cfe4dc 70%,#eef7f2);
-  --ph:#4ef08a; --ph-2:#9de5c7; --sky:#60a5fa;
-  /* chart marks: validated for the dark surface (lightness band, chroma, CVD, contrast) */
-  --c1:#1ba468; --c2:#4a86e8; --c3:#b07d1c; --c1-deep:#0f6c44;
-  --track:rgba(74,94,130,.22);
-  --px:"VT323",ui-monospace,monospace;
-  --sans:"IBM Plex Sans",-apple-system,system-ui,sans-serif;
-  --mono:"IBM Plex Mono",ui-monospace,Menlo,monospace;
-}
-*{box-sizing:border-box;margin:0;padding:0}
-html{scroll-behavior:smooth}
-body{background:var(--bg);color:var(--ink);font-family:var(--sans);font-size:16px;line-height:1.6;
-  background-image:
-    radial-gradient(ellipse 55% 34% at 50% -6%, rgba(78,240,138,.10), transparent),
-    radial-gradient(ellipse 58% 40% at 50% -4%, rgba(216,225,236,.06), transparent),
-    radial-gradient(ellipse 40% 30% at 90% 14%, rgba(78,240,138,.05), transparent)}
-body::before{content:"";position:fixed;inset:0;pointer-events:none;z-index:100;
-  background:repeating-linear-gradient(0deg, rgba(3,18,11,.16) 0 1px, transparent 1px 3px)}
-body::after{content:"";position:fixed;inset:0;pointer-events:none;z-index:99;
-  background:radial-gradient(ellipse 92% 86% at 50% 50%, transparent 68%, rgba(2,5,4,.30) 100%)}
-.wrap{max-width:1160px;margin:0 auto;padding:0 clamp(1.25rem,4vw,2.5rem)}
-a{color:inherit;text-decoration:none}
-img,video{max-width:100%;display:block}
-.hud{font-family:var(--mono);font-size:.7rem;letter-spacing:.14em;text-transform:uppercase;color:var(--muted)}
-.metal{background:var(--metal);-webkit-background-clip:text;background-clip:text;color:transparent}
-.metal.lit{background:var(--metal-ph);-webkit-background-clip:text;background-clip:text}
-.lit{filter:drop-shadow(0 0 14px rgba(78,240,138,.42)) drop-shadow(0 0 34px rgba(78,240,138,.20))}
-.cursor{display:inline-block;width:.5em;height:.95em;background:var(--ph);vertical-align:-.1em;margin-left:.15em;
-  box-shadow:0 0 8px rgba(78,240,138,.55);animation:blink 1.1s steps(1) infinite}
-@keyframes blink{50%{opacity:0}}
-
-/* nav */
-.nav{position:sticky;top:0;z-index:50;border-bottom:1px solid var(--line);background:rgba(5,7,13,.88);backdrop-filter:blur(9px)}
-.nav .wrap{display:flex;align-items:center;justify-content:space-between;height:3.6rem}
-.mark{display:flex;align-items:center;gap:.55rem}
-.mark .nm{font-weight:700;font-size:1.05rem;letter-spacing:-.01em}
-.nav-links{display:flex;align-items:center;gap:1.5rem;font-family:var(--mono);font-size:.74rem;letter-spacing:.1em;text-transform:uppercase;color:var(--ink-2)}
-.nav-links a:hover{color:var(--ph)}
-.nav-links .ico{display:flex;align-items:center;color:var(--ink-2)}
-.nav-links .ico svg{width:1.05rem;height:1.05rem;display:block}
-.nav-links .ico:hover{color:var(--ph)}
-.menu{position:relative}
-.menu-btn{appearance:none;background:none;border:none;cursor:pointer;color:var(--ink-2);
-  font:inherit;text-transform:uppercase;letter-spacing:.1em;display:flex;align-items:center;gap:.35rem;padding:0}
-.menu-btn svg{transition:transform .15s}
-.menu:hover .menu-btn,.menu:focus-within .menu-btn{color:var(--ph)}
-.menu:hover .menu-btn svg,.menu:focus-within .menu-btn svg{transform:rotate(180deg)}
-.menu-list{position:absolute;top:calc(100% + .75rem);left:50%;transform:translateX(-50%) translateY(-.35rem);
-  min-width:9.5rem;border:1px solid var(--line-2);background:rgba(8,11,19,.97);backdrop-filter:blur(9px);
-  display:flex;flex-direction:column;opacity:0;visibility:hidden;transition:opacity .14s,transform .14s,visibility .14s;
-  box-shadow:0 18px 44px rgba(0,0,0,.55)}
-.menu:hover .menu-list,.menu:focus-within .menu-list{opacity:1;visibility:visible;transform:translateX(-50%) translateY(0)}
-.menu-list::before{content:"";position:absolute;left:0;right:0;top:-.75rem;height:.75rem}
-.menu-list a{padding:.6rem .9rem;border-bottom:1px solid var(--line)}
-.menu-list a:last-child{border-bottom:none}
-.menu-list a:hover{background:var(--panel);color:var(--ph)}
-
+/* pocketjs.dev homepage sections. Tokens and chrome live beside this file. */
 /* hero: the demo wall runs full bleed behind everything, nav included */
 .hero{position:relative;overflow:hidden;margin-top:-3.6rem;padding:calc(3.6rem + clamp(3rem,8vw,6rem)) 0 clamp(3rem,8vw,6rem);
   min-height:min(92vh,880px);display:flex;align-items:center}
@@ -89,12 +26,6 @@ img,video{max-width:100%;display:block}
 .hero .sub{margin-top:1.5rem;color:var(--ink-2);max-width:52ch;font-size:1.05rem}
 .hero .sub strong{color:var(--ink)}
 .hero .ctas{margin-top:1.7rem;display:flex;gap:.8rem;flex-wrap:wrap}
-.btn{font-family:var(--mono);font-size:.78rem;letter-spacing:.1em;text-transform:uppercase;padding:.72rem 1.25rem;border:1px solid var(--line-2)}
-.btn--pri{background:linear-gradient(180deg,#f4f8ff,#c9d5e4);color:#0b1220;border-color:transparent;font-weight:600;
-  box-shadow:0 1px 0 rgba(255,255,255,.35) inset, 0 0 18px rgba(216,225,236,.16)}
-.btn--pri:hover{filter:brightness(1.05)}
-.btn--sec{color:var(--ink-2)} .btn--sec:hover{color:var(--ph);border-color:rgba(78,240,138,.55)}
-
 /* terminal */
 .term{border:1px solid var(--line-2);background:#060a0c;box-shadow:inset 0 0 40px rgba(78,240,138,.045)}
 .term .bar{display:flex;align-items:center;gap:.45rem;border-bottom:1px solid var(--line);padding:.5rem .8rem;background:var(--panel)}
@@ -317,13 +248,18 @@ img,video{max-width:100%;display:block}
 .cells .ph{position:absolute;top:-.2rem;bottom:-.2rem;width:calc(12.5% - 2px);border:1px solid rgba(78,240,138,.55);
   box-shadow:0 0 14px rgba(78,240,138,.22) inset;animation:sweep 4.8s steps(8) infinite;pointer-events:none}
 @keyframes sweep{from{transform:translateX(0)} to{transform:translateX(800%)}}
-.wallclock{position:relative;height:1.6rem;margin-bottom:.1rem}
-.wallclock .arrive{position:absolute;left:43%;top:0;font-family:var(--mono);font-size:.6rem;color:var(--c3);
-  white-space:nowrap;animation:arrive 4.8s linear infinite;opacity:0;
+/* the arrive chip sits in the fourth cell of the same eight-column grid the
+   tape uses, so it points at frame +3 in every engine instead of at a
+   hand-tuned percentage (Safari resolved that differently) */
+.wallclock{display:grid;grid-template-columns:repeat(8,minmax(0,1fr));gap:2px;height:1.6rem;margin-bottom:.1rem}
+.wallclock .arrive{grid-column:4;grid-row:1;position:relative;justify-self:start;align-self:start;
+  font-family:var(--mono);font-size:.6rem;color:var(--c3);white-space:nowrap;
+  animation:arrive 4.8s linear infinite;opacity:0;
   background:rgba(6,11,9,.95);border:1px solid rgba(176,125,28,.55);padding:.14rem .35rem}
 .wallclock .arrive::after{content:"";position:absolute;left:.1rem;top:1.4rem;width:1px;height:.5rem;background:var(--c3)}
 @keyframes arrive{0%,38%{opacity:0} 41%,49%{opacity:1} 52%,100%{opacity:0}}
-.deliver{position:absolute;left:50%;top:-.1rem;bottom:-.1rem;width:2px;background:var(--ph);
+.deliver{grid-column:5;grid-row:1;justify-self:start;position:relative;width:2px;
+  margin:-.1rem 0 -.1rem -2px;background:var(--ph);
   box-shadow:0 0 10px rgba(78,240,138,.8);animation:deliver 4.8s linear infinite;opacity:0}
 .deliver::after{content:"delivered at the boundary";position:absolute;left:.35rem;top:-1.55rem;
   font-family:var(--mono);font-size:.6rem;color:var(--ph);white-space:nowrap;
@@ -430,11 +366,6 @@ img,video{max-width:100%;display:block}
 .spon-gallery a:hover{filter:none;border-color:rgba(78,240,138,.65);transform:translateY(-2px)}
 .spon-gallery img{width:100%;height:100%;object-fit:cover}
 
-.foot{border-top:1px solid var(--line);padding:2.2rem 0 3rem;background:var(--bg-2)}
-.foot .wrap{display:flex;flex-wrap:wrap;gap:1.4rem;justify-content:space-between;align-items:center}
-.foot .cols2{display:flex;gap:1.8rem;flex-wrap:wrap;font-family:var(--mono);font-size:.72rem;color:var(--ink-2)}
-.foot .cols2 a:hover{color:var(--ph)}
-
 @media (max-width:1000px){
   /* the hero is a flex row on wide screens; stack it here so the note flows below */
   .hero{min-height:auto;display:block}
@@ -459,3 +390,50 @@ img,video{max-width:100%;display:block}
 .eco{grid-template-columns:1fr}.row{grid-template-columns:4.4rem minmax(0,1fr) 4rem}}
 
 
+
+/* readout tiles: a machine-reported number and what it means */
+.reads{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.7rem}
+.read{border:1px solid var(--line);padding:.85rem 1rem .95rem;position:relative;overflow:hidden;
+  background:linear-gradient(180deg, rgba(78,240,138,.05), transparent), var(--panel)}
+.read::after{content:"";position:absolute;inset:0;pointer-events:none;
+  background:repeating-linear-gradient(0deg, rgba(0,0,0,.05) 0 1px, transparent 1px 3px)}
+.read b{display:block;font-family:var(--px);font-size:2.1rem;line-height:1;color:var(--ph);
+  text-shadow:0 0 18px rgba(78,240,138,.55)}
+.read b.st{background:var(--metal);-webkit-background-clip:text;background-clip:text;color:transparent;text-shadow:none}
+.read span{position:relative;display:block;margin-top:.35rem;font-size:.74rem;line-height:1.45;color:var(--muted)}
+
+/* framework names in prose: plain text with a hairline, nothing louder */
+.pl{color:inherit;text-decoration:underline;text-decoration-thickness:1px;text-underline-offset:2px;
+  text-decoration-color:rgba(185,195,212,.4)}
+.pl:hover{color:var(--ph);text-decoration-color:rgba(78,240,138,.6)}
+
+/* motion: six recorded clips, engine output, looping */
+.mgrid{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:.7rem}
+.mcell{border:1px solid rgba(78,240,138,.20);background:#000;padding:.4rem}
+.mcell .scr{position:relative;overflow:hidden;background:#000;aspect-ratio:154/121}
+.mcell .scr::after{content:"";position:absolute;inset:0;pointer-events:none;
+  background:repeating-linear-gradient(0deg, rgba(0,0,0,.06) 0 1px, transparent 1px 3px);
+  box-shadow:inset 0 0 26px rgba(78,240,138,.10)}
+.mcell img{width:100%;height:100%;object-fit:cover;image-rendering:pixelated}
+.mcell figcaption{font-family:var(--mono);font-size:.58rem;letter-spacing:.08em;text-transform:uppercase;
+  color:var(--muted);padding:.4rem .1rem 0}
+
+/* compatibility: what it runs on, split by operating system and by device */
+.cpanel{border:1px solid var(--line);background:var(--panel);padding:1.1rem 1.2rem 1.2rem}
+.cpanel .lb{display:block;font-family:var(--mono);font-size:.64rem;letter-spacing:.12em;text-transform:uppercase;
+  color:var(--ph);margin-bottom:.9rem}
+.cgrid{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:.4rem}
+.cchip{font-family:var(--mono);font-size:.64rem;line-height:1.25;border:1px solid var(--line);background:var(--bg);
+  padding:.4rem .5rem;color:var(--ink-2)}
+.cchip em{display:block;font-style:normal;font-size:.55rem;letter-spacing:.06em;text-transform:uppercase;
+  color:var(--muted);margin-top:.15rem}
+@media (max-width:620px){
+  .mgrid{grid-template-columns:repeat(2,minmax(0,1fr))}
+  .cgrid{grid-template-columns:1fr}
+}
+
+/* motion: the handheld floats on the page, no frame and no plate behind it */
+.motion-stage{margin:0;border:0;background:transparent;padding:0}
+.motion-stage .pg-stage__viewport{background:transparent;border:0}
+.motion-stage .pg-stage__status{justify-content:center}
+.spon-cta{margin-top:1.4rem;display:inline-flex;gap:.5rem;align-items:center}

--- a/site/assets/landing.js
+++ b/site/assets/landing.js
@@ -24,3 +24,43 @@ if (scale) {
     io.observe(scale);
   }
 }
+
+// Reference links leave the page: open them in their own tab.
+for (const a of document.querySelectorAll("[data-refs] a")) {
+  a.target = "_blank";
+  a.rel = "noreferrer";
+}
+
+// The motion stage is the real runtime in WebAssembly, so it boots only when
+// the chapter is actually on screen.
+const motionStage = document.querySelector("[data-motion-stage]");
+if (motionStage) {
+  let booted = false;
+  const boot = async () => {
+    if (booted) return;
+    booted = true;
+    try {
+      const { mountPocketStage } = await import("/assets/pocket-stage-web.js");
+      await mountPocketStage(motionStage, {
+        bootApp: "motions-main",
+        readyText: "yui540 motion studies, live",
+        errorText: "Interactive 3D is unavailable in this browser.",
+        receiptName: "__motionStageReceipt",
+      });
+    } catch (error) {
+      motionStage.classList.add("has-error");
+      const status = motionStage.querySelector("[data-stage-status]");
+      if (status) status.textContent = "The motion studies could not be loaded.";
+      console.error("motion stage failed", error);
+    }
+  };
+  if (!("IntersectionObserver" in window)) void boot();
+  else {
+    const io = new IntersectionObserver((entries) => {
+      if (!entries.some((e) => e.isIntersecting)) return;
+      io.disconnect();
+      void boot();
+    }, { rootMargin: "300px 0px", threshold: 0.01 });
+    io.observe(motionStage);
+  }
+}

--- a/site/assets/pocket-stage-web.js
+++ b/site/assets/pocket-stage-web.js
@@ -491,7 +491,7 @@ export async function mountPocketStage(root, options = {}) {
     const view = profile.view ?? {};
     camera.fov = view.fov_y_degrees ?? camera.fov;
     camera.updateProjectionMatrix();
-    camera.position.fromArray(view.desk_position_mm ?? [0, 46, 190]);
+    camera.position.fromArray(options.deskPositionMm ?? view.desk_position_mm ?? [0, 0, 190]);
     controls.target.fromArray(view.desk_target_mm ?? [0, 0, 0]);
     controls.update();
     focusDistanceMm = view.focus_distance_mm ?? focusDistanceMm;
@@ -506,9 +506,11 @@ export async function mountPocketStage(root, options = {}) {
         hostReady,
       ]);
     } else {
-      // The homepage stage boots the Pocket Launcher (docs/LAUNCHER.md) — the
-      // same multi-app deck the PSP EBOOT ships. The Playground skips this
-      // branch because its supplied host already owns the live-compiled app.
+      // Without a supplied host the stage boots a package of its own: the
+      // Pocket Launcher deck (docs/LAUNCHER.md) by default, or whatever
+      // options.bootApp names, which is how the homepage boots one app
+      // directly. The Playground skips this branch because its supplied host
+      // already owns the live-compiled app.
       const bundleCache = new Map();
       fetchBundle = async (output) => {
         if (!bundleCache.has(output)) {
@@ -537,7 +539,7 @@ export async function mountPocketStage(root, options = {}) {
       const [loadedModel, registryResponse, loadedLauncher] = await Promise.all([
         loader.loadAsync(modelUrl),
         fetch(STAGE_ROOT + "apps/apps.json").then(failResponse),
-        fetchBundle("launcher-main"),
+        fetchBundle(options.bootApp ?? "launcher-main"),
         hostReady,
       ]);
       model = loadedModel;

--- a/site/assets/tailwind.css
+++ b/site/assets/tailwind.css
@@ -1,83 +1,75 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
+/* One design system. tokens.css holds the values, chrome.css the shared shell;
+   the @theme mapping below re-exports the same tokens as Tailwind utilities so
+   a docs page and the homepage cannot drift apart. */
+@import "./tokens.css";
+@import "./chrome.css" layer(components);
+
 /* Scan every place a class can appear (TS template strings, HTML, JS glue,
    raw HTML embedded in blog/docs markdown). */
 @source "../**/*.{ts,html,js,md}";
 
-@font-face {
-  font-family: "Inter";
-  src: url("/pg/fonts/Inter-Regular.ttf") format("truetype");
-  font-weight: 400;
-  font-style: normal;
-  font-display: swap;
+/* ---- theme: utilities resolve to the tokens, never to their own copies ---- */
+@theme inline {
+  --font-sans: var(--sans);
+  --font-mono: var(--mono);
+  --font-px: var(--px);
+  --font-math: var(--math);
+
+  --color-ink: var(--bg);
+  --color-ink-2: var(--bg-2);
+  --color-surface: var(--panel);
+  --color-surface-2: var(--panel-2);
+  --color-line: var(--line);
+  --color-line-2: var(--line-2);
+
+  --color-fg: var(--ink);
+  --color-fg-2: var(--ink-2);
+  --color-muted: var(--muted);
+
+  --color-steel: var(--steel-2);
+  --color-steel-1: var(--steel-1);
+  --color-phosphor: var(--ph);
+  --color-phosphor-2: var(--ph-2);
+  --color-brand: var(--sky);
+  --color-brand-2: var(--ph);
+  --color-brand-3: var(--sky);
 }
 
-@font-face {
-  font-family: "Inter";
-  src: url("/pg/fonts/Inter-Bold.ttf") format("truetype");
-  font-weight: 700;
-  font-style: normal;
-  font-display: swap;
-}
-
-/* ---- brand theme ---------------------------------------------------------- */
-@theme {
-  --font-sans:
-    Inter, ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --font-mono:
-    ui-monospace, "SF Mono", "JetBrains Mono", "Fira Code", Menlo, Consolas, monospace;
-
-  /* near-black navy base + layered surfaces */
-  --color-ink: #05070d;
-  --color-ink-2: #070a11;
-  --color-surface: #0b0f1a;
-  --color-surface-2: #101827;
-  --color-line: #1e293b;
-  --color-line-2: #2b3a55;
-
-  /* the blue→cyan brand ramp (matches the logo + demos) */
-  --color-brand: #38bdf8;
-  --color-brand-2: #22d3ee;
-  --color-brand-3: #60a5fa;
-}
-
-/* ---- base ----------------------------------------------------------------- */
+/* ---- base: chrome.css sets the ground; this adds prose-only defaults ------ */
 @layer base {
-  html {
-    scroll-behavior: smooth;
-    -webkit-text-size-adjust: 100%;
-  }
+  html { scroll-behavior: smooth; -webkit-text-size-adjust: 100%; }
   body {
-    background:
-      radial-gradient(42% 72% at 0% 6%, color-mix(in oklab, var(--color-brand-3) 10%, transparent), transparent 66%),
-      radial-gradient(36% 70% at 100% 12%, color-mix(in oklab, var(--color-brand-2) 6%, transparent), transparent 68%),
-      linear-gradient(180deg, #070a11 0%, var(--color-ink) 48%, #070a11 100%);
-    color: var(--color-slate-300);
-    font-family: var(--font-sans);
+    background: var(--bg);
+    background-image:
+      radial-gradient(ellipse 55% 34% at 50% -6%, rgba(78, 240, 138, 0.1), transparent),
+      radial-gradient(ellipse 58% 40% at 50% -4%, rgba(216, 225, 236, 0.06), transparent),
+      radial-gradient(ellipse 40% 30% at 90% 14%, rgba(78, 240, 138, 0.05), transparent);
+    color: var(--ink-2);
+    font-family: var(--sans);
     -webkit-font-smoothing: antialiased;
     text-rendering: optimizeLegibility;
   }
-  ::selection {
-    background: color-mix(in oklab, var(--color-brand) 40%, transparent);
-    color: #fff;
-  }
-  a {
-    color: inherit;
-    text-decoration: none;
-  }
-  /* Edge-only page glow, shared with the landing page direction. */
+  /* the same tube glass the homepage sits behind */
   body::before {
     content: "";
     position: fixed;
-    inset: 0 0 auto 0;
-    height: 620px;
+    inset: 0;
     pointer-events: none;
-    z-index: -1;
-    background:
-      radial-gradient(42% 72% at 0% 6%, color-mix(in oklab, var(--color-brand-3) 9%, transparent), transparent 66%),
-      radial-gradient(36% 70% at 100% 12%, color-mix(in oklab, var(--color-brand-2) 5%, transparent), transparent 68%);
+    z-index: 100;
+    background: repeating-linear-gradient(0deg, rgba(3, 18, 11, 0.16) 0 1px, transparent 1px 3px);
   }
+  a { color: inherit; text-decoration: none; }
+  ::selection { background: color-mix(in oklab, var(--ph) 32%, transparent); color: #04170c; }
+}
+
+/* prose links carry the accent the rest of the system uses for references */
+@layer components {
+  .prose a { color: var(--sky); font-weight: 500; }
+  .prose a:hover { color: var(--ph); }
+  .prose :where(code):not(:where(pre *)) { color: var(--ph-2); }
 }
 
 /* ---- reusable brand bits -------------------------------------------------- */
@@ -89,152 +81,6 @@
 }
 
 @layer components {
-  .site-nav {
-    position: sticky;
-    top: 0;
-    z-index: 50;
-    border-bottom: 1px solid var(--color-line);
-    background:
-      linear-gradient(180deg, rgba(20, 29, 49, 0.46), rgba(9, 12, 20, 0.82)),
-      rgba(9, 12, 20, 0.78);
-    backdrop-filter: blur(14px) saturate(1.25);
-    -webkit-backdrop-filter: blur(14px) saturate(1.25);
-  }
-  .site-nav__in {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    width: 100%;
-    max-width: 1160px;
-    height: 62px;
-    margin: 0 auto;
-    padding: 0 clamp(1.25rem, 4vw, 2.75rem);
-  }
-  .site-brand {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.55rem;
-    color: var(--color-slate-100);
-    font-weight: 700;
-    letter-spacing: -0.02em;
-  }
-  .site-brand svg {
-    width: 26px;
-    height: 26px;
-    flex: none;
-  }
-  .site-nav__links {
-    display: flex;
-    align-items: center;
-    justify-content: flex-end;
-    gap: 0.25rem;
-    min-width: 0;
-    font-size: 0.875rem;
-    font-weight: 500;
-  }
-  .site-nav__link {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.45rem;
-    color: var(--color-slate-300);
-    border-radius: 0.5rem;
-    padding: 0.5rem 0.75rem;
-    transition:
-      color 0.2s ease,
-      background 0.2s ease;
-  }
-  .site-nav__link:hover,
-  .site-nav__link.on {
-    color: var(--color-slate-50);
-    background: rgba(20, 29, 49, 0.9);
-  }
-  .site-nav__gh svg {
-    width: 18px;
-    height: 18px;
-  }
-  .site-nav__discord {
-    color: #cfd3ff;
-  }
-  .site-nav__discord svg {
-    width: 18px;
-    height: 18px;
-  }
-  .site-nav__x {
-    display: inline-flex;
-    align-items: center;
-  }
-  .site-nav__x svg {
-    width: 16px;
-    height: 16px;
-  }
-  .site-nav__3d {
-    color: #a9e7ff;
-    background: transparent;
-    border: 1px solid transparent;
-  }
-  .site-nav__3d svg {
-    width: 16px;
-    height: 16px;
-  }
-  .site-nav__3d:hover {
-    color: #e4f5ff;
-    background: linear-gradient(180deg, rgba(56, 152, 224, 0.16), rgba(56, 152, 224, 0.06));
-    border-color: rgba(120, 190, 240, 0.32);
-  }
-  .site-nav__3d.on {
-    color: #e4f5ff;
-    background: linear-gradient(180deg, rgba(56, 152, 224, 0.28), rgba(56, 152, 224, 0.12));
-    border-color: rgba(150, 210, 250, 0.55);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.06);
-  }
-  @media (max-width: 480px) {
-    .site-nav__ghlabel {
-      display: none;
-    }
-    .site-nav__optional {
-      display: none;
-    }
-    .site-nav__link {
-      padding: 0.5rem 0.32rem;
-      font-size: 12px;
-    }
-  }
-
-  .btn {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.4rem;
-    border-radius: 0.6rem;
-    padding: 0.5rem 0.95rem;
-    font-size: 0.9rem;
-    font-weight: 600;
-    border: 1px solid var(--color-line-2);
-    background: var(--color-surface-2);
-    color: var(--color-slate-100);
-    cursor: pointer;
-    transition:
-      transform 0.12s ease,
-      background 0.12s ease,
-      border-color 0.12s ease;
-  }
-  .btn:hover {
-    border-color: var(--color-brand);
-    transform: translateY(-1px);
-  }
-  .btn-primary {
-    border-color: rgba(226, 232, 240, 0.44);
-    color: #05070d;
-    background:
-      linear-gradient(180deg, rgba(255, 255, 255, 0.5), rgba(255, 255, 255, 0) 40%),
-      linear-gradient(112deg, #eef3fa 0%, #d2dbe7 26%, #b3becc 45%, #e8edf4 67%, #c2ccd9 100%);
-  }
-  .btn-primary:hover {
-    filter: brightness(1.06);
-  }
-  .btn-ghost {
-    background: transparent;
-  }
-
   .card {
     border: 1px solid var(--color-line);
     background: color-mix(in oklab, var(--color-surface) 70%, transparent);
@@ -289,28 +135,6 @@
   }
 
   /* ---- handheld device frame (hero + playground) ------------------------- */
-  .pocket-frame {
-    width: 100%;
-    max-width: 440px;
-    padding: 14px;
-    border-radius: 22px;
-    border: 1px solid var(--color-line-2);
-    background:
-      linear-gradient(160deg, color-mix(in oklab, var(--color-surface-2) 90%, #fff 4%), var(--color-ink-2));
-    box-shadow:
-      0 1px 0 rgba(255, 255, 255, 0.05) inset,
-      0 30px 60px -30px rgba(0, 0, 0, 0.7),
-      0 0 0 1px rgba(56, 189, 248, 0.05);
-  }
-  .pocket-screen {
-    position: relative;
-    border-radius: 12px;
-    overflow: hidden;
-    background: #000;
-    border: 1px solid #05070d;
-    box-shadow: 0 0 0 6px #05070d, 0 0 18px -8px rgba(56, 189, 248, 0.22) inset;
-    aspect-ratio: 480 / 272;
-  }
   .pocket-screen canvas,
   .pg-screen canvas {
     display: block;
@@ -318,15 +142,6 @@
     height: 100%;
     image-rendering: pixelated;
     outline: none;
-  }
-  .pocket-loading {
-    position: absolute;
-    inset: 0;
-    display: grid;
-    place-items: center;
-    font-family: var(--font-mono);
-    font-size: 12px;
-    color: var(--color-slate-500);
   }
 
   /* ---- code sample card -------------------------------------------------- */
@@ -444,110 +259,6 @@
       radial-gradient(42% 60% at 0% 8%, color-mix(in oklab, var(--color-brand-3) 7%, transparent), transparent 70%),
       radial-gradient(36% 58% at 100% 12%, color-mix(in oklab, var(--color-brand-2) 4%, transparent), transparent 72%),
       var(--color-ink);
-  }
-  .pg-stage {
-    width: 100%;
-    margin: 0;
-    outline: none;
-  }
-  .pg-stage__viewport {
-    position: relative;
-    width: 100%;
-    aspect-ratio: 16 / 9;
-    overflow: hidden;
-    outline: none;
-  }
-  .pg-stage__canvas {
-    display: block;
-    width: 100%;
-    height: 100%;
-    outline: none;
-    cursor: grab;
-    touch-action: none;
-  }
-  .pg-stage__canvas:active { cursor: grabbing; }
-  .pg-stage__viewport:focus-visible .pg-stage__canvas {
-    border-radius: 0.8rem;
-    box-shadow: inset 0 0 0 2px color-mix(in oklab, var(--color-brand-2) 78%, white);
-  }
-  .pg-stage__screen { display: none; }
-  .pg-stage__status {
-    position: absolute;
-    left: 50%;
-    bottom: 0.7rem;
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
-    max-width: calc(100% - 2rem);
-    padding: 0.45rem 0.75rem;
-    border: 1px solid rgba(85, 103, 133, 0.56);
-    border-radius: 999px;
-    color: var(--color-slate-300);
-    background: rgba(6, 10, 18, 0.82);
-    font-family: var(--font-mono);
-    font-size: 0.68rem;
-    line-height: 1.25;
-    text-align: center;
-    transform: translateX(-50%);
-    backdrop-filter: blur(8px);
-    transition: opacity 0.25s ease, transform 0.25s ease;
-  }
-  .pg-stage__status-dot {
-    width: 6px;
-    height: 6px;
-    flex: none;
-    border-radius: 50%;
-    background: #9de5c7;
-    box-shadow: 0 0 10px rgba(157, 229, 199, 0.82);
-    animation: pg-stage-pulse 1.1s ease-in-out infinite alternate;
-  }
-  .pg-stage.is-ready .pg-stage__status {
-    opacity: 0;
-    transform: translate(-50%, 5px);
-    pointer-events: none;
-  }
-  .pg-stage.has-error .pg-stage__viewport { height: auto; }
-  .pg-stage.has-error .pg-stage__canvas { display: none; }
-  .pg-stage.has-error .pg-stage__screen {
-    display: block;
-    width: min(100%, 480px);
-    height: auto;
-    margin: 0 auto;
-    border-radius: 0.65rem;
-    background: #000;
-    image-rendering: pixelated;
-    box-shadow: 0 0 0 1px var(--color-line-2), 0 24px 54px -34px #000;
-  }
-  .pg-stage.has-error .pg-stage__viewport:focus-visible .pg-stage__screen {
-    box-shadow:
-      0 0 0 2px color-mix(in oklab, var(--color-brand-2) 78%, white),
-      0 24px 54px -34px #000;
-  }
-  .pg-stage.has-error .pg-stage__status {
-    color: #fecaca;
-    border-color: rgba(248, 113, 113, 0.44);
-  }
-  .pg-stage.has-error .pg-stage__status-dot {
-    background: #f87171;
-    box-shadow: none;
-    animation: none;
-  }
-  .pg-stage__credit {
-    padding: 0.35rem 0.35rem 0;
-    color: var(--color-slate-600);
-    font-size: 0.66rem;
-    line-height: 1.4;
-    text-align: right;
-  }
-  .pg-stage__credit a {
-    color: var(--color-slate-400);
-    text-decoration: underline;
-    text-underline-offset: 2px;
-  }
-  .pg-stage__credit a:hover { color: var(--color-slate-200); }
-  @keyframes pg-stage-pulse {
-    from { opacity: 0.35; transform: scale(0.78); }
-    to { opacity: 1; transform: scale(1); }
   }
   .pg-error {
     width: 100%; max-width: 620px; margin: 0; padding: 0.75rem 0.9rem;

--- a/site/assets/tokens.css
+++ b/site/assets/tokens.css
@@ -1,0 +1,20 @@
+/* site/assets/tokens.css — the design system's single source of truth.
+   Every page loads these: the homepage through assets/landing.css (tokens +
+   chrome + landing, concatenated by site/build.ts) and every other page
+   through assets/site.css, where tailwind.css maps them onto @theme so
+   utilities and components resolve to the same values. */
+:root{
+  --bg:#05070d; --bg-2:#080b13; --panel:#0d1220; --panel-2:#101828;
+  --line:rgba(43,58,85,.55); --line-2:rgba(74,94,130,.6);
+  --ink:#f3f7fd; --ink-2:#b9c3d4; --muted:#7b8aa1;
+  --steel-1:#d8e1ec; --steel-2:#a7b3c5; --steel-3:#66748a;
+  --metal:linear-gradient(100deg,#f4f8ff,#a7b3c5 55%,#d8e1ec);
+  --metal-ph:linear-gradient(100deg,#f2fbf5,#a9d8bd 42%,#cfe4dc 70%,#eef7f2);
+  --ph:#4ef08a; --ph-2:#9de5c7; --sky:#60a5fa;
+  /* chart marks: validated for the dark surface (lightness band, chroma, CVD, contrast) */
+  --c1:#1ba468; --c2:#4a86e8; --c3:#b07d1c; --c1-deep:#0f6c44;
+  --track:rgba(74,94,130,.22);
+  --px:"VT323",ui-monospace,monospace;
+  --sans:"IBM Plex Sans",-apple-system,system-ui,sans-serif;
+  --mono:"IBM Plex Mono",ui-monospace,Menlo,monospace;
+}

--- a/site/build.ts
+++ b/site/build.ts
@@ -593,7 +593,11 @@ async function main() {
   //    landing.js (the framework code tabs). Not wrapped in the shared
   //    header/footer (those stay for docs + playground).
   write("index.html", renderHome());
-  copy(SITE + "assets/landing.css", "assets/landing.css");
+  // The homepage ships one stylesheet: the same tokens and chrome the Tailwind
+  // build imports, plus the landing sections, concatenated in layer order.
+  write("assets/landing.css", ["tokens.css", "base.css", "chrome.css", "landing.css"]
+    .map((f) => readFileSync(SITE + "assets/" + f, "utf8"))
+    .join("\n"));
   await bundle("assets/landing.js", "assets/landing.js");
   // home.css stays for the /for/ pages, which keep the .lp-* chrome.
   copy(SITE + "assets/home.css", "assets/home.css");

--- a/site/home.html
+++ b/site/home.html
@@ -27,11 +27,14 @@
           <a href="/changelog/">Changelog</a>
         </div>
       </div>
-      <a class="ico" href="https://discord.gg/cTce4eXzSK" aria-label="PocketJS on Discord">
-        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.54 5.34A17.75 17.75 0 0 0 15.07 4c-.19.35-.41.82-.56 1.19a16.5 16.5 0 0 0-5.02 0A12.1 12.1 0 0 0 8.92 4c-1.55.27-3.06.73-4.47 1.34C1.62 9.54.86 13.64 1.24 17.68A17.9 17.9 0 0 0 6.72 20.4c.44-.59.83-1.22 1.16-1.89-.64-.24-1.25-.54-1.83-.89.15-.11.3-.23.44-.35a12.68 12.68 0 0 0 11.02 0c.15.12.29.24.44.35-.58.35-1.2.65-1.84.89.34.67.72 1.3 1.16 1.89a17.85 17.85 0 0 0 5.49-2.72c.45-4.69-.75-8.75-3.22-12.34ZM8.7 15.19c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Zm6.6 0c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Z"/></svg>
+      <a class="ico" href="https://x.com/pocket_js" aria-label="PocketJS on X">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>
       </a>
       <a class="ico" href="https://github.com/pocket-stack/pocketjs" aria-label="PocketJS on GitHub">
         <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.7.5.5 5.7.5 12c0 5.1 3.3 9.4 7.9 10.9.6.1.8-.3.8-.6v-2c-3.2.7-3.9-1.5-3.9-1.5-.5-1.3-1.3-1.7-1.3-1.7-1.1-.7.1-.7.1-.7 1.2.1 1.8 1.2 1.8 1.2 1 1.8 2.7 1.3 3.4 1 .1-.8.4-1.3.8-1.6-2.6-.3-5.3-1.3-5.3-5.8 0-1.3.5-2.3 1.2-3.1-.1-.3-.5-1.5.1-3.1 0 0 1-.3 3.3 1.2a11.5 11.5 0 0 1 6 0C17 4.7 18 5 18 5c.6 1.6.2 2.8.1 3.1.8.8 1.2 1.8 1.2 3.1 0 4.5-2.7 5.5-5.3 5.8.4.4.8 1.1.8 2.2v3.3c0 .3.2.7.8.6 4.6-1.5 7.9-5.8 7.9-10.9C23.5 5.7 18.3.5 12 .5z"/></svg>
+      </a>
+      <a class="ico" href="https://discord.gg/cTce4eXzSK" aria-label="PocketJS on Discord">
+        <svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.54 5.34A17.75 17.75 0 0 0 15.07 4c-.19.35-.41.82-.56 1.19a16.5 16.5 0 0 0-5.02 0A12.1 12.1 0 0 0 8.92 4c-1.55.27-3.06.73-4.47 1.34C1.62 9.54.86 13.64 1.24 17.68A17.9 17.9 0 0 0 6.72 20.4c.44-.59.83-1.22 1.16-1.89-.64-.24-1.25-.54-1.83-.89.15-.11.3-.23.44-.35a12.68 12.68 0 0 0 11.02 0c.15.12.29.24.44.35-.58.35-1.2.65-1.84.89.34.67.72 1.3 1.16 1.89a17.85 17.85 0 0 0 5.49-2.72c.45-4.69-.75-8.75-3.22-12.34ZM8.7 15.19c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Zm6.6 0c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Z"/></svg>
       </a>
     </nav>
   </div>
@@ -66,7 +69,10 @@
       <span class="vwrap"><span class="verb metal lit">Modern DX</span><span class="vrail"></span></span>
       <span class="fill"></span><span class="hud">solid · vue vapor · octane</span>
     </div>
-    <p class="slede">Write components as you already do, in Solid, Vue Vapor or Octane. Each one compiles to the
+    <p class="slede">Write components as you already do, in
+      <a class="pl" href="https://www.solidjs.com" target="_blank" rel="noreferrer">Solid</a>,
+      <a class="pl" href="https://vuejs.org" target="_blank" rel="noreferrer">Vue Vapor</a> or
+      <a class="pl" href="https://github.com/octanejs/octane" target="_blank" rel="noreferrer">Octane</a>. Each one compiles to the
       same native tree and runs on QuickJS, so <b>the framework you pick changes your code and nothing below
       it</b>.</p>
     <div class="cols" style="grid-template-columns:minmax(0,1.4fr) minmax(0,1fr)">
@@ -179,11 +185,35 @@
             </div>
           </div>
         </div>
-        <div class="receipts"><span>Refs</span>
+        <div class="receipts" data-refs><span>Refs</span>
           <a href="/docs/architecture/">docs/architecture</a>
           <a href="/docs/frameworks/">docs/frameworks</a>
         </div>
       </div>
+    </div>
+  </div>
+</section>
+
+<section class="sect" id="motion">
+  <div class="wrap">
+    <div class="shead">
+      <span class="vwrap"><span class="verb metal lit">Motion</span><span class="vrail"></span></span>
+      <span class="fill"></span><span class="hud">compiled at build time</span>
+    </div>
+    <div class="cols" style="grid-template-columns:minmax(0,1fr) minmax(0,1.1fr)">
+      <p class="slede" style="margin-bottom:0">Animation is compiled. Keyframe timelines and spring curves are
+        baked into the style table at build time and advanced by the Rust core on its own clock, so <b>a page can
+        animate with no per-frame JavaScript at all</b>. What runs beside this is the real thing: the yui540 motion
+        studies, in WebAssembly, inside the handheld they were written for.</p>
+      <figure class="pg-stage motion-stage" data-pocket-stage data-motion-stage>
+        <div class="pg-stage__viewport" data-stage-viewport tabindex="0" role="group"
+             aria-label="Interactive 3D PSP running the yui540 motion studies. Drag to rotate, click the device controls, or use the keyboard.">
+          <canvas class="pg-stage__canvas" data-stage-canvas aria-hidden="true"></canvas>
+          <canvas class="pg-stage__screen" data-stage-screen width="480" height="272"
+                  aria-label="The motion studies running on the PocketJS runtime"></canvas>
+        </div>
+        <figcaption class="pg-stage__status" data-stage-status><span class="pg-stage__status-dot"></span>Loading the motion studies</figcaption>
+      </figure>
     </div>
   </div>
 </section>
@@ -315,7 +345,7 @@
       </div>
 
     </div>
-    <div class="receipts"><span>Refs</span>
+    <div class="receipts" data-refs><span>Refs</span>
       <a href="/blog/shipping-openstrike/">shipping openstrike</a>
       <a href="/blog/pocket-character/">pocket character</a>
       <a href="/blog/pocketjs-on-ps-vita/">twice the pixels, zero forks</a>
@@ -336,7 +366,7 @@
       measure</b>: a journey that takes six seconds in front of a user is a few dozen frames in CI.</p>
     <div class="cols">
       <div>
-        <div class="tl">
+        <div class="pl">
           <span class="lb">where an effect actually lands</span>
           <div class="lane">
             <span class="ln">wall clock</span>
@@ -437,7 +467,7 @@
           splice in a different press, re-run the fold, and a counterfactual world exists in <strong>22 ms</strong>.
           Chaos mode proves the floor holds, injecting real sleeps, allocation churn and forced GC between frames
           without moving the trace by one bit.</p>
-        <div class="receipts"><span>Refs</span>
+        <div class="receipts" data-refs><span>Refs</span>
           <a href="/blog/ui-runtime-that-cant-flake/">the runtime that can't flake</a>
           <a href="/blog/time-travel-devtools/">time-travel devtools</a>
         </div>
@@ -487,12 +517,67 @@
             <img class="ph3" src="/assets/blog/voxel-psp-route-1.png" alt="Pocket Voxel, a route of extruded voxel grass and carved trees">
           </div>
         </div>
-        <div class="receipts"><span>Refs</span>
+        <div class="receipts" data-refs><span>Refs</span>
           <a href="/blog/shipping-openstrike/">shipping openstrike</a>
           <a href="/blog/pocket-voxel/">pocket voxel</a>
           <a href="/docs/concepts/">docs/concepts</a>
         </div>
       </div>
+    </div>
+  </div>
+</section>
+
+<section class="sect" id="compat">
+  <div class="wrap">
+    <div class="shead">
+      <span class="vwrap"><span class="verb metal lit">Compatibility</span><span class="vrail"></span></span>
+      <span class="fill"></span><span class="hud">run on the metal, not emulated</span>
+    </div>
+    <p class="slede">The list below is not a roadmap. Each entry has booted the runtime on the real thing, and
+      <b>the fork between them is one native submission layer, never the application</b>.</p>
+    <div class="cols" style="grid-template-columns:minmax(0,1fr) minmax(0,1fr)">
+      <div class="cpanel">
+        <span class="lb">operating systems</span>
+        <div class="cgrid">
+          <span class="cchip">PSP system software<em>MIPS, 32 MB</em></span>
+          <span class="cchip">PS Vita system software<em>ARM, GXM</em></span>
+          <span class="cchip">iPhone OS 3.1.3<em>ARMv6, GL ES 1.1</em></span>
+          <span class="cchip">iOS 6.1.3<em>ARMv7</em></span>
+          <span class="cchip">iOS 12.5.8<em>arm64</em></span>
+          <span class="cchip">iOS, current<em>NativeScript host</em></span>
+          <span class="cchip">macOS<em>Metal window and widget</em></span>
+          <span class="cchip">Symbian Belle<em>Qt, GLES2</em></span>
+          <span class="cchip">Windows CE 6<em>GDI framebuffer</em></span>
+          <span class="cchip">BlackBerry 10.3<em>QNX, native ELF</em></span>
+          <span class="cchip">Android 4.3<em>BlackBerry runtime, JNI</em></span>
+          <span class="cchip">PocketBook e-ink<em>inkview, partial refresh</em></span>
+          <span class="cchip">ESP-IDF<em>RGB565 and PPA</em></span>
+          <span class="cchip">the browser<em>WebAssembly core</em></span>
+        </div>
+      </div>
+      <div class="cpanel">
+        <span class="lb">devices it has booted on</span>
+        <div class="cgrid">
+          <span class="cchip">Sony PSP<em>2004</em></span>
+          <span class="cchip">PS Vita<em>2011</em></span>
+          <span class="cchip">iPhone<em>2007</em></span>
+          <span class="cchip">iPhone 4S<em>2011</em></span>
+          <span class="cchip">iPod touch 6<em>2015</em></span>
+          <span class="cchip">Nokia E7<em>2011</em></span>
+          <span class="cchip">Meizu M8<em>2009</em></span>
+          <span class="cchip">BlackBerry Classic<em>2014</em></span>
+          <span class="cchip">PocketBook reader<em>e-ink</em></span>
+          <span class="cchip">ESP32-P4 devkit<em>microcontroller</em></span>
+          <span class="cchip">Mac<em>Apple silicon</em></span>
+        </div>
+      </div>
+    </div>
+    <div class="receipts" data-refs><span>Refs</span>
+      <a href="/blog/pocketjs-on-ps-vita/">ps vita</a>
+      <a href="/blog/pocketjs-on-the-first-iphone/">first iphone</a>
+      <a href="/blog/pocketjs-on-symbian/">symbian</a>
+      <a href="/blog/pocketjs-on-windows-ce/">windows ce</a>
+      <a href="/docs/platform-contracts/">docs/platform-contracts</a>
     </div>
   </div>
 </section>
@@ -562,7 +647,7 @@
     </div>
     <div class="labband">
       <div>
-        <span class="lb">the organization behind it</span>
+        <span class="lb">who builds this</span>
         <p><strong>Pocket Lab</strong> is an independent, non-VC-backed organization built on this runtime, so
           that <strong>the joy of creating belongs to everyone</strong>.</p>
       </div>
@@ -582,7 +667,11 @@
       <span class="vwrap"><span class="verb metal lit">Sponsors</span><span class="vrail"></span></span>
       <span class="fill"></span><span class="hud">thank you</span>
     </div>
+    <p class="slede">We can only develop PocketJS full-time thanks to your support.</p>
     <div class="spon-gallery">{{SPONSOR_GALLERY}}</div>
+    <a class="btn btn--pri spon-cta" href="https://github.com/sponsors/doodlewind" target="_blank" rel="noreferrer">
+      <span aria-hidden="true">👾</span> Become a sponsor
+    </a>
   </div>
 </section>
 

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -55,66 +55,50 @@ function header(active: string): string {
     '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M19.54 5.34A17.75 17.75 0 0 0 15.07 4c-.19.35-.41.82-.56 1.19a16.5 16.5 0 0 0-5.02 0A12.1 12.1 0 0 0 8.92 4c-1.55.27-3.06.73-4.47 1.34C1.62 9.54.86 13.64 1.24 17.68A17.9 17.9 0 0 0 6.72 20.4c.44-.59.83-1.22 1.16-1.89-.64-.24-1.25-.54-1.83-.89.15-.11.3-.23.44-.35a12.68 12.68 0 0 0 11.02 0c.15.12.29.24.44.35-.58.35-1.2.65-1.84.89.34.67.72 1.3 1.16 1.89a17.85 17.85 0 0 0 5.49-2.72c.45-4.69-.75-8.75-3.22-12.34ZM8.7 15.19c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Zm6.6 0c-1.07 0-1.95-.98-1.95-2.18s.86-2.18 1.95-2.18c1.08 0 1.96.98 1.95 2.18 0 1.2-.87 2.18-1.95 2.18Z"/></svg>';
   const xIcon =
     '<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M18.244 2.25h3.308l-7.227 8.26 8.502 11.24H16.17l-5.214-6.817L4.99 21.75H1.68l7.73-8.835L1.254 2.25H8.08l4.713 6.231zm-1.161 17.52h1.833L7.084 4.126H5.117z"/></svg>';
-  const link = (href: string, label: string, key: string, ext = false, className = "") =>
-    `<a href="${href}"${ext ? ' target="_blank" rel="noreferrer"' : ""} ` +
-    `class="site-nav__link ${className} ${active === key ? "on" : ""}">${label}</a>`;
-  return `<header class="site-nav">
-  <div class="site-nav__in">
-    <a href="/" class="site-brand" aria-label="PocketJS home">
-      ${LOGO}<span class="text-[17px]">PocketJS</span>
+  const link = (href: string, label: string, key: string) =>
+    `<a href="${href}" class="${active === key ? "on" : ""}">${label}</a>`;
+  const ico = (href: string, label: string, svg: string) =>
+    `<a class="ico" href="${href}" target="_blank" rel="noreferrer" aria-label="${label}">${svg}</a>`;
+  return `<header class="nav">
+  <div class="wrap">
+    <a href="/" class="mark" aria-label="PocketJS home">
+      ${LOGO}<span class="nm">PocketJS</span>
     </a>
-    <nav class="site-nav__links" aria-label="Primary">
+    <nav class="nav-links" aria-label="Primary">
       ${link("/docs/overview/", "Docs", "docs")}
-      ${link("/playground/", "Playground", "playground")}
       ${link("/blog/", "Blog", "blog")}
-      ${link("/changelog/", "Changelog", "changelog", false, "site-nav__optional")}
-      <a href="${GH}" target="_blank" rel="noreferrer" class="site-nav__link site-nav__gh" aria-label="PocketJS on GitHub">${ghIcon}</a>
-      <a href="${DISCORD}" target="_blank" rel="noreferrer" class="site-nav__link site-nav__discord" aria-label="PocketJS Discord">${discordIcon}</a>
-      <a href="${X_URL}" target="_blank" rel="noreferrer" class="site-nav__link site-nav__x" aria-label="PocketJS on X">${xIcon}</a>
+      <div class="menu">
+        <button class="menu-btn" aria-haspopup="true" aria-expanded="false">Resources
+          <svg width="9" height="9" viewBox="0 0 10 10" aria-hidden="true"><path d="M1 3l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </button>
+        <div class="menu-list">
+          <a href="https://pocketlab.build">Lab</a>
+          <a href="/playground/">Playground</a>
+          <a href="/changelog/">Changelog</a>
+        </div>
+      </div>
+      ${ico(X_URL, "PocketJS on X", xIcon)}
+      ${ico(GH, "PocketJS on GitHub", ghIcon)}
+      ${ico(DISCORD, "PocketJS Discord", discordIcon)}
     </nav>
   </div>
 </header>`;
 }
 
-const footer = `<footer class="mt-24 border-t border-line/70 bg-ink-2/60">
-  <div class="mx-auto max-w-6xl px-5 py-12">
-    <div class="grid gap-10 sm:grid-cols-2 lg:grid-cols-4">
-      <div>
-        <div class="flex items-center gap-2 font-semibold text-slate-100">${LOGO}<span>PocketJS</span></div>
-        <p class="mt-3 max-w-xs text-sm text-slate-400">${SITE_FOOTER_DESC}</p>
-      </div>
-      <div class="text-sm">
-        <h4 class="mb-3 font-semibold text-slate-200">Docs</h4>
-        <ul class="space-y-2 text-slate-400">
-          <li><a class="hover:text-brand-2" href="/docs/overview/">Overview</a></li>
-          <li><a class="hover:text-brand-2" href="/docs/getting-started/">Getting started</a></li>
-          <li><a class="hover:text-brand-2" href="/docs/architecture/">Architecture</a></li>
-          <li><a class="hover:text-brand-2" href="/docs/api/">API reference</a></li>
-        </ul>
-      </div>
-      <div class="text-sm">
-        <h4 class="mb-3 font-semibold text-slate-200">Framework</h4>
-        <ul class="space-y-2 text-slate-400">
-          <li><a class="hover:text-brand-2" href="/playground/">Playground</a></li>
-          <li><a class="hover:text-brand-2" href="/docs/components/">Components</a></li>
-          <li><a class="hover:text-brand-2" href="/docs/styling/">Styling</a></li>
-          <li><a class="hover:text-brand-2" href="/docs/animation/">Animation</a></li>
-        </ul>
-      </div>
-      <div class="text-sm">
-        <h4 class="mb-3 font-semibold text-slate-200">Project</h4>
-        <ul class="space-y-2 text-slate-400">
-          <li><a class="hover:text-brand-2" href="/blog/">Blog</a></li>
-          <li><a class="hover:text-brand-2" href="${GH}" target="_blank" rel="noreferrer">GitHub</a></li>
-          <li><a class="hover:text-brand-2" href="${X_URL}" target="_blank" rel="noreferrer">X (Twitter)</a></li>
-          <li><a class="hover:text-brand-2" href="/docs/native-contract/">Native contract</a></li>
-          <li><a class="hover:text-brand-2" href="/docs/build-pipeline/">Build pipeline</a></li>
-        </ul>
-      </div>
-    </div>
-    <div class="mt-10 flex flex-col gap-2 border-t border-line/60 pt-6 text-xs text-slate-500 sm:flex-row sm:items-center sm:justify-end">
-      <span>© ${YEAR} PocketJS · MIT</span>
-    </div>
+const footer = `<footer class="foot">
+  <div class="wrap">
+    <span class="hud">© ${YEAR} PocketJS · MIT · a Pocket Lab project</span>
+    <nav class="cols2" aria-label="Footer">
+      <a href="/docs/overview/">Docs</a>
+      <a href="/playground/">Playground</a>
+      <a href="/blog/">Blog</a>
+      <a href="/changelog/">Changelog</a>
+      <a href="https://pocketlab.build">Pocket Lab</a>
+      <a href="${GH}" target="_blank" rel="noreferrer">GitHub</a>
+      <a href="${X_URL}" target="_blank" rel="noreferrer">X</a>
+      <a href="${DISCORD}" target="_blank" rel="noreferrer">Discord</a>
+    </nav>
+    <span class="hud">${SITE_FOOTER_DESC}</span>
   </div>
 </footer>`;
 
@@ -157,6 +141,9 @@ export function renderPage(o: PageOpts): string {
 <meta name="twitter:image" content="${OG_IMAGE_URL}">
 <meta name="theme-color" content="#05070d">
 <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=STIX+Two+Text:ital,wght@0,400;0,600;1,400&family=VT323&family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500;600&display=swap">
 <link rel="stylesheet" href="/assets/site.css">
 <script type="application/ld+json">${jsonLd}</script>
 ${o.head ?? ""}

--- a/tests/site-stage.test.ts
+++ b/tests/site-stage.test.ts
@@ -57,7 +57,10 @@ test("homepage Stage package has one semantic screen and its declared suppressio
 test("homepage ships the four-chapter landing", () => {
   const home = readFileSync(ROOT + "site/home.html", "utf8");
   // The 3D stage lives in the playground; the homepage must not mount it.
-  expect(home).not.toContain("data-pocket-stage");
+  // the motion chapter mounts the real runtime in the PSP model, booting one
+  // app directly rather than the launcher deck
+  expect(home).toContain("data-motion-stage");
+  expect(home).toContain("data-stage-viewport");
   expect(home).not.toContain("lp-stage");
   // House style: no em dashes anywhere on the landing surfaces.
   for (const file of [
@@ -134,7 +137,10 @@ test("homepage ships the four-chapter landing", () => {
   expect(home).toContain('<div class="spon-gallery">{{SPONSOR_GALLERY}}</div>');
   expect(home).toContain('<span class="verb metal lit">Sponsors</span>');
   const sponsorSection = home.slice(home.indexOf('id="sponsors"'), home.indexOf("<footer"));
-  for (const pitch of ["$", "tier", "Tier", "become a sponsor", "Become a sponsor", "Sponsor on GitHub"]) {
+  // one line of thanks and one way in; still no amounts and no tier ladder
+  expect(sponsorSection).toContain("thanks to your support");
+  expect(sponsorSection).toContain("https://github.com/sponsors/doodlewind");
+  for (const pitch of ["$", "tier", "Tier", "monthly"]) {
     expect(sponsorSection).not.toContain(pitch);
   }
   const roster = JSON.parse(readFileSync(ROOT + "site/sponsors.json", "utf8")) as {
@@ -174,6 +180,15 @@ test("homepage ships the four-chapter landing", () => {
   expect(homeCss).toContain(".lp-nav");
 });
 
+test("the PSP stage looks straight at the screen", () => {
+  const profile = JSON.parse(
+    readFileSync(ROOT + "engine/pocket3d/examples/handheld/assets/dibad-psp/profile.json", "utf8"),
+  ) as { view: { desk_position_mm: number[]; desk_target_mm: number[] } };
+  // a level camera: no downward tilt on the playground or the homepage
+  expect(profile.view.desk_position_mm[1]).toBe(0);
+  expect(profile.view.desk_target_mm[1]).toBe(0);
+});
+
 test("playground wraps its live framebuffer in the PSP model", () => {
   const playground = readFileSync(ROOT + "site/playground/page.html", "utf8");
   for (const marker of [
@@ -191,9 +206,11 @@ test("playground wraps its live framebuffer in the PSP model", () => {
   expect(playground).not.toContain("screen-emu");
   expect(playground).not.toContain("data-btn");
 
-  // The stage is playground-only now: the homepage must not pull the module.
+  // Both surfaces share one stage module; the homepage boots a single app and
+  // the playground supplies its own live-compiled host.
   const homeGlue = readFileSync(ROOT + "site/assets/landing.js", "utf8");
-  expect(homeGlue).not.toContain("pocket-stage-web.js");
+  expect(homeGlue).toContain('import("/assets/pocket-stage-web.js")');
+  expect(homeGlue).toContain('bootApp: "motions-main"');
   const playgroundGlue = readFileSync(ROOT + "site/playground/playground.js", "utf8");
   expect(playgroundGlue).toContain('import("/assets/pocket-stage-web.js")');
   expect(playgroundGlue).toContain("mountPocketStage");
@@ -216,7 +233,9 @@ test("playground wraps its live framebuffer in the PSP model", () => {
   expect(build).not.toContain("screen.css");
   expect(existsSync(ROOT + "site/assets/screen.css")).toBe(false);
 
-  const css = readFileSync(ROOT + "site/assets/tailwind.css", "utf8");
+  // the stage's own styles moved into the shared chrome, which both the
+  // playground and the homepage load
+  const css = readFileSync(ROOT + "site/assets/chrome.css", "utf8");
   expect(css).toContain(".pg-stage.has-error .pg-stage__canvas { display: none; }");
   expect(css).toContain(".pg-stage.has-error .pg-stage__screen");
   expect(css).toContain(".pg-stage.has-error .pg-stage__viewport:focus-visible .pg-stage__screen");


### PR DESCRIPTION
The homepage had moved to a new look while the docs, blog and playground were still on the old blue theme. This makes them one system, and adds the two chapters the landing was missing.

## The design system

| file | what it owns |
|---|---|
| `site/assets/tokens.css` | the palette and the faces, once |
| `site/assets/chrome.css` | shared shell: nav, resource menu, buttons, footer, the 3D stage |
| `site/assets/base.css` | the homepage's own reset and ground |
| `site/assets/tailwind.css` | imports the tokens, re-exports them through `@theme inline`, pulls the chrome into its components layer |

So a utility (`bg-surface`, `text-fg-2`, `font-px`) and a homepage rule resolve to the same value, and the chrome is one implementation rather than two. The duplicate button (`.btn--pri` vs `.btn-primary`) is now one rule with both names.

**Cascade layers bite here.** An unlayered `*{margin:0;padding:0}` outranks every `@layer` rule regardless of specificity, so the reset had to stay out of the shared chrome: with it in, the docs prose lost all its spacing. The stage styles moving between files also cost a brace, which nested the rest of the playground's rules inside `.pg-framework-btn:disabled` and flattened its split pane. Both are fixed and the layout is verified at 1440 and 994 px.

## Motion

States the mechanism in two sentences, then runs it: the yui540 motion studies, live in WebAssembly, inside the PSP model, booting when the chapter scrolls into view. Verified from the stage receipt: ready, ~420 guest ticks, ~165 screen uploads.

`mountPocketStage` gained a `bootApp` option so a page can boot one app instead of the launcher deck, and the authored camera in `dibad-psp/profile.json` now looks straight at the screen (`desk_position_mm` y: 46 → 0), which straightens the playground's model too.

## Compatibility

What has actually booted, split by operating system and by device: PSP and Vita system software, iPhone OS 3.1.3, iOS 6.1.3 and 12.5.8, current iOS, macOS, Symbian Belle, Windows CE 6, BlackBerry 10.3 on QNX plus its Android 4.3 runtime, PocketBook e-ink, ESP-IDF, and the browser. The Vapor cartridge targets are their own story and are not in this list.

## Smaller things

- nav carries X, GitHub and Discord as icons, in that order, on every page
- refs open in their own tab
- the framework names link out as plain text, not boxes
- the sponsor section thanks people and offers one way in
- the effect timeline's markers are grid items now, so they point at frame +3 in Safari too rather than at a hand-tuned percentage

🤖 Generated with [Claude Code](https://claude.com/claude-code)