### PR TITLE
fix(site): separate the two halves of the tab title with a middle dot

### DIFF
--- a/site/assets/site.webmanifest
+++ b/site/assets/site.webmanifest
@@ -1,5 +1,5 @@
 {
-  "name": "PocketJS JavaScript UI runtime",
+  "name": "PocketJS · JavaScript UI runtime",
   "short_name": "PocketJS",
   "description": "A UI runtime that keeps JSX, Tailwind and reactive state, then removes every layer below them.",
   "start_url": "/",

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -7,7 +7,7 @@ const GH = "https://github.com/pocket-stack/pocketjs";
 const DISCORD = "https://discord.gg/cTce4eXzSK";
 const X_URL = "https://x.com/pocket_js";
 export const SITE_URL = "https://pocketjs.dev";
-export const SITE_TITLE = "PocketJS JavaScript UI runtime";
+export const SITE_TITLE = "PocketJS · JavaScript UI runtime";
 export const SITE_DESC =
   "A compact JavaScript runtime for building UI, games, 3D experiences and AI-native applications across radically different devices. A tiny JavaScript guest where it fits; the framework compiled away where it doesn't.";
 // Shared by the standalone homepage and every page rendered through renderPage().

--- a/tests/site-stage.test.ts
+++ b/tests/site-stage.test.ts
@@ -461,7 +461,7 @@ test("the icon family is rendered from one drawing and linked from every head", 
   // Nothing links it, but iOS fetches this path from the root on its own.
   expect(build).toContain('"apple-touch-icon-precomposed.png"');
   // The tab title says what this is.
-  expect(SITE_TITLE).toBe("PocketJS JavaScript UI runtime");
+  expect(SITE_TITLE).toBe("PocketJS · JavaScript UI runtime");
 
   // The generator reads the one drawing and nothing else.
   const gen = readFileSync(ROOT + "tools/icons.ts", "utf8");


### PR DESCRIPTION
The tab title ran `PocketJS JavaScript UI runtime` as one phrase, which reads as a product named "PocketJS JavaScript". A middle dot (U+00B7) marks where the name ends and the description begins:

```
PocketJS · JavaScript UI runtime
```

That is already the separator every other page uses — `renderPage` builds subpage titles as `${title} · PocketJS`, so the homepage now matches (`Blog · PocketJS`, `Docs · PocketJS`).

The web app manifest `name` tracks `SITE_TITLE`, so it moves with it; `short_name` stays `PocketJS`, which is what a home screen actually shows.

- `site/templates.ts` — `SITE_TITLE`, read by `<title>`, `og:title`, `twitter:title` and `og:image:alt` on both the standalone homepage and every `renderPage` document.
- `site/assets/site.webmanifest` — `name`.
- `tests/site-stage.test.ts` — the exact-title assertion.

Verified: `bun test tests/site-stage.test.ts` → 13 pass / 296 expect(); `bun run site:build` renders `<title>PocketJS · JavaScript UI runtime</title>` on the homepage and `<title>Blog · PocketJS</title>` on subpages; the manifest still parses as JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
