### PR TITLE
fix(ios): restore the classic icon bevel

### DIFF
--- a/docs/IPHONE4S.md
+++ b/docs/IPHONE4S.md
@@ -81,11 +81,12 @@ It fails instead of silently presenting the software rasterizer through a
 `CAEAGLLayer` when that contract cannot be established.
 
 SpringBoard artwork uses `hosts/iphone2g/Icon.png` as its single source.
-The 1× `PocketClassic-v3.png` is copied byte-for-byte. The Retina
-`PocketClassic-v3@2x.png` is independently rasterized from
+The 1× `PocketClassic-v4.png` is copied byte-for-byte. The Retina
+`PocketClassic-v4@2x.png` is independently rasterized from
 `hosts/iphone4s/Icon.svg` with 8× supersampling, retaining the original icon's
-transparent rounded corners, chrome bevel, enamel face, Pocket mark, and curved
-glass highlight without duplicating each 1× source pixel into a 2×2 block. The
+transparent rounded corners, thin metal edge, dark inset trim, enamel face,
+Pocket mark, and curved glass highlight without duplicating each 1× source
+pixel into a 2×2 block. The
 versioned basename prevents SpringBoard from reusing artwork cached under an
 older bundle resource name. `UIPrerenderedIcon` keeps iOS from adding a second
 gloss treatment.

--- a/docs/IPODTOUCH4.md
+++ b/docs/IPODTOUCH4.md
@@ -81,6 +81,12 @@ embedded as `__pocket_js` / `__pocket_pak` sections. The build id hashes the
 plan, the guest artifacts, every native object, the sysroot stubs, and the
 baked artwork.
 
+**SpringBoard receives the iPhone 2G icon byte-for-byte at 1× and a separately
+rasterized 118×120 Retina reconstruction with the same thin metal edge and
+dark inset trim.** The `PocketClassic-v4` resource name invalidates older iOS 6
+icon-cache entries, while `UIPrerenderedIcon` prevents SpringBoard from adding
+another gloss layer.
+
 `deploy` copies the bundle over the USB SSH tunnel, verifies every file's
 SHA-256 on the device against the local receipt, and installs under a leased
 transactional lock with rollback — the same protocol as the iPhone 4S, with

--- a/hosts/iphone4s/Icon.svg
+++ b/hosts/iphone4s/Icon.svg
@@ -1,19 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg" width="590" height="600" viewBox="0 0 590 600">
   <defs>
-    <linearGradient id="outer-chrome" x1="0" y1="0" x2="0" y2="1">
-      <stop offset="0" stop-color="#ffffff"/>
-      <stop offset="0.12" stop-color="#8f949c"/>
-      <stop offset="0.24" stop-color="#f7f8fa"/>
-      <stop offset="0.63" stop-color="#5f646b"/>
-      <stop offset="0.82" stop-color="#f8fafc"/>
-      <stop offset="1" stop-color="#71767e"/>
+    <linearGradient id="outer-metal" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#9da1a7"/>
+      <stop offset="0.025" stop-color="#747982"/>
+      <stop offset="0.055" stop-color="#e0e2e5"/>
+      <stop offset="0.085" stop-color="#8a8d94"/>
+      <stop offset="0.13" stop-color="#66646f"/>
+      <stop offset="0.22" stop-color="#858991"/>
+      <stop offset="0.78" stop-color="#848890"/>
+      <stop offset="0.87" stop-color="#60616a"/>
+      <stop offset="0.915" stop-color="#7e8188"/>
+      <stop offset="0.95" stop-color="#e1e3e5"/>
+      <stop offset="0.98" stop-color="#b8bbc0"/>
+      <stop offset="1" stop-color="#72767c"/>
     </linearGradient>
-    <linearGradient id="outer-rim" x1="0" y1="0" x2="1" y2="1">
-      <stop offset="0" stop-color="#f8fafc"/>
-      <stop offset="0.34" stop-color="#555b63"/>
-      <stop offset="0.68" stop-color="#ffffff"/>
-      <stop offset="1" stop-color="#767b83"/>
+    <linearGradient id="inner-bevel" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#4a425c"/>
+      <stop offset="0.12" stop-color="#2c2738"/>
+      <stop offset="0.5" stop-color="#24202d"/>
+      <stop offset="0.88" stop-color="#33303d"/>
+      <stop offset="1" stop-color="#666671"/>
     </linearGradient>
     <linearGradient id="enamel" x1="0" y1="0" x2="0" y2="1">
       <stop offset="0" stop-color="#3a2f57"/>
@@ -26,31 +33,31 @@
       <stop offset="0.54" stop-color="#ffffff" stop-opacity="0.14"/>
       <stop offset="1" stop-color="#ffffff" stop-opacity="0"/>
     </linearGradient>
-    <filter id="soft-shadow" x="-20%" y="-20%" width="140%" height="150%">
-      <feGaussianBlur stdDeviation="9"/>
+    <filter id="mark-shadow" x="-20%" y="-20%" width="140%" height="150%">
+      <feGaussianBlur stdDeviation="7"/>
     </filter>
   </defs>
 
