### PR TITLE
docs: rewrite the README around the new landing chapters

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,69 +9,26 @@
 [Playground](https://pocketjs.dev/playground/) ·
 [Documentation](https://pocketjs.dev/docs/overview/) ·
 [Blog](https://pocketjs.dev/blog/) ·
-[Changelog](https://pocketjs.dev/changelog/)
+[Changelog](https://pocketjs.dev/changelog/) ·
+[Pocket Lab](https://pocketlab.build) ·
+[Pocket Museum](https://museum.pocketlab.build/)
 
-## Rich interactive JavaScript where no browser fits.
+## Keeps JSX, Tailwind and reactive state. Removes every layer below them.
 
-PocketJS is a compact runtime family for building **user interfaces, games,
-3D experiences, and AI-native applications** across radically different
-devices. Write familiar JavaScript and TypeScript components; native cores and
-host modules own layout, rendering, simulation, audio, and other per-frame work.
-
-Where a machine can host JavaScript, a small guest runs Solid, Vue Vapor, or
-Octane against those native cores. Where even a JavaScript engine is too much,
-[Pocket Vapor](./vapor/README.md) compiles a strict Vue Vapor program into
-native code. Neither path ships a browser DOM, browser layout engine, or
-runtime CSS engine.
+PocketJS is a UI runtime with **no DOM, no CSS engine and no WebView**. An app
+is a QuickJS guest on a Rust core that performs flexbox layout and draws every
+pixel itself, in **one thread inside one process**. The frameworks, the class
+strings and the reactive state stay the ones you already use; everything under
+them is replaced.
 
 <a href="https://pocketjs.dev">
   <img src="./site/assets/pocketjs-demo-wall.jpg" alt="A wall of PocketJS software: music, deep-zoom graphics, messaging, a digital character, galleries, DevTools, dashboards, media, and a café app, alongside OpenStrike, Pocket Voxel and Pocket Figma on PSP, including Motion Lab studies credited to yui540" />
 </a>
 
-## What it carries
+## Write components as you already do
 
-PocketJS is broader than a UI renderer. The PocketJS runtime family now carries
-four kinds of software, each backed by shipped open-source work.
-
-| Software | What PocketJS provides | Proof |
-| --- | --- | --- |
-| **User interfaces** | Solid, Vue Vapor, and Octane over one native tree, with flexbox, compile-time Tailwind, baked motion, touch, focus, and text input | [Three frameworks, one core](https://pocketjs.dev/blog/octane-on-psp/) |
-| **Games** | Scriptable native simulation and rendering cores composed with a full JSX HUD | [OpenStrike at 60 FPS on a real PSP](https://pocketjs.dev/blog/shipping-openstrike/) · [A creature-RPG as a voxel diorama](https://pocketjs.dev/blog/pocket-voxel/) |
-| **3D experiences** | Portable BSP worlds, native 3D backends, and VRM digital humans with one-process desktop surfaces | [Pocket Character](https://pocketjs.dev/blog/pocket-character/) |
-| **AI-native apps** | When time, randomness, and effects enter through the virtual clock, seeded state, and recorded contracts, fixed-step sessions can be replayed, forked, and diffed byte-for-byte; small enough to host an agent in the guest | [The runtime agents want](https://pocketjs.dev/blog/ui-runtime-that-cant-flake/) · [Pocket Pi](https://github.com/pocket-stack/pocket-pi) |
-
-## Run JavaScript where it fits. Compile it away where it doesn't.
-
-PocketJS has two execution paths. They share component-oriented authoring,
-explicit target demands, and verification tools; they do not pretend that one
-runtime or one binary fits every device.
-
-```text
-Solid / Vue Vapor / Octane
-        │
-        └─ Guest build ──> JavaScript guest ──> declared native APIs ──> Rust cores and renderers
-
-strict Vue Vapor subset
-        │
-        └─ Pocket Vapor ──> target-native C ──> ROM, firmware, or PDX
-```
-
-| | Guest runtime | Pocket Vapor AOT |
-| --- | --- | --- |
-| **Authoring** | Solid JSX, Vue Vapor JSX, Vue SFC, or Octane JSX | Strict TypeScript/Vue Vapor JSX subset |
-| **Execution** | JavaScript guest plus native cores and host modules | Native target program; no JS engine, GC, or allocator |
-| **Admission** | `pocket.json` requirements resolved against a target profile | Compiler-derived demands checked against a target or board profile |
-| **Outputs** | Target-specific bundles, assets, `.pocket` variants, EBOOTs, VPKs, and host packages | `.gba`, `.gb`, `.nes`, firmware, and `.pdx` artifacts |
-| **Current examples** | PSP, PS Vita, PocketBook, and macOS widget registered Guest profiles | Game Boy Advance, Game Boy, NES, ESP32 MeowBit, and Playdate compiler targets |
-
-Pocket Vapor is not a low-memory mode for arbitrary PocketJS apps. It is a
-deliberately strict Vue Vapor subset with its own compiler and target
-contracts. The current [`.pocket` format](./docs/PLATFORM.md) packages Guest
-target variants; AOT programs are built separately today.
-
-## Familiar code, native machinery
-
-Guest apps choose one of three framework adapters over the same native UI tree:
+Three frameworks compile to the same native tree and run on the same QuickJS
+guest, so the framework you pick changes your code and nothing below it.
 
 | Framework | State and lifecycle | Source forms |
 | --- | --- | --- |
@@ -81,10 +38,10 @@ Guest apps choose one of three framework adapters over the same native UI tree:
 
 Framework primitives come directly from `solid-js`, `vue`, or `octane`.
 PocketJS owns the runtime, host components, lifecycle wiring, input, animation,
-assets, and native boundary.
+assets, and the native boundary.
 
 ```tsx
-import { createSignal } from "solid-js";
+import { createSignal, Show } from "solid-js";
 import { mount } from "@pocketjs/framework/solid";
 import { Text, View } from "@pocketjs/framework/solid/components";
 
@@ -93,14 +50,17 @@ function Counter() {
 
   return (
     <View class="w-full h-full flex-col items-center gap-4 p-4 bg-slate-50">
-      <Text class="text-xl font-bold text-slate-950">Count: {count()}</Text>
+      <Text class="text-xl text-slate-950 font-bold">Count: {count()}</Text>
       <View
-        class="px-4 py-2 rounded-xl bg-blue-600 focus:bg-blue-500 active:bg-blue-700"
+        class="px-4 py-2 rounded-xl shadow-md bg-blue-600 focus:bg-blue-500"
         focusable
         onPress={() => setCount(count() + 1)}
       >
-        <Text class="text-base font-bold text-white">Press Circle</Text>
+        <Text class="text-base text-white font-bold">Press Circle</Text>
       </View>
+      <Show when={count() > 3}>
+        <Text class="text-sm text-emerald-600">Reactive on real hardware.</Text>
+      </Show>
     </View>
   );
 }
@@ -108,15 +68,217 @@ function Counter() {
 mount(() => <Counter />);
 ```
 
-Class literals compile into compact style records. The Rust core performs
-flexbox layout and emits the draw list; target backends render it through GE,
-GXM, wgpu, software rasterization, e-ink updates, or another declared host.
-There is no runtime CSS parser, cascade, or browser layout engine.
+Class literals compile into a baked style table at build time. There is no
+runtime CSS parser, cascade, or specificity resolution, and no reflow: the core
+lays out the tree and emits a draw list that the target backend submits through
+GE, GXM, Metal, wgpu, software rasterization, e-ink updates, or another declared
+host.
+
+```text
+PocketJS · 1 thread, 1 process
+  your component                        guest
+  renderer adapter                      guest
+  native tree                           core
+  flexbox layout, baked style table     core
+  drawlist                              core
+  backend draw                          core
+  → pixels
+
+Browser or WebView · 4 threads, 2 processes
+  your component                        main
+  framework runtime, vdom diff          main
+  dom mutation                          main
+  cssom, cascade, specificity           main
+  style recalculation                   main
+  layout, reflow                        main
+  paint records                         main
+  commit the layer tree across threads
+  layer tree, tiling compositor         compositor
+  queue raster tasks, invalidations     compositor
+  rasterization                         raster pool
+  ipc to the gpu process, sync fences
+  draw quads                            gpu
+  present                               gpu
+  → pixels
+```
+
+One bundle serves machines of different densities. The manifest declares what
+the app needs, and the target is checked against it before a build proceeds —
+from the app directory, against its `pocket.json`:
+
+```sh
+pocket check --target psp     # ok  480x272 · text.glyphs.baked · input.buttons
+pocket check --target vita    # ok  same bundle, density 2, no component edited
+```
 
 See [Frameworks](https://pocketjs.dev/docs/frameworks/),
-[Architecture](https://pocketjs.dev/docs/architecture/), and
-[Styling](https://pocketjs.dev/docs/styling/) for the supported forms and
-compile-time rules.
+[Architecture](https://pocketjs.dev/docs/architecture/) and
+[Styling](https://pocketjs.dev/docs/styling/).
+
+## Animation is compiled
+
+Keyframe timelines and spring curves are baked into the style table at build
+time and advanced by the Rust core on its own clock, so a screen can **animate
+with no per-frame JavaScript at all**. Motion Lab runs the yui540 studies in
+WebAssembly on [pocketjs.dev](https://pocketjs.dev), and on the handheld they
+were written for.
+
+| Baked keyframe timelines · (yui540) | 3D motion pipeline · (yui540) |
+| --- | --- |
+| ![Motion studies by yui540: menu, d-pad, share, hover, reload and keypad animations](./assets/screenshots/motions-53.gif) | ![3D motion studies by yui540: door, cubes, page flips and room transition](./assets/screenshots/motions-3d.gif) |
+
+## What it asks of the machine
+
+With no browser engine in the middle, the cost of a screen is close to what the
+bare metal can do. A whole PocketJS app drawing a smooth interface **lives in
+8 MB on a single 333 MHz core** — a quarter of the PSP's 32 MB, one part in 1536
+of a 12 GB iPhone 17 Pro Max, on a core clocked 13 times slower than an A19 Pro
+performance core at 4.26 GHz.
+
+Benchmarked on a Sony PSP — one MIPS core at 333 MHz, 32 MB of RAM, 2004
+hardware, against the 16.67 ms budget for 60 fps:
+
+| Measurement | Result |
+| --- | --- |
+| OpenStrike frame budget | **2.2 ms** of JavaScript, 8.4 ms of total CPU work, worst observed frame 9.7 ms |
+| Hero demo, why not just ship a virtual DOM | Solid 15.15 ms · Vue Vapor 16.74 ms · **Vue with a virtual DOM 90.75 ms** |
+| Hero demo, the three shipped frameworks | Solid 3.66 ms · Vue Vapor 3.61 ms · Octane 6.53 ms |
+
+Seven samples per app. The two hero-demo rows come from separate runs and the
+toolchain got faster in between, so read each on its own terms rather than
+across them.
+
+The same markdown editor, shelled three ways on an Apple M3 Max
+([full report](./docs/bench/gpui-vs-tauri-electron-2026-08-18.md), reproduce
+with `bun tools/bench-desktop.ts`):
+
+| | pocket | Tauri v2 | Electron |
+| --- | --- | --- | --- |
+| Processes | **1** | 4 | 5 |
+| Cold start to first painted frame | **149 ms** | 380 ms | 301 ms |
+| Idle resident memory | **83 MB** | 193 MB | 382 MB |
+| On disk | 10 MB | 9 MB | 242 MB |
+
+Left alone with a document open, the pocket build redraws **about twice a
+second**: the caret blinking, and nothing else. The report also records where
+the pocket build loses, and why — the storm CPU ramps with document length,
+because the note re-wraps the whole document through the QuickJS interpreter on
+every keystroke.
+
+Further reading: [Shipping OpenStrike](https://pocketjs.dev/blog/shipping-openstrike/) ·
+[Pocket Character](https://pocketjs.dev/blog/pocket-character/) ·
+[Twice the pixels, zero forks](https://pocketjs.dev/blog/pocketjs-on-ps-vita/) ·
+[The first iPhone](https://pocketjs.dev/blog/pocketjs-on-the-first-iphone/)
+
+## The frame contract
+
+Time is the frame counter. One `frame(buttons)` call is a transaction nothing
+outside it can interrupt, and nothing waits on a wall clock, so tests run as
+fast as the CPU allows without changing the timing they measure: a journey that
+takes six seconds in front of a user is a few dozen frames in CI.
+
+```text
+state n+1 = F(state n, input n)
+pixels n  = G(state n)
+```
+
+- **Effects land on frame boundaries.** A network reply that arrives partway
+  through frame +3 is queued, not applied. It is delivered at the start of
+  frame +4, in FIFO order, before any app hook runs. No microtask races, no
+  mid-frame callbacks, and `after()` replaces `setTimeout` with a deadline
+  measured in frames.
+- **The same async task lands on the same frame.** Driven by
+  `requestAnimationFrame` against a wall clock, one awaited confirmation lands
+  on **22 different frames** across 60 runs and its timing assertion passes
+  **9 times out of 60**. On the frame clock it lands on **frame 144 in every
+  run**, 60 out of 60.
+- **History is a data structure.** Tapes replay byte-for-byte, a session
+  subsampled to 2 Hz is byte-identical to its 60 Hz counterpart, and forking a
+  tape at frame 9 to splice in a different press produces a counterfactual
+  world in **22 ms**.
+- **Chaos mode proves the floor holds**, injecting real sleeps, allocation
+  churn and forced GC between frames without moving the trace by one bit.
+
+Further reading: [The runtime that can't flake](https://pocketjs.dev/blog/ui-runtime-that-cant-flake/) ·
+[Time-travel DevTools](https://pocketjs.dev/blog/time-travel-devtools/) ·
+[Determinism](./docs/DETERMINISM.md)
+
+## Beyond 2D UI: mount what the content needs
+
+PocketJS is an application runtime with a game engine's architecture, so a game
+and an app are built the same way. Cores are **independent native modules,
+loaded the way a kernel loads drivers**: an app takes the ones its content needs
+and the rest never enters the build. Adding one widens what the program is
+allowed to ask for; it never changes how the program is written.
+
+```text
+guest program · your JavaScript, one frame at a time
+  ui       tree, layout, draw, input, focus
+  net      poll batches
+  audio    pcm mixer
+  strike   bsp, bots, hits
+  voxel    chunks, meshing
+```
+
+Further reading: [Core concepts](https://pocketjs.dev/docs/concepts/) ·
+[The runtime family](./docs/RUNTIMES.md) ·
+[Pocket3D](./engine/pocket3d/README.md)
+
+## Compatibility: run on the metal, not emulated
+
+Not a roadmap. Every entry below has booted the runtime on the real machine, and
+what changes between them is one native submission layer, never the
+application. Keeping the hardware bootable is its own work, so we started
+[Pocket Museum](https://museum.pocketlab.build/) to repair these machines and
+keep them running.
+
+| Operating system | Native submission layer | Receipt |
+| --- | --- | --- |
+| PSP system software | MIPS, 32 MB | [Introducing PocketJS](https://pocketjs.dev/blog/introducing-pocketjs/) |
+| PS Vita system software | ARM, GXM | [Twice the pixels, zero forks](https://pocketjs.dev/blog/pocketjs-on-ps-vita/) |
+| iPhone OS 3.1.3 | ARMv6, GL ES 1.1 | [The first iPhone](https://pocketjs.dev/blog/pocketjs-on-the-first-iphone/) |
+| iOS 6.1.3 | ARMv7 | [`hosts/iphone4s`](./hosts/iphone4s) |
+| iOS 12.5.8 | arm64 | [#278](https://github.com/pocket-stack/pocketjs/pull/278) |
+| iOS, current | NativeScript host | [#256](https://github.com/pocket-stack/pocketjs/pull/256) |
+| macOS | Metal window and widget | [#293](https://github.com/pocket-stack/pocketjs/pull/293) |
+| Symbian Belle | Qt, GLES2 | [Symbian wanted a frame function](https://pocketjs.dev/blog/pocketjs-on-symbian/) |
+| Windows CE 6 | GDI framebuffer | [From message pump to multitouch](https://pocketjs.dev/blog/pocketjs-on-windows-ce/) |
+| BlackBerry 10.3 | QNX, native ELF | [One square screen, two native stacks](https://pocketjs.dev/blog/blackberry-classic/) |
+| Android 4.3 | BlackBerry runtime, JNI | [#298](https://github.com/pocket-stack/pocketjs/pull/298) |
+| PocketBook e-ink | inkview, partial refresh | [#172](https://github.com/pocket-stack/pocketjs/pull/172) |
+| ESP-IDF | RGB565 and PPA | [#160](https://github.com/pocket-stack/pocketjs/pull/160) |
+| The browser | WebAssembly core | [Playground](https://pocketjs.dev/playground/) |
+
+Devices it has booted on: **Sony PSP** (2004) · **PS Vita** (2011) ·
+**iPhone** (2007) · **iPhone 4S** (2011) · **iPod touch 6** (2015) ·
+**Nokia E7** (2011) · **Meizu M8** (2009) · **BlackBerry Classic** (2014) ·
+**PocketBook reader** (e-ink) · **ESP32-P4 devkit** (microcontroller) ·
+**Mac** (Apple silicon).
+
+The authoritative host and target inventory lives in
+[`contracts/spec/platforms.ts`](./contracts/spec/platforms.ts); an entry there
+records what has been verified and how. See
+[Platform contracts](https://pocketjs.dev/docs/platform-contracts/) and the
+[Native contract](https://pocketjs.dev/docs/native-contract/).
+
+## Shipped on the runtime
+
+| Project | What it carries |
+| --- | --- |
+| [**OpenStrike**](https://pocketjs.dev/blog/shipping-openstrike/) | A Counter-Strike-shaped shooter on 2004 hardware: BSP maps, bots, and a HUD written in Solid JSX, at 60 fps with 2.2 ms of JavaScript per frame |
+| [**Pocket Voxel**](https://pocketjs.dev/blog/pocket-voxel/) | A creature-RPG town rebuilt as a walking voxel diorama. Game state lives in the JS guest; logic runs at 60 Hz while presentation holds a locked 30 fps beat |
+| [**Pocket Figma**](https://pocketjs.dev/blog/pocket-figma/) | A real 14,430-node design file, cooked into streamed tile pyramids and panned with the analog nub at 60 fps on a handheld with 32 MB of RAM |
+| [**Pocket Character**](https://pocketjs.dev/blog/pocket-character/) | A rigged VRM companion in a transparent always-on-top window, rendering skinned 3D at 60 fps in one process and 118 MB, against 8 processes and 2184 MB for the Electron build of the same idea |
+| [**Pocket YouTube**](https://pocketjs.dev/blog/pocket-youtube/) | Search, thumbnails, playback and seeking on a console that predates streaming, where the network is a USB cable and a Mac companion does the fetching |
+| [**Pocket DevTools**](https://pocketjs.dev/blog/time-travel-devtools/) | Time-travel debugging over a USB cable at 2 bytes per frame. The inspector highlight is emitted by the core into the draw list, so it renders on the device, on every backend |
+| [**Pocket Launcher**](./docs/LAUNCHER.md) | Whole-app lifecycle, target admission, frozen shots, and guest switching on PSP and Vita |
+| [**Pocket Pi**](https://github.com/pocket-stack/pocket-pi) | A coding agent running inside the QuickJS guest environment, with no Node underneath |
+
+<p align="center">
+  <a href="https://github.com/pocket-stack/pocket-voxel"><img src="./site/assets/blog/voxel-psp-pallet-town.png" width="720" alt="Pocket Voxel on a real PSP: Pallet Town as a voxel diorama with gabled roofs, carved bushes, flowers, an NPC and the player on the path, in per-tile color." /></a>
+</p>
+
+<p align="center"><em>Pocket Voxel, captured on a PSP-2000: the flat Game Boy world standing up as geometry. <a href="https://pocketjs.dev/blog/pocket-voxel/">The making-of story</a>.</em></p>
 
 ## Try it
 
@@ -144,93 +306,26 @@ pocket build --target psp --manifest apps/my-app/pocket.json -- --release
 ```
 
 Vita packaging additionally needs VitaSDK and the pinned Rust toolchain
-documented in [`hosts/vita/README.md`](./hosts/vita/README.md).
+documented in [`hosts/vita/README.md`](./hosts/vita/README.md). Guest builds can
+be packaged as inspectable, target-thinnable
+[`.pocket` files](./docs/PLATFORM.md) instead of ad hoc port directories.
 
-To explore Pocket Vapor without a device:
+## Machines without a JavaScript engine
+
+Where even QuickJS is too much, [Pocket Vapor](./vapor/README.md) compiles a
+strict Vue Vapor subset ahead of time into target-native C: `.gba`, `.gb`,
+`.nes`, ESP32 firmware, and Playdate `.pdx` artifacts, with no JS engine, GC, or
+allocator on the device. It is a separate compiler with its own target and board
+contracts, not a low-memory mode for arbitrary PocketJS apps.
 
 ```sh
-bun run vapor:dev             # run the component on the real Vue oracle in a browser
-bun run vapor:check           # show target admission and lossy lowering
+bun run vapor:dev             # run the component against the real Vue oracle in a browser
 bun run vapor:test            # oracle + compiler + console parity suites
 bun vapor/compiler/cli.ts vapor/examples/todo/todo.tsx --target gb
 ```
 
-## The platform around the program
-
-- **Capability contracts.** An app declares its viewport and required or
-  optional APIs. A target must satisfy that contract before compilation and
-  packaging continue.
-- **Deterministic packages.** Guest builds can become inspectable, verifiable,
-  and target-thinnable `.pocket` files instead of ad hoc port directories.
-- **System software.** The framework and supporting hosts provide a multi-app
-  launcher, focus and touch input, gesture physics, OSK and text editing,
-  credit-based PCM audio, and explicit host-service boundaries.
-- **Replayable time.** When time, randomness, and effects enter through the
-  virtual clock, seeded state, and recorded contracts, tapes and traces can
-  reproduce sessions byte-for-byte.
-- **Specialized native cores.** UI, 3D, and game systems expose small declared
-  APIs to the product guest while keeping hot state and per-frame work native.
-
-Start with [Platform contracts](https://pocketjs.dev/docs/platform-contracts/),
-[The `.pocket` platform](./docs/PLATFORM.md),
-[The runtime family](./docs/RUNTIMES.md), and
-[Determinism](./docs/DETERMINISM.md).
-
-## The proof is what it can carry
-
-| Project | What it proves |
-| --- | --- |
-| [**Pocket Launcher**](./docs/LAUNCHER.md) | Whole-app lifecycle, target admission, frozen shots, and Guest switching on PSP and Vita |
-| [**OpenStrike**](https://github.com/pocket-stack/open-strike) | A scriptable FPS core, portable BSP worlds, and a Solid HUD at a locked 60 FPS on real PSP hardware |
-| [**Pocket Voxel**](https://github.com/pocket-stack/pocket-voxel) | A ROM-fed Game Boy creature-RPG as a walking voxel diorama: the whole game state lives in the TypeScript Guest over a Rust scene core, at a locked 30 FPS on real PSP hardware |
-| [**Pocket Figma**](https://github.com/pocket-stack/pocket-figma) | A 14,430-node Figma document baked into streamed tiles for pan and zoom on a PSP |
-| [**Pocket YouTube**](https://github.com/pocket-stack/pocket-youtube) | USB host services, search, video, audio, seeking, CJK text, and a system keyboard on a PSP |
-| [**Pocket Character**](https://github.com/pocket-stack/pocket-character) | A VRM digital human in one native transparent desktop process instead of an Electron stage |
-| [**Pocket Vapor Todo**](./vapor/README.md) | A strict Vue Vapor program lowered to console ROMs and firmware, checked step-by-step against a real Vue oracle |
-| [**Pocket Pi**](https://github.com/pocket-stack/pocket-pi) | A coding agent running inside the QuickJS Guest environment without Node underneath |
-
-<p align="center">
-  <a href="https://github.com/pocket-stack/pocket-voxel"><img src="./site/assets/blog/voxel-psp-pallet-town.png" width="720" alt="Pocket Voxel on a real PSP: Pallet Town as a voxel diorama with gabled roofs, carved bushes, flowers, an NPC and the player on the path, in per-tile color." /></a>
-</p>
-
-<p align="center"><em>Pocket Voxel, captured on a PSP-2000: the flat Game Boy world standing up as geometry. <a href="https://pocketjs.dev/blog/pocket-voxel/">The making-of story</a>.</em></p>
-
-## Platforms and evidence
-
-Target status is evidence-specific. A registry entry, an emulator parity suite,
-a hardware protocol receipt, and a manual screen check prove different things.
-
-| Platform or host | Path | Current evidence |
-| --- | --- | --- |
-| **Sony PSP** | Registered Guest profile | Real-hardware applications plus PPSSPP input journeys and frame goldens |
-| **PS Vita** | Registered Guest profile | Real-hardware install, boot, GXM presentation, controller, and interactive flows; Vita3K-driven 960×544 CPU pixel oracle plus GXM texture/font residency checks |
-| **PocketBook** | Registered Guest profile | Hardware boot, rendering, centering, and animated partial refresh; broader input and panel acceptance remains in progress |
-| **macOS widget** | Registered Guest profile | Dynamic native window, pointer, keyboard/IME, clipboard, and runtime glyph paths |
-| **Browser, desktop, headless Bun** | Guest development and verification hosts | WASM/native rendering, interactive development, deterministic simulation, and image goldens |
-| **Nokia E7 / Symbian** | Hardware-tested development Guest host | SIS install, launch, visible rendering, keys, and rotation on the reference device; not a production target profile |
-| **iOS (NativeScript host)** | Development Guest host | Simulator boot, rendering, touch, and the guest↔host service round trip in both guest modes (sidecar realm and the NativeScript runtime as guest engine); not a production target profile |
-| **GBA, Game Boy, NES** | Pocket Vapor AOT | Per-interaction emulator parity against the Vue oracle, including logical characters and styles |
-| **ESP32 MeowBit** | Pocket Vapor AOT | Optional physical-board UART replay verifies the logical grid and exercises LCD commits; it neither reads panel pixels nor actuates GPIO buttons |
-| **Playdate** | Pocket Vapor AOT | Native-boundary tests and Simulator/device package smoke; physical display and input acceptance remains manual |
-| **ESP32-P4** | Native renderer integration | Reusable RGB565/PPA backend and ESP-IDF component smoke; not a stock application target |
-
-The authoritative Guest inventory lives in
-[`contracts/spec/platforms.ts`](./contracts/spec/platforms.ts). Pocket Vapor
-uses compiler-side target and board contracts instead; see
-[`vapor/DESIGN.md`](./vapor/DESIGN.md). Recent machine-family work and its exact
-validation level are tracked in the [changelog](https://pocketjs.dev/changelog/).
-
-## Choose a path
-
-| Goal | Start here |
-| --- | --- |
-| Build a Guest application | [Getting started](https://pocketjs.dev/docs/getting-started/) |
-| Compare Solid, Vue Vapor, Vue SFC, and Octane | [Frameworks](https://pocketjs.dev/docs/frameworks/) |
-| Compile for machines without a JS engine | [Pocket Vapor](./vapor/README.md) |
-| Add or embed a native host | [Native contract](https://pocketjs.dev/docs/native-contract/) · [Platform contracts](https://pocketjs.dev/docs/platform-contracts/) |
-| Build a game or specialized runtime | [Runtime family](./docs/RUNTIMES.md) · [Pocket3D](./engine/pocket3d/README.md) |
-| Debug, replay, and verify | [DevTools](./docs/DEVTOOLS.md) · [Determinism](./docs/DETERMINISM.md) |
-| Browse complete examples | [`apps/`](./apps/) · [PocketJS blog](https://pocketjs.dev/blog/) |
+Compiler-derived demands are checked against a target or board profile before
+lowering; see [`vapor/DESIGN.md`](./vapor/DESIGN.md).
 
 ## Repository map
 
@@ -242,8 +337,9 @@ validation level are tracked in the [changelog](https://pocketjs.dev/changelog/)
 | [`hosts/`](./hosts/) | PSP, Vita, web, desktop, e-reader, phone, and MCU host integrations |
 | [`vapor/`](./vapor/) | Pocket Vapor compiler, oracle, board contracts, target runtimes, and parity harnesses |
 | [`apps/`](./apps/) | Framework demos and system applications used by the launcher and acceptance suites |
-| [`tools/`](./tools/) | Build, package, launcher, device, DevTools, and release commands |
+| [`tools/`](./tools/) | Build, package, launcher, device, DevTools, benchmark, and release commands |
 | [`tests/`](./tests/) | Contract, compiler, simulation, emulator, package, and golden verification |
+| [`docs/`](./docs/) | Platform, runtime, determinism, DevTools, backend, and benchmark records |
 
 Common repository checks (emulator journeys require their external toolchains):
 
@@ -255,11 +351,14 @@ bun run e2e:vita              # Vita3K native-density journey
 bun run site:build            # docs, playground, Stage, and landing build
 ```
 
-## Motion Lab attribution
+## Who builds this
 
-| Baked keyframe timelines · (yui540) | 3D motion pipeline · (yui540) |
-| --- | --- |
-| ![Motion studies by yui540: menu, d-pad, share, hover, reload and keypad animations](./assets/screenshots/motions-53.gif) | ![3D motion studies by yui540: door, cubes, page flips and room transition](./assets/screenshots/motions-3d.gif) |
+[Pocket Lab](https://pocketlab.build) is an independent, non-VC-backed
+organization built on this runtime, so that the joy of creating belongs to
+everyone. Development is funded by
+[sponsors](https://github.com/sponsors/doodlewind).
+
+## Motion Lab attribution
 
 The original motion studies are by [yui540](https://yui540.com/). PocketJS
 accepts yui540's two stated conditions for continued use: Motion Lab carries


### PR DESCRIPTION
## What

The homepage was rebuilt around what the runtime removes (#311, #313, #315, #316, #317, #323); the README still opened on the old *runtime family / four kinds of software / two execution paths* framing. This re-orders the README on the landing's chapters.

| README section | Landing chapter |
| --- | --- |
| Keeps JSX, Tailwind and reactive state. Removes every layer below them. | Hero |
| Write components as you already do | Modern DX — three frameworks, `pocket check`, component-to-pixel stack vs a browser's |
| Animation is compiled | Motion |
| What it asks of the machine | Performance — PSP frame budget, markdown editor three ways |
| The frame contract | Architecture — frame transaction, pure fold, flake histogram, subsampling |
| Beyond 2D UI: mount what the content needs | Beyond 2D UI |
| Compatibility: run on the metal, not emulated | Compatibility |
| Shipped on the runtime | Ecosystem |
| Who builds this | Pocket Lab |

## Fixes along the way

- **`bun run vapor:check` does not exist** as a package script. Pocket Vapor shrinks to one section ("Machines without a JavaScript engine") using `vapor:dev`, `vapor:test`, and `bun vapor/compiler/cli.ts … --target gb`.
- Desktop numbers now come from [`docs/bench/gpui-vs-tauri-electron-2026-08-18.md`](https://github.com/pocket-stack/pocketjs/blob/main/docs/bench/gpui-vs-tauri-electron-2026-08-18.md) (149/380/301 ms cold start, 83/193/382 MB idle RSS, 1/4/5 processes, 10/9/242 MB on disk), with the report and `bun tools/bench-desktop.ts` linked, including where the pocket build loses.
- The platform table becomes per-entry receipts — the post or the pull request that brought each machine up (#278, #256, #293, #298, #172, #160) — with `contracts/spec/platforms.ts` still named as the authoritative inventory.
- `pocket check` snippet now says it runs from the app directory against its `pocket.json` (the CLI's `--manifest` default).

## Verification

- All 28 repo-relative paths in the README resolve on disk; every `pocketjs.dev` blog and docs slug used exists in `site/nav.ts`.
- Rendered through GitHub's own `/markdown` API locally and read end to end: 7 tables, 18 fenced blocks, both `text` diagrams and the images render.
- Prose scanned against the CLAUDE.md documentation red lines (no slogans, imported jargon, or empty intensifiers).

Docs only — no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)