### PR TITLE
ci: extract reusable validation workflow shared by PR CI and release …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+# PR CI — runs validation on every pull request targeting main.
+# Cancels superseded runs on the same PR to save minutes.
+
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    uses: ./.github/workflows/validate.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,16 @@ permissions:
   id-token: write # npm --provenance
 
 jobs:
+# ── Shared validation (reusable workflow) ─────────────────────────
+# Runs the same gates as PR CI.  Defined once in validate.yml so the
+# two callers cannot drift apart.
+validate:
+  uses: ./.github/workflows/validate.yml
+
   publish:
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    needs: [validate]
     steps:
       - uses: actions/checkout@v7
 
@@ -50,57 +57,6 @@ jobs:
       - name: Upgrade npm for Trusted Publishing
         run: npm install -g npm@latest
 
-      # hosts/web/pocketjs.wasm is a gitignored build artifact shipped in the
-      # framework tarball, so build it from engine/core/wasm. Stable Rust suffices.
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          targets: wasm32-unknown-unknown
-
-      - name: Cache cargo + wasm target
-        uses: actions/cache@v6
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            engine/wasm/target
-          key: ${{ runner.os }}-wasm-${{ hashFiles('engine/wasm/Cargo.toml', 'engine/core/Cargo.toml', 'engine/wasm/src/**', 'engine/core/src/**') }}
-          restore-keys: ${{ runner.os }}-wasm-
-
-      - name: Install dependencies
-        run: bun install --frozen-lockfile
-
-      - name: Build wasm (core + software rasterizer)
-        run: bun tools/wasm.ts
-
-      - name: Test JavaScript and package contracts
-        run: bun run test
-
-      # The app build at the start of `bun run test` generates the local style
-      # module that TypeScript intentionally imports.
-      - name: Typecheck
-        run: bunx tsc --noEmit
-
-      - name: Test Rust core
-        run: cargo test --locked --manifest-path engine/core/Cargo.toml
-
-      - name: Test desktop 3D and widget workspace
-        run: cargo test --locked --manifest-path engine/Cargo.toml --workspace
-
-      # The bridge is a standalone workspace because only its device build
-      # needs nightly build-std. Host tests stay stable-compatible.
-      - name: Test Symbian bridge
-        run: cargo test --locked --manifest-path engine/symbian/Cargo.toml
-
-      - name: Test renderer goldens
-        run: bun tests/golden.ts
-
-      - name: Test deterministic tape replay
-        run: bun run tape:check
-
-      - name: Build documentation and public schema
-        run: |
-          bun run site:build
-          cmp contracts/schema/pocket-2.json site/dist/schema/pocket-2.json
 
       - name: Publish @pocketjs/framework
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,237 @@
+# Reusable validation workflow — called by both CI (pull_request) and
+# Release (tag push / workflow_dispatch). Every hermetic test gate that
+# matters before merge lives here so the logic is defined once and cannot
+# drift between the two callers.
+#
+# Job layout:
+#   wasm        → builds pocketjs.wasm, uploads as artifact
+#   js          → bun test + tsc (downloads wasm artifact)
+#   rust-*      → cargo test for core / workspace / symbian (independent)
+#   goldens     → renderer golden comparison (downloads wasm artifact)
+#   tape        → deterministic tape replay (downloads wasm artifact)
+#   docs        → site build + schema parity (downloads wasm artifact)
+
+name: Validate
+
+on:
+  workflow_call:
+
+permissions:
+  contents: read
+
+jobs:
+  # ── Shared wasm build ──────────────────────────────────────────────
+  wasm:
+    name: Build wasm
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Cache cargo + wasm target
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            engine/wasm/target
+          key: ${{ runner.os }}-wasm-${{ hashFiles('engine/wasm/Cargo.toml', 'engine/core/Cargo.toml', 'engine/wasm/src/**', 'engine/core/src/**') }}
+          restore-keys: ${{ runner.os }}-wasm-
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build wasm (core + software rasterizer)
+        run: bun tools/wasm.ts
+
+      - name: Upload wasm artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: pocketjs-wasm
+          path: hosts/web/pocketjs.wasm
+          retention-days: 1
+
+  # ── JavaScript: install, test, typecheck ───────────────────────────
+  js:
+    name: JavaScript & TypeScript
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [wasm]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Download wasm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pocketjs-wasm
+          path: hosts/web
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test JavaScript and package contracts
+        run: bun run test
+
+      # The app build at the start of `bun run test` generates the local
+      # style module that TypeScript intentionally imports.
+      - name: Typecheck
+        run: bunx tsc --noEmit
+
+  # ── Rust: core, workspace, Symbian bridge ──────────────────────────
+  # These jobs are independent — they do not need the wasm artifact.
+  rust:
+    name: Rust (${{ matrix.label }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - label: core
+            manifest: engine/core/Cargo.toml
+            workspace: false
+            cache-target: engine/core/target
+          - label: workspace
+            manifest: engine/Cargo.toml
+            workspace: true
+            cache-target: engine/target
+          - label: symbian
+            manifest: engine/symbian/Cargo.toml
+            workspace: false
+            cache-target: engine/symbian/target
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache Cargo registry and build
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            ${{ matrix.cache-target }}
+          key: ${{ runner.os }}-rust-${{ matrix.label }}-${{ hashFiles('engine/**/Cargo.toml', 'engine/**/Cargo.lock', 'engine/**/src/**') }}
+          restore-keys: ${{ runner.os }}-rust-${{ matrix.label }}-
+
+      - name: Test Rust (${{ matrix.label }})
+        run: >
+          cargo test --locked --manifest-path ${{ matrix.manifest }}
+          ${{ matrix.workspace && '--workspace' || '' }}
+
+  # ── Renderer golden image comparison ───────────────────────────────
+  goldens:
+    name: Renderer goldens
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [wasm]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Download wasm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pocketjs-wasm
+          path: hosts/web
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test renderer goldens
+        run: bun tests/golden.ts
+
+  # ── Deterministic tape replay ──────────────────────────────────────
+  tape:
+    name: Tape replay
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    needs: [wasm]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Download wasm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pocketjs-wasm
+          path: hosts/web
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Test deterministic tape replay
+        run: bun run tape:check
+
+  # ── Documentation & schema parity ──────────────────────────────────
+  docs:
+    name: Docs & schema
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    needs: [wasm]
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Cache Bun dependencies
+        uses: actions/cache@v6
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-${{ hashFiles('bun.lock') }}
+          restore-keys: ${{ runner.os }}-bun-
+
+      - name: Download wasm artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: pocketjs-wasm
+          path: hosts/web
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Build documentation and public schema
+        run: |
+          bun run site:build
+          cmp contracts/schema/pocket-2.json site/dist/schema/pocket-2.json


### PR DESCRIPTION
## Summary

Extract the test gates that were inlined in `release.yml` into a reusable
workflow (`validate.yml`) called by both a new PR CI workflow (`ci.yml`)
and the release workflow. This addresses the feedback on #303.

## Fixes from #303

| Problem | Fix |
|---------|-----|
| `wasm32-unknown-unknown` not installed — `js` job and all downstream jobs fail | Dedicated `wasm` job installs the target via `dtolnay/rust-toolchain@stable`, uploads the artifact, and downstream jobs download it |
| Rust matrix compares boolean `true` with string `"true"` — `--workspace` silently dropped, wrong cache path | Moved `cache-target` into the matrix `include` list; use `matrix.workspace && '--workspace' \|\| ''` directly |
| `checkout@v4` / `cache@v4` drifted from `release.yml` | All actions bumped to `v7` / `v6` to match |
| Validation logic duplicated between CI and release | Single `validate.yml` called by both `ci.yml` and `release.yml` |

## Job graph
wasm ──┬── js (bun test + tsc)
```text
├── goldens

   ├── tape

   └── docs
 ```
 rust (core / workspace / symbian) ← independent, no wasm needed 
 
 ## Not included (by design)

- PSP EBOOT / Vita VPK / Symbian E7 builds — require proprietary toolchains
- These remain validated only through the release workflow and manual evidence

Closes #182. 