### PR TITLE
docs(site): remove Pocket Lab and Museum links

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@
 [Playground](https://pocketjs.dev/playground/) ·
 [Documentation](https://pocketjs.dev/docs/overview/) ·
 [Blog](https://pocketjs.dev/blog/) ·
-[Changelog](https://pocketjs.dev/changelog/) ·
-[Pocket Lab](https://pocketlab.build) ·
-[Pocket Museum](https://museum.pocketlab.build/)
+[Changelog](https://pocketjs.dev/changelog/)
 
 PocketJS is a portable application runtime that turns modern component code into
 native pixels across radically different hardware. Solid, Vue Vapor and Octane
@@ -256,8 +254,7 @@ See also: [Core concepts](https://pocketjs.dev/docs/concepts/) ·
 PocketJS has booted on every operating system below, on the real machine. What
 changes between them is one native submission layer, never the application, and
 each row links to the post or pull request that brought it up. Keeping the
-hardware bootable is its own work, tracked in
-[Pocket Museum](https://museum.pocketlab.build/).
+hardware bootable is its own work, tracked in Pocket Museum.
 
 | Operating system | Native submission layer | Receipt |
 | --- | --- | --- |
@@ -398,9 +395,8 @@ bun run site:build            # docs, playground, Stage, and landing build
 
 ## Project
 
-[Pocket Lab](https://pocketlab.build) is an independent, non-VC-backed
-organization built on this runtime, so that the joy of creating belongs to
-everyone. Development is funded by
+Pocket Lab is an independent, non-VC-backed organization built on this runtime,
+so that the joy of creating belongs to everyone. Development is funded by
 [sponsors](https://github.com/sponsors/doodlewind).
 
 ## Attribution

--- a/site/assets/chrome.css
+++ b/site/assets/chrome.css
@@ -52,10 +52,10 @@
 .foot .wrap{display:flex;flex-wrap:wrap;gap:1.4rem;justify-content:space-between;align-items:center}
 .foot .cols2{display:flex;gap:1.3rem;flex-wrap:wrap;font-family:var(--mono);font-size:.72rem;color:var(--ink-2)}
 .foot .cols2 a:hover{color:var(--ph)}
-/* The row carries three groups: this site, the Pocket Lab family, then the
-   accounts. A muted dot marks each boundary, so the footer stays one line of
-   links instead of growing headings. The dot is the first child of the group it
-   opens, so wrapping can never leave one stranded at the end of a line. */
+/* The row carries two groups: this site, then the accounts. A muted dot marks
+   the boundary, so the footer stays one line of links instead of growing
+   headings. The dot is the first child of the group it opens, so wrapping can
+   never leave one stranded at the end of a line. */
 .foot .cols2 .fgrp{display:flex;gap:1.3rem;flex-wrap:wrap;align-items:baseline}
 .foot .cols2 .fdot{color:var(--muted);opacity:.6}
 

--- a/site/home.html
+++ b/site/home.html
@@ -22,8 +22,6 @@
           <svg width="9" height="9" viewBox="0 0 10 10" aria-hidden="true"><path d="M1 3l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
         <div class="menu-list">
-          <a href="https://pocketlab.build">Lab</a>
-          <a href="https://museum.pocketlab.build">Museum</a>
           <a href="/playground/">Playground</a>
           <a href="/changelog/">Changelog</a>
         </div>
@@ -536,10 +534,8 @@
     </div>
     <p class="slede">PocketJS has booted on every operating system below, on the real machine, and
       <b>what changes between them is one native submission layer, never the application</b>. Each entry links
-      to the post or pull request that brought it up. Keeping the hardware bootable is its own work, so we
-      started
-      <a class="olink" href="https://museum.pocketlab.build/" target="_blank" rel="noreferrer">Pocket Museum</a>
-      to repair these machines and keep them running.</p>
+      to the post or pull request that brought it up. Keeping the hardware bootable is its own work, so the
+      Pocket Museum project repairs these machines and keeps them running.</p>
     <div class="cols" style="grid-template-columns:minmax(0,1fr) minmax(0,1fr)">
       <div class="cpanel">
         <span class="lb">operating systems</span>
@@ -656,7 +652,6 @@
           that <strong>the joy of creating belongs to everyone</strong>.</p>
       </div>
       <div class="labctas">
-        <a class="btn btn--pri" href="https://pocketlab.build">Visit Pocket Lab</a>
         <a class="btn btn--sec" href="https://github.com/pocket-stack/pocketjs">Star on GitHub</a>
       </div>
     </div>
@@ -696,10 +691,6 @@
         <a href="/playground/">Playground</a>
         <a href="/blog/">Blog</a>
         <a href="/changelog/">Changelog</a>
-      </span>
-      <span class="fgrp"><span class="fdot" aria-hidden="true">·</span>
-        <a href="https://pocketlab.build">Pocket Lab</a>
-        <a href="https://museum.pocketlab.build">Pocket Museum</a>
       </span>
       <span class="fgrp"><span class="fdot" aria-hidden="true">·</span>
         <a href="https://github.com/pocket-stack/pocketjs" target="_blank" rel="noreferrer">GitHub</a>

--- a/site/templates.ts
+++ b/site/templates.ts
@@ -105,8 +105,6 @@ function header(active: string): string {
           <svg width="9" height="9" viewBox="0 0 10 10" aria-hidden="true"><path d="M1 3l4 4 4-4" fill="none" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </button>
         <div class="menu-list">
-          <a href="https://pocketlab.build">Lab</a>
-          <a href="https://museum.pocketlab.build">Museum</a>
           <a href="/playground/">Playground</a>
           <a href="/changelog/">Changelog</a>
         </div>
@@ -128,10 +126,6 @@ const footer = `<footer class="foot">
         <a href="/playground/">Playground</a>
         <a href="/blog/">Blog</a>
         <a href="/changelog/">Changelog</a>
-      </span>
-      <span class="fgrp"><span class="fdot" aria-hidden="true">·</span>
-        <a href="https://pocketlab.build">Pocket Lab</a>
-        <a href="https://museum.pocketlab.build">Pocket Museum</a>
       </span>
       <span class="fgrp"><span class="fdot" aria-hidden="true">·</span>
         <a href="${GH}" target="_blank" rel="noreferrer">GitHub</a>

--- a/tests/site-stage.test.ts
+++ b/tests/site-stage.test.ts
@@ -167,8 +167,8 @@ test("homepage ships the four-chapter landing", () => {
   const gen = readFileSync(ROOT + "tools/sponsors.ts", "utf8");
   expect(gen).toContain("includePrivate: false");
 
-  // Closing band: Pocket Lab, plus the two calls to action.
-  expect(home).toContain("https://pocketlab.build");
+  // Closing band: project provenance plus the remaining external call to action.
+  expect(home).toContain("Pocket Lab");
   expect(home).toContain("Star on GitHub");
   expect(home).toContain("See use cases");
 
@@ -230,29 +230,24 @@ test("every compatibility entry cites a receipt that resolves", () => {
   // Receipts, so they open in their own tab like the rest of the references.
   expect(readFileSync(ROOT + "site/assets/landing.js", "utf8")).toContain('[data-refs] a, .cgrid a');
 
-  // Keeping the hardware bootable is its own project, and the chapter says where.
-  expect(compat).toContain('<a class="olink" href="https://museum.pocketlab.build/"');
+  // Keeping the hardware bootable is its own project, without linking away.
+  expect(compat).toContain("Pocket Museum project repairs these machines");
 });
 
-test("the Pocket Lab family is one click away from every page", () => {
+test("Pocket Lab and Pocket Museum are not linked from the README or website", () => {
+  const readme = readFileSync(ROOT + "README.md", "utf8");
   const home = readFileSync(ROOT + "site/home.html", "utf8");
   const templates = readFileSync(ROOT + "site/templates.ts", "utf8");
+  for (const source of [readme, home, templates]) {
+    expect(source).not.toContain("https://pocketlab.build");
+    expect(source).not.toContain("https://museum.pocketlab.build");
+  }
   for (const source of [home, templates]) {
-    // Resources menu: the two sibling sites, in order.
-    expect(source).toMatch(
-      /<a href="https:\/\/pocketlab\.build">Lab<\/a>\s*\n\s*<a href="https:\/\/museum\.pocketlab\.build">Museum<\/a>/,
-    );
-    // Footer: the same pair in its own group rather than appended to a row of
-    // nine flat links.
-    expect(source).toMatch(
-      /<span class="fgrp"><span class="fdot" aria-hidden="true">·<\/span>\s*\n\s*<a href="https:\/\/pocketlab\.build">Pocket Lab<\/a>\s*\n\s*<a href="https:\/\/museum\.pocketlab\.build">Pocket Museum<\/a>/,
-    );
     // Every divider opens a group instead of trailing one, so a wrapped footer
     // never ends a line with a lone dot.
-    expect(source.match(/<span class="fdot"/g)).toHaveLength(2);
-    expect(source.match(/<span class="fgrp"><span class="fdot"/g)).toHaveLength(2);
-    expect(source.match(/<span class="fgrp">/g)).toHaveLength(3);
-    expect(source.match(/museum\.pocketlab\.build/g)?.length).toBeGreaterThanOrEqual(2);
+    expect(source.match(/<span class="fdot"/g)).toHaveLength(1);
+    expect(source.match(/<span class="fgrp"><span class="fdot"/g)).toHaveLength(1);
+    expect(source.match(/<span class="fgrp">/g)).toHaveLength(2);
   }
   const chromeCss = readFileSync(ROOT + "site/assets/chrome.css", "utf8");
   expect(chromeCss).toContain(".foot .cols2 .fdot{");


### PR DESCRIPTION
## Summary

- remove Pocket Lab and Pocket Museum links from the README
- remove both destinations from the homepage and shared site chrome
- replace the previous link-presence contract with a regression test that forbids both domains

## Validation

- `bun test tests/site-stage.test.ts`
- `bun run site:build`
- confirmed no matching links remain in `README.md` or generated `site/dist`