### PR TITLE
feat(site): link Pocket Museum from the chapter, the nav and the footer

### DIFF
--- a/site/assets/chrome.css
+++ b/site/assets/chrome.css
@@ -50,8 +50,14 @@
 /* footer */
 .foot{border-top:1px solid var(--line);padding:2.2rem 0 3rem;background:var(--bg-2)}
 .foot .wrap{display:flex;flex-wrap:wrap;gap:1.4rem;justify-content:space-between;align-items:center}
-.foot .cols2{display:flex;gap:1.8rem;flex-wrap:wrap;font-family:var(--mono);font-size:.72rem;color:var(--ink-2)}
+.foot .cols2{display:flex;gap:1.3rem;flex-wrap:wrap;font-family:var(--mono);font-size:.72rem;color:var(--ink-2)}
 .foot .cols2 a:hover{color:var(--ph)}
+/* The row carries three groups: this site, the Pocket Lab family, then the
+   accounts. A muted dot marks each boundary, so the footer stays one line of
+   links instead of growing headings. The dot is the first child of the group it
+   opens, so wrapping can never leave one stranded at the end of a line. */
+.foot .cols2 .fgrp{display:flex;gap:1.3rem;flex-wrap:wrap;align-items:baseline}
+.foot .cols2 .fdot{color:var(--muted);opacity:.6}
 
 
 /* the interactive 3D stage: one implementation for the playground and the homepage */

--- a/site/assets/landing.css
+++ b/site/assets/landing.css
@@ -444,4 +444,11 @@
 .motion-stage{margin:0;border:0;background:transparent;padding:0}
 .motion-stage .pg-stage__viewport{background:transparent;border:0}
 .motion-stage .pg-stage__status{justify-content:center}
+/* The status pill fades out once the runtime is live, so the control hint is its
+   own line under the model. It appears with the model and never in the 2D
+   fallback, where there are no buttons to press. */
+.stage-hint{margin:.55rem 0 0;font-family:var(--mono);font-size:.66rem;line-height:1.4;
+  color:var(--muted);text-align:center;opacity:0;transition:opacity .3s ease}
+.pg-stage.is-ready .stage-hint{opacity:1}
+.pg-stage.has-error .stage-hint{display:none}
 .spon-cta{margin-top:1.4rem;display:inline-flex;gap:.5rem;align-items:center}

--- a/site/home.html
+++ b/site/home.html
@@ -23,6 +23,7 @@
         </button>
         <div class="menu-list">
           <a href="https://pocketlab.build">Lab</a>
+          <a href="https://museum.pocketlab.build">Museum</a>
           <a href="/playground/">Playground</a>
           <a href="/changelog/">Changelog</a>
         </div>
@@ -213,6 +214,7 @@
                   aria-label="The motion studies running on the PocketJS runtime"></canvas>
         </div>
         <figcaption class="pg-stage__status" data-stage-status><span class="pg-stage__status-dot"></span>Loading the motion studies</figcaption>
+        <p class="stage-hint">Press left or right on the d-pad, or the L and R shoulders, to switch studies.</p>
       </figure>
     </div>
   </div>
@@ -533,9 +535,11 @@
       <span class="vwrap"><span class="verb metal lit">Compatibility</span><span class="vrail"></span></span>
       <span class="fill"></span><span class="hud">run on the metal, not emulated</span>
     </div>
-    <p class="slede">The list below is not a roadmap. Each entry has booted the runtime on the real thing, and
-      <b>the fork between them is one native submission layer, never the application</b>. Every entry links to
-      the post or the pull request that brought it up.</p>
+    <p class="slede">Not a roadmap. Every entry below has booted the runtime on the real machine, and
+      <b>what changes between them is one native submission layer, never the application</b>. Each links to the
+      post or pull request that brought it up. Keeping the hardware bootable is its own work, so we started
+      <a class="olink" href="https://museum.pocketlab.build/" target="_blank" rel="noreferrer">Pocket Museum</a>
+      to repair these machines and keep them running.</p>
     <div class="cols" style="grid-template-columns:minmax(0,1fr) minmax(0,1fr)">
       <div class="cpanel">
         <span class="lb">operating systems</span>
@@ -685,14 +689,21 @@
       <span class="nm">PocketJS</span>
     </span>
     <nav class="cols2" aria-label="Footer">
