### PR TITLE
fix(fs): tolerate FatFS VFS limits in atomic dir writes

### DIFF
--- a/engine/crates/pocket-fs/src/lib.rs
+++ b/engine/crates/pocket-fs/src/lib.rs
@@ -571,10 +571,23 @@ fn dir_write(
     // directory, sync, then rename over the target (same filesystem —
     // cross-directory rename is atomic).
     std::fs::create_dir_all(tmp_dir).map_err(|e| e.to_string())?;
+    // The temp name must not collide with a leftover from a crash. Prefer
+    // create_new, but fall back to create+truncate: ESP-IDF's FATFS VFS
+    // fails O_EXCL opens with ENOENT, and the swept, module-owned tmp dir
+    // plus the monotonic counter still make the name unique.
     let mut suffix = tmp_counter;
     let (tmp, mut file) = loop {
         let candidate = tmp_dir.join(suffix.to_string());
-        match std::fs::OpenOptions::new().write(true).create_new(true).open(&candidate) {
+        let new = std::fs::OpenOptions::new().write(true).create_new(true).open(&candidate);
+        let opened = match new {
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => std::fs::OpenOptions::new()
+                .write(true)
+                .create(true)
+                .truncate(true)
+                .open(&candidate),
+            other => other,
+        };
+        match opened {
             Ok(file) => break (candidate, file),
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => suffix += 1,
             Err(e) => return Err(e.to_string()),
@@ -586,7 +599,21 @@ fn dir_write(
         .map_err(|e| e.to_string());
     drop(file);
     landed
-        .and_then(|()| std::fs::rename(&tmp, &full).map_err(|e| e.to_string()))
+        .and_then(|()| {
+            // FATFS f_rename refuses to overwrite an existing destination
+            // (surfaced as EEXIST); POSIX rename replaces it. Remove the
+            // stale target first when the filesystem requires it — the
+            // atomic-overwrite contract is not representable there.
+            match std::fs::rename(&tmp, &full) {
+                Ok(()) => Ok(()),
+                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                    std::fs::remove_file(&full)
+                        .and_then(|()| std::fs::rename(&tmp, &full))
+                        .map_err(|e| e.to_string())
+                }
+                Err(e) => Err(e.to_string()),
+            }
+        })
         .inspect_err(|_| {
             let _ = std::fs::remove_file(&tmp);
         })


### PR DESCRIPTION
## Problem

`dir_write`'s atomic-overwrite path assumes two POSIX behaviors that **ESP-IDF's FATFS VFS does not provide**, so every atomic write through the fs module fails on ESP32 targets with a FatFS-backed root:

- **O_EXCL opens fail with ENOENT** on the FATFS VFS, so the temp-file `create_new` call never succeeds and the write errors out before any payload lands.
- **FatFS `f_rename` refuses to overwrite an existing destination** (FR_EXIST, surfaced as EEXIST) where POSIX `rename` replaces it, so rewriting an existing file fails even after the temp file landed and synced.

## Fix

Both fallbacks arm only on the exact error kinds where the filesystem is known to diverge from POSIX:

- **Temp-file creation falls back to create+truncate on ENOENT.** The tmp dir is module-owned and swept, and the monotonic counter keeps the name unique, so losing O_EXCL costs nothing.
- **The final rename falls back to remove+rename on EEXIST.** The atomic-overwrite contract is not representable on FatFS, so the stale target is removed first.

**Behavior on POSIX filesystems is unchanged** — both fallback arms are unreachable there.

## Verification

- `cargo test -p pocket-fs` — **12/12 pass** on the host.
- Real hardware: Seeed reTerminal D1001 (**ESP32-P4, ESP-IDF v6.1, FatFS on SD over the VFS**) — `data.fs` writes and rewrites land and **persist across reboots**. Board-side receipts: [pocketjs-d1001 verification doc](https://github.com/Love4yzp/pocketjs-d1001/blob/master/docs/VERIFICATION.md).