-  <!-- Transparent corners and a precomposed chrome bezel match the iPhone 2G artwork. -->
-  <rect x="13" y="13" width="564" height="574" rx="119" fill="#000000" opacity="0.55"
-        filter="url(#soft-shadow)"/>
-  <rect x="4" y="4" width="582" height="592" rx="126" fill="url(#outer-chrome)"/>
-  <rect x="13" y="13" width="564" height="574" rx="116" fill="none"
-        stroke="url(#outer-rim)" stroke-width="15"/>
-  <rect x="37" y="39" width="516" height="522" rx="91" fill="url(#enamel)"
-        stroke="#120e1f" stroke-width="8"/>
-  <rect x="48" y="50" width="494" height="500" rx="80" fill="none"
-        stroke="#ffffff" stroke-opacity="0.18" stroke-width="7"/>
+  <!-- Thin metal and dark trim follow the installed iPhone 2G icon. The old
+       broad white rim read as an extra iOS gloss halo at SpringBoard size. -->
+  <rect x="8" y="7" width="574" height="586" rx="120" fill="#111019" opacity="0.42"/>
+  <rect x="5" y="4" width="580" height="592" rx="122" fill="url(#outer-metal)"/>
+  <rect x="20" y="19" width="550" height="562" rx="108" fill="url(#inner-bevel)"
+        stroke="#d8dade" stroke-opacity="0.22" stroke-width="4"/>
+  <rect x="36" y="36" width="518" height="528" rx="94" fill="url(#enamel)"
+        stroke="#171222" stroke-width="7"/>
+  <rect x="45" y="45" width="500" height="510" rx="84" fill="none"
+        stroke="#a29cad" stroke-opacity="0.24" stroke-width="5"/>
 
   <!-- Curved glass highlight is baked so UIPrerenderedIcon can remain enabled. -->
-  <path d="M65 76 Q295 32 525 76 L525 220 Q295 178 65 236 Z" fill="url(#glass)"/>
-  <path d="M72 82 Q295 45 518 82" fill="none" stroke="#ffffff"
-        stroke-opacity="0.45" stroke-width="8" stroke-linecap="round"/>
+  <path d="M63 73 Q295 39 527 73 L527 208 Q295 174 63 222 Z" fill="url(#glass)"/>
+  <path d="M72 79 Q295 50 518 79" fill="none" stroke="#ffffff"
+        stroke-opacity="0.32" stroke-width="7" stroke-linecap="round"/>
 
   <!-- Pocket mark: the 32-unit drawing from site/assets/favicon.svg, mounted
        rather than redrawn, so the retina icon cannot drift from the source. -->
   <rect x="105" y="187" width="380" height="246" rx="88" fill="#000000" opacity="0.34"
-        filter="url(#soft-shadow)"/>
+        filter="url(#mark-shadow)"/>
   <g data-brand-source="site/assets/favicon.svg"
      transform="translate(88.99 114.48) scale(12.8758)">
     <rect x="2" y="6" width="28" height="20" rx="6" fill="none" stroke="#ffd23f" stroke-width="2.6" stroke-linejoin="round"/>

--- a/hosts/iphone4s/Info.plist
+++ b/hosts/iphone4s/Info.plist
@@ -16,19 +16,19 @@
   <key>CFBundleName</key>
   <string>PocketJS iPhone 4S</string>
   <key>CFBundleIconFile</key>
-  <string>PocketClassic-v3.png</string>
+  <string>PocketClassic-v4.png</string>
   <key>CFBundleIconFiles</key>
   <array>
-    <string>PocketClassic-v3</string>
+    <string>PocketClassic-v4</string>
   </array>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>0.1.2</string>
+  <string>0.1.3</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.2</string>
+  <string>0.1.3</string>
   <key>CFBundleURLTypes</key>
   <array>
     <dict>

--- a/hosts/iphone4s/README.md
+++ b/hosts/iphone4s/README.md
@@ -9,8 +9,8 @@ The wrapper defaults to required OpenGL ES 1.1. Its retained UI core and UIKit
 view both use density 2, and it accepts only a 640×960 renderbuffer for the
 320×480 logical surface. SpringBoard artwork preserves the byte-identical
 iPhone 2G `Icon.png` at 1× and rasterizes the matching local `Icon.svg` with 8×
-supersampling for Retina, including the precomposed round mask, chrome bevel,
-and glass highlight.
+supersampling for Retina, including the precomposed round mask, thin metal edge,
+dark inset trim, and glass highlight.
 
 Use `bun iphone4s doctor`, `bun iphone4s prepare-sysroot`, and then the build,
 deploy, launch, status, and capture commands documented in `docs/IPHONE4S.md`.