-      <a href="/docs/overview/">Docs</a>
-      <a href="/playground/">Playground</a>
-      <a href="/blog/">Blog</a>
-      <a href="/changelog/">Changelog</a>
-      <a href="https://pocketlab.build">Pocket Lab</a>
-      <a href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">GitHub</a>
-      <a href="https://x.com/pocket_js" target="_blank" rel="noreferrer">X</a>
-      <a href="https://discord.gg/cTce4eXzSK" target="_blank" rel="noreferrer">Discord</a>
+      <span class="fgrp">
+        <a href="/docs/overview/">Docs</a>
+        <a href="/playground/">Playground</a>
+        <a href="/blog/">Blog</a>
+        <a href="/changelog/">Changelog</a>
+      </span>
+      <span class="fgrp"><span class="fdot" aria-hidden="true">·</span>
+        <a href="https://pocketlab.build">Pocket Lab</a>
+        <a href="https://museum.pocketlab.build">Pocket Museum</a>
+      </span>
+      <span class="fgrp"><span class="fdot" aria-hidden="true">·</span>
+        <a href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">GitHub</a>
+        <a href="https://x.com/pocket_js" target="_blank" rel="noreferrer">X</a>
+        <a href="https://discord.gg/cTce4eXzSK" target="_blank" rel="noreferrer">Discord</a>
+      </span>
     </nav>
     <span class="hud">© 2026 PocketJS · MIT · a Pocket Lab project</span>
   </div>

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -106,6 +106,7 @@ function header(active: string): string {
         </button>
         <div class="menu-list">
           <a href="https://pocketlab.build">Lab</a>
+          <a href="https://museum.pocketlab.build">Museum</a>
           <a href="/playground/">Playground</a>
           <a href="/changelog/">Changelog</a>
         </div>
@@ -122,14 +123,21 @@ const footer = `<footer class="foot">
   <div class="wrap">
     <span class="hud">© ${YEAR} PocketJS · MIT · a Pocket Lab project</span>
     <nav class="cols2" aria-label="Footer">
-      <a href="/docs/overview/">Docs</a>
-      <a href="/playground/">Playground</a>
-      <a href="/blog/">Blog</a>
-      <a href="/changelog/">Changelog</a>
-      <a href="https://pocketlab.build">Pocket Lab</a>
-      <a href="${GH}" target="_blank" rel="noreferrer">GitHub</a>
-      <a href="${X_URL}" target="_blank" rel="noreferrer">X</a>
-      <a href="${DISCORD}" target="_blank" rel="noreferrer">Discord</a>
+      <span class="fgrp">
+        <a href="/docs/overview/">Docs</a>
+        <a href="/playground/">Playground</a>
+        <a href="/blog/">Blog</a>
+        <a href="/changelog/">Changelog</a>
+      </span>
+      <span class="fgrp"><span class="fdot" aria-hidden="true">·</span>
+        <a href="https://pocketlab.build">Pocket Lab</a>
+        <a href="https://museum.pocketlab.build">Pocket Museum</a>
+      </span>
+      <span class="fgrp"><span class="fdot" aria-hidden="true">·</span>
+        <a href="${GH}" target="_blank" rel="noreferrer">GitHub</a>
+        <a href="${X_URL}" target="_blank" rel="noreferrer">X</a>
+        <a href="${DISCORD}" target="_blank" rel="noreferrer">Discord</a>
+      </span>
     </nav>
     <span class="hud">${SITE_FOOTER_DESC}</span>
   </div>

--- a/tests/site-stage.test.ts
+++ b/tests/site-stage.test.ts
@@ -227,6 +227,53 @@ test("every compatibility entry cites a receipt that resolves", () => {
 
   // Receipts, so they open in their own tab like the rest of the references.
   expect(readFileSync(ROOT + "site/assets/landing.js", "utf8")).toContain('[data-refs] a, .cgrid a');
+
+  // Keeping the hardware bootable is its own project, and the chapter says where.
+  expect(compat).toContain('<a class="olink" href="https://museum.pocketlab.build/"');
+});
+
+test("the Pocket Lab family is one click away from every page", () => {
+  const home = readFileSync(ROOT + "site/home.html", "utf8");
+  const templates = readFileSync(ROOT + "site/templates.ts", "utf8");
+  for (const source of [home, templates]) {
+    // Resources menu: the two sibling sites, in order.
+    expect(source).toMatch(
+      /<a href="https:\/\/pocketlab\.build">Lab<\/a>\s*\n\s*<a href="https:\/\/museum\.pocketlab\.build">Museum<\/a>/,
+    );
+    // Footer: the same pair in its own group rather than appended to a row of
+    // nine flat links.
+    expect(source).toMatch(
+      /<span class="fgrp"><span class="fdot" aria-hidden="true">·<\/span>\s*\n\s*<a href="https:\/\/pocketlab\.build">Pocket Lab<\/a>\s*\n\s*<a href="https:\/\/museum\.pocketlab\.build">Pocket Museum<\/a>/,
+    );
+    // Every divider opens a group instead of trailing one, so a wrapped footer
+    // never ends a line with a lone dot.
+    expect(source.match(/<span class="fdot"/g)).toHaveLength(2);
+    expect(source.match(/<span class="fgrp"><span class="fdot"/g)).toHaveLength(2);
+    expect(source.match(/<span class="fgrp">/g)).toHaveLength(3);
+    expect(source.match(/museum\.pocketlab\.build/g)?.length).toBeGreaterThanOrEqual(2);
+  }
+  const chromeCss = readFileSync(ROOT + "site/assets/chrome.css", "utf8");
+  expect(chromeCss).toContain(".foot .cols2 .fdot{");
+  expect(chromeCss).toContain(".foot .cols2 .fgrp{display:flex;");
+});
+
+test("the motion stage tells the reader which buttons change the study", () => {
+  const home = readFileSync(ROOT + "site/home.html", "utf8");
+  const hint = home.match(/<p class="stage-hint">([^<]+)<\/p>/);
+  expect(hint).not.toBeNull();
+  const line = hint![1];
+  // What the hint claims has to be what the guest app binds: left and right on
+  // the d-pad, or the two shoulders. Nothing else steps the studies.
+  const app = readFileSync(ROOT + "apps/motions/app.tsx", "utf8");
+  expect(app).toContain("onButtonPress(BTN.RIGHT | BTN.RTRIGGER");
+  expect(app).toContain("onButtonPress(BTN.LEFT | BTN.LTRIGGER");
+  expect(line).toContain("d-pad");
+  expect(line).toContain("L and R");
+  // It rides with the model: shown once the runtime is live, gone in the 2D
+  // fallback, where there is no model to press.
+  const landingCss = readFileSync(ROOT + "site/assets/landing.css", "utf8");
+  expect(landingCss).toContain(".pg-stage.is-ready .stage-hint{opacity:1}");
+  expect(landingCss).toContain(".pg-stage.has-error .stage-hint{display:none}");
 });
 
 test("the PSP stage looks straight at the screen", () => {


### PR DESCRIPTION
### Compatibility reads shorter, and cites the museum

The chapter's lede spent three clauses saying the list is not a roadmap. Now:

> Not a roadmap. Every entry below has booted the runtime on the real machine, and **what changes between them is one native submission layer, never the application**. Each links to the post or pull request that brought it up. Keeping the hardware bootable is its own work, so we started [Pocket Museum](https://museum.pocketlab.build/) to repair these machines and keep them running.

### Museum sits next to Lab

`Resources` → Lab, **Museum**, Playground, Changelog, in both the landing header and the shared chrome (`site/templates.ts`), so every page carries it.

### The footer is grouped instead of nine links long

Appending Pocket Museum to a flat row would have made ten items on one line. It is three groups now: this site, the Pocket Lab family, then the accounts, with a muted middle dot opening each group after the first.

The divider is the **first child of the group it opens**, not a sibling between groups: measured at 320–1440 px, a sibling dot ends up stranded at the end of a wrapped line at 320, 390 and 560 px. Grouped this way, 390 px renders three tidy lines, one per group, each later line led by its dot.

### The model says how to drive it

A line under the PSP names the controls that step the motion studies. It fades in with `is-ready` and is hidden under `has-error`, so it never appears over the 2D fallback where there are no buttons to press. `apps/motions/app.tsx` binds `BTN.RIGHT | BTN.RTRIGGER` and `BTN.LEFT | BTN.LTRIGGER`, and the test asserts both bindings alongside the hint's wording so the copy cannot drift from the app.

### Verification

- `bun test tests/site-stage.test.ts` → 15 pass / 318 expect(), including two new tests: the Pocket Lab family in both nav and footer with dividers that open their group, and the stage hint checked against the app's real bindings.
- `bun run site:build`, then headless Chrome over the built site: menu contents on the landing and on `/docs/overview/`, footer grouping at 320/390/480/560/640/700/760/820/900/1100/1440 px, and the hint under the booted model (`is-ready`, opacity 1, sitting 9 px below the viewport).
- `https://museum.pocketlab.build/` → 200, `<title>The Pocket Museum</title>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
