### PR TITLE
fix(site): give Safari an icon it can actually use for bookmarks

### DIFF
--- a/site/templates.ts
+++ b/site/templates.ts
@@ -26,11 +26,20 @@ export const OG_IMAGE_URL = `${SITE_URL}/og-image.png`;
 // versions those URLs because iOS caches the home screen icon per URL and keeps
 // serving a page screenshot if the first fetch ever came up empty; bump it when
 // the drawing changes.
+//
+// Two of these entries exist for Safari specifically. The sizes-less
+// apple-touch-icon is the form Apple documents, at the root name Safari looks
+// for on its own, with no query on it: bookmarks and the Favorites grid read
+// that path rather than the sized ladder the home screen picks from. And Safari
+// could not render an SVG favicon until version 26, so a large PNG favicon has
+// to be declared as well or every Safari before that has only the 96 to scale.
 const ICON_V = "2";
 export const ICON_LINKS = [
   '<link rel="icon" href="/favicon.svg" type="image/svg+xml">',
   '<link rel="icon" href="/favicon.ico" sizes="48x48">',
   '<link rel="icon" href="/favicon-96.png" type="image/png" sizes="96x96">',
+  '<link rel="icon" href="/icon-192.png" type="image/png" sizes="192x192">',
+  '<link rel="apple-touch-icon" href="/apple-touch-icon.png">',
   `<link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png?v=${ICON_V}">`,
   `<link rel="apple-touch-icon" sizes="167x167" href="/apple-touch-icon-167.png?v=${ICON_V}">`,
   `<link rel="apple-touch-icon" sizes="152x152" href="/apple-touch-icon-152.png?v=${ICON_V}">`,

--- a/tests/site-stage.test.ts
+++ b/tests/site-stage.test.ts
@@ -401,6 +401,17 @@ test("the icon family is rendered from one drawing and linked from every head", 
   expect(ICON_LINKS).toContain("?v=");
   expect(ICON_LINKS).toContain('name="apple-mobile-web-app-title"');
 
+  // Safari's bookmarks and Favorites grid read the plain root name, so that one
+  // link carries neither a size nor a query.
+  expect(ICON_LINKS).toContain('<link rel="apple-touch-icon" href="/apple-touch-icon.png">');
+  // Safari could not render an SVG favicon before version 26, so the raster
+  // favicons have to reach a size a Favorites tile can use.
+  const pngFavicons = [...ICON_LINKS.matchAll(/rel="icon" href="\/([^"]+\.png)" type="image\/png" sizes="(\d+)x/g)];
+  expect(Math.max(...pngFavicons.map((m) => Number(m[2])))).toBeGreaterThanOrEqual(192);
+  for (const [, file, size] of pngFavicons) {
+    expect(ihdr(file)).toEqual([Number(size), Number(size)]);
+  }
+
   // favicon.ico carries 16, 32 and 48 as PNG payloads in one container
   const ico = readFileSync(ROOT + "site/assets/favicon.ico");
   expect(ico.readUInt16LE(0)).toBe(0);


### PR DESCRIPTION
The home screen icon from #319 works, but adding pocketjs.dev to Safari Favorites still produced a blank tile. Two gaps, both specific to Safari.

## The plain root path was never declared

After #319, every `apple-touch-icon` link carried both a `sizes` attribute and a `?v=2` query. Apple documents the canonical form as a **sizes-less link** at the root name Safari also probes on its own, and that root path is what bookmarks and the Favorites grid read — not the sized ladder the home screen picks from. A sizes-less `/apple-touch-icon.png` link with no query now sits alongside the ladder, so both consumers get the form they expect.

## Safari cannot render our SVG favicon

Per caniuse, SVG favicons are **unsupported in Safari and Safari iOS through 18.7**, and only land in version 26. Ours was the first `rel="icon"` declared, and behind it there was nothing raster larger than 96 — too small for a Favorites tile to draw. A **192 PNG** favicon is now declared as well, so every Safari before 26 has a real icon at a usable size while Chrome and Firefox keep using the SVG.

## What I verified rather than assumed

Ran Apple's own decoder over what we serve, since Safari draws these through ImageIO:

- `sips` reads `favicon.ico` at 48×48 — the PNG-payload container from #317 decodes fine, so that was not the problem
- `apple-touch-icon.png` is **180×180, no alpha channel**, which is what Apple requires for these tiles (a transparent touch icon is a documented cause of a blank tile)
- all four rungs plus the precomposed file still return 200 `image/png` from the edge, byte-identical to the repo

So the assets were sound and the markup was the gap.

`bun test tests/site-stage.test.ts` — 13 pass, with two new assertions: the sizes-less query-less link must be present, and the largest declared PNG favicon must be at least 192 with its IHDR matching the size its link claims.

Same change on pocketlab.build in pocket-stack/pocketlab.build#7.

Note for the device: Safari keeps per-site icons in its own store, so a Favorites entry made earlier will not re-fetch. Remove it, reload the page, then re-add — or clear website data if it persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