--- a/hosts/ipodtouch4/Info.plist
+++ b/hosts/ipodtouch4/Info.plist
@@ -16,19 +16,19 @@
   <key>CFBundleName</key>
   <string>PocketJS iPod touch 4</string>
   <key>CFBundleIconFile</key>
-  <string>PocketClassic-v3.png</string>
+  <string>PocketClassic-v4.png</string>
   <key>CFBundleIconFiles</key>
   <array>
-    <string>PocketClassic-v3</string>
+    <string>PocketClassic-v4</string>
   </array>
   <key>CFBundlePackageType</key>
   <string>APPL</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>
-  <string>0.1.0</string>
+  <string>0.1.1</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.0</string>
+  <string>0.1.1</string>
   <key>CFBundleURLTypes</key>
   <array>
     <dict>

--- a/tests/iphone4s-profile.test.ts
+++ b/tests/iphone4s-profile.test.ts
@@ -200,6 +200,12 @@ describe("private iPhone 4S profile", () => {
     const output = mkdtempSync(join(tmpdir(), "pocket-iphone4s-artwork-"));
     try {
       await bakeClassicIPhoneArtwork(output);
+      expect(IPHONE_CLASSIC_ICON_FILE).toBe("PocketClassic-v4.png");
+      for (const host of ["iphone4s", "ipodtouch4"]) {
+        const plist = readFileSync(join(repository, `hosts/${host}/Info.plist`), "utf8");
+        expect(plist).toContain(`<string>${IPHONE_CLASSIC_ICON_FILE}</string>`);
+        expect(plist).toMatch(/<key>UIPrerenderedIcon<\/key>\s*<true\/>/);
+      }
       expect(readFileSync(join(output, IPHONE_CLASSIC_ICON_FILE))).toEqual(readFileSync(IPHONE_CLASSIC_ICON_SOURCE));
 
       const one = await loadImage(join(output, IPHONE_CLASSIC_ICON_FILE));
@@ -226,6 +232,22 @@ describe("private iPhone 4S profile", () => {
         if (twoPixels[index] > 0 && twoPixels[index] < 255) antialiasedAlphaPixels += 1;
       }
       expect(antialiasedAlphaPixels).toBeGreaterThan(100);
+
+      let brightOuterPixels = 0;
+      for (let y = 0; y < two.height; y += 1) {
+        for (let x = 0; x < two.width; x += 1) {
+          if (x >= 10 && x < two.width - 10 && y >= 10 && y < two.height - 10) continue;
+          const index = (y * two.width + x) * 4;
+          if (twoPixels[index + 3] < 64) continue;
+          const luminance = (
+            0.2126 * twoPixels[index] +
+            0.7152 * twoPixels[index + 1] +
+            0.0722 * twoPixels[index + 2]
+          );
+          if (luminance > 220) brightOuterPixels += 1;
+        }
+      }
+      expect(brightOuterPixels).toBeLessThan(80);
     } finally {
       rmSync(output, { recursive: true, force: true });
     }

--- a/tools/iphone-classic-icon.ts
+++ b/tools/iphone-classic-icon.ts
@@ -8,8 +8,8 @@ const REPOSITORY = fileURLToPath(new URL("..", import.meta.url));
 /** The installed iPhone 2G artwork is the single source for legacy iPhone icons. */
 export const IPHONE_CLASSIC_ICON_SOURCE = resolve(REPOSITORY, "hosts/iphone2g/Icon.png");
 export const IPHONE_CLASSIC_RETINA_SOURCE = resolve(REPOSITORY, "hosts/iphone4s/Icon.svg");
-export const IPHONE_CLASSIC_ICON_FILE = "PocketClassic-v3.png";
-export const IPHONE_CLASSIC_RETINA_ICON_FILE = "PocketClassic-v3@2x.png";
+export const IPHONE_CLASSIC_ICON_FILE = "PocketClassic-v4.png";
+export const IPHONE_CLASSIC_RETINA_ICON_FILE = "PocketClassic-v4@2x.png";
 
 const ICON_SUPERSAMPLE = 8;
 


### PR DESCRIPTION
## Summary

- rebuild the shared iOS 6 Retina icon with the iPhone 2G thin metal edge and dark inset trim
- version the SpringBoard resource as PocketClassic-v4 and bump both legacy bundle versions
- guard against a bright outer halo and document the cache/gloss contract

## Validation

- bun run test: 12/12 stages green
- bun ipodtouch4 build: ARMv7 Mach-O, build 0699f4f443753f90efc38a1651b1f1cf
- focused iPhone 4S and iPod touch 4 tests: 12 passed
- both Info.plist files pass plutil

## Hardware

- jailbroken iPod4,1 on iOS 6.1.6 with Cydia 1.1.30 and key-only USB SSH
- deployment completed with byte-exact readback
- runtime receipt: GLES1, DisplayLink, 640x960, 8 completed touch sequences, clear_gesture accepted
- decoded the device SpringBoard icon cache for PocketClassic-v4; the cached Retina icon has the thin bevel without the previous white halo