### PR TITLE
fix(types): restore the release typecheck gate

### DIFF
--- a/apps/clear/keyboard.tsx
+++ b/apps/clear/keyboard.tsx
@@ -44,7 +44,7 @@ export interface KeyboardHandlers {
 const LAYER_NAMES: readonly KbLayerName[] = ["lower", "upper", "numbers", "symbols"];
 
 export interface Keyboard {
-  view: unknown;
+  view: JSX.Element;
   /** Dock/undock the panel (animated). */
   setOpen(open: boolean): void;
   isOpen(): boolean;

--- a/apps/clear/lists-screen.tsx
+++ b/apps/clear/lists-screen.tsx
@@ -11,7 +11,7 @@ import { listRowColors } from "./palette.ts";
 import { ROW_H } from "./metrics.ts";
 
 export interface ListsScreen {
-  view: unknown;
+  view: JSX.Element;
   /** Full content height (rows only; the credit hangs above y 0). */
   height: number;
   canvas(): NodeMirror | null;

--- a/apps/clear/rows.tsx
+++ b/apps/clear/rows.tsx
@@ -4,7 +4,7 @@
 // motion goes through jump()/animate() — the only reactive state per slot is
 // its text, done-look and lift refs.
 
-import { shallowRef } from "vue";
+import { shallowRef, type ShallowRef } from "vue";
 import { Text, View, type NodeMirror } from "@pocketjs/framework/components";
 import { jump } from "@pocketjs/framework/animation";
 import { ROW_H } from "./metrics.ts";
@@ -20,7 +20,7 @@ export interface RowSlot {
   strike: NodeMirror | null;
   text: ReturnType<typeof shallowRef<string>>;
   done: ReturnType<typeof shallowRef<boolean>>;
-  lift: ReturnType<typeof shallowRef<number>>;
+  lift: ShallowRef<number>;
   todoId: number;
   /** Current resting y (display index * ROW_H). */
   y: number;

--- a/hosts/web/system-engine.d.ts
+++ b/hosts/web/system-engine.d.ts
@@ -1,0 +1,33 @@
+// Type surface of system-engine.js for the TS harness
+// (tests/web-system-host.test.ts). The .js stays plain ESM so the browser
+// loads it without a build step — the same split wasm-ops.d.ts documents.
+
+import type { ResolvedSystemPackage, ResolvedSystemPlan } from "../../framework/src/manifest/system.ts";
+
+/** Focus without scrolling, so a double-click cannot land on another surface. */
+export declare function focusCanvas(
+  canvas: { focus(options: { preventScroll: boolean }): void },
+): void;
+
+/** One-based compositor handles in installation order. */
+export declare function createSurfaceCatalog(
+  applications: readonly ResolvedSystemPackage[],
+): {
+  catalog: Map<number, ResolvedSystemPackage>;
+  surfaces: Record<string, number>;
+};
+
+/** Throws unless the plan is a web-app ABI 4 System the browser host can run. */
+export declare function validateSystemPlan(plan: ResolvedSystemPlan): void;
+
+export declare function mountPocketSystem(
+  canvas: unknown,
+  options?: {
+    planUrl?: string;
+    baseUrl?: string;
+    distBase?: string;
+    wasmUrl?: string;
+    instanceUrl?: string;
+    onLog?: (message: string) => void;
+  },
+): Promise<unknown>;

--- a/tests/web-system-host.test.ts
+++ b/tests/web-system-host.test.ts
@@ -25,6 +25,15 @@ async function resolvedWebSystem() {
   return result.plan;
 }
 
+/** The resolver hands back a deeply readonly plan. The rejection tests
+ *  deliberately corrupt a clone of one, so they need a writable view of it. */
+type Mutable<T> = T extends object ? { -readonly [K in keyof T]: Mutable<T[K]> } : T;
+type WebSystemPlan = Awaited<ReturnType<typeof resolvedWebSystem>>;
+
+async function corruptibleWebSystem(): Promise<Mutable<WebSystemPlan>> {
+  return structuredClone(await resolvedWebSystem()) as Mutable<WebSystemPlan>;
+}
+
 describe("browser Pocket System host", () => {
   test("focusing the canvas cannot move a double-click onto another surface", () => {
     let options: FocusOptions | undefined;
@@ -51,11 +60,11 @@ describe("browser Pocket System host", () => {
   });
 
   test("rejects child companions and artifact collisions at its trust boundary", async () => {
-    const companions = structuredClone(await resolvedWebSystem());
+    const companions = await corruptibleWebSystem();
     companions.applications[0].plan.companions = ["note"];
     expect(() => validateSystemPlan(companions)).toThrow("unsupported companions");
 
-    const collision = structuredClone(await resolvedWebSystem());
+    const collision = await corruptibleWebSystem();
     collision.applications[1].plan.app.output = collision.applications[0].plan.app.output;
     expect(() => validateSystemPlan(collision)).toThrow("duplicate or missing artifact output");
   });


### PR DESCRIPTION
`bunx tsc --noEmit` — the step release.yml runs between `bun run test` and the npm publish — has been failing on main since #326 and #341 landed, so the release workflow cannot ship a new version as it stands.

Six errors, fixed at their source rather than by loosening a type:

- `RowSlot.lift` was declared through the `shallowRef<number>()` overload that yields `number | undefined`, while the slot is built with `shallowRef(0)` and the value feeds `zIndex`. It is a `ShallowRef<number>`.
- The lists screen and the keyboard typed their rendered `view` as `unknown`, which no JSX child position accepts. Both are JSX expressions.
- `hosts/web/system-engine.js` had no declarations, so the test's import was an implicit `any`. Added `system-engine.d.ts` beside it — the same .js/.d.ts split `wasm-ops.d.ts` documents.
- The two System-host rejection tests deliberately corrupt a clone of a deeply readonly resolved plan; they now go through one `corruptibleWebSystem()` helper naming the writable view.

Verified: `bunx tsc --noEmit` exits 0, `bun run test` is 12/12 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)