### PR TITLE
feat(host): memory receipt on the desktop host exit line

### DIFF
--- a/engine/core/src/lib.rs
+++ b/engine/core/src/lib.rs
@@ -240,6 +240,30 @@ struct AuxiliarySurface {
     inspect_drawn: Option<(f32, f32, f32, f32)>,
 }
 
+/// Advisory memory breakdown of the retained state, for host receipts and
+/// diagnostics. NOT a wire contract: fields are estimates (heap capacity,
+/// not live payload) and may change between releases.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct MemoryReceipt {
+    pub tree_slots: u32,
+    pub tree_alive: u32,
+    /// children/overrides/anim_values/text heap capacity over all slots.
+    pub tree_heap_bytes: u64,
+    /// Nodes currently mirrored into the taffy layout tree.
+    pub taffy_nodes: u32,
+    /// Baked font atlases: cmap records + coverage bitmaps.
+    pub font_bytes: u64,
+    /// Baked style table: prop lists + animation tracks/segments.
+    pub style_bytes: u64,
+    pub texture_slots: u32,
+    /// Pixel planes + T8 palettes.
+    pub texture_bytes: u64,
+    pub drawlist_words: u32,
+    pub drawlist_capacity_words: u32,
+    /// Live explicit animation tracks (transition tracks excluded).
+    pub anim_tracks: u32,
+}
+
 /// The retained UI core. One per AppInstance, with an optional independent
 /// auxiliary output root sharing the same resources and frame clock.
 pub struct Ui {
@@ -1598,6 +1622,51 @@ impl Ui {
     pub fn set_text_measure(&mut self, f: Option<text::MeasureFn>) {
         self.fonts.set_native_measure(f);
         self.mark_layout_dirty();
+    }
+
+    /// [`MemoryReceipt`] — the advisory breakdown behind this core's resident
+    /// state. Hosts print it in exit receipts; it is a diagnostic, not a
+    /// contract, and walking the tree costs O(slots).
+    pub fn memory_receipt(&self) -> MemoryReceipt {
+        use core::mem::size_of;
+        let mut r = MemoryReceipt::default();
+        for node in &self.tree.slots {
+            r.tree_slots += 1;
+            r.tree_alive += node.alive as u32;
+            r.taffy_nodes += node.taffy.is_some() as u32;
+            r.tree_heap_bytes += (node.children.capacity() * size_of::<i32>()
+                + node.overrides.capacity() * size_of::<(u8, u32)>()
+                + node.anim_values.capacity() * size_of::<(u8, u32)>()
+                + node.text.capacity()) as u64;
+        }
+        for slot in 0..spec::MAX_FONT_SLOTS as u8 {
+            if let Some(atlas) = self.fonts.atlas(slot) {
+                r.font_bytes +=
+                    (atlas.bitmap.len() + atlas.glyph_count as usize * size_of::<text::CmapEntry>())
+                        as u64;
+            }
+        }
+        for record in &self.styles.records {
+            r.style_bytes += (record.base.capacity() * size_of::<(u8, u32)>()
+                + record.focus.capacity() * size_of::<(u8, u32)>()
+                + record.active.capacity() * size_of::<(u8, u32)>()) as u64;
+        }
+        for timeline in &self.styles.anims {
+            for track in &timeline.tracks {
+                r.style_bytes += (track.segments.capacity() * size_of::<style::Segment>()) as u64;
+            }
+        }
+        r.texture_slots = self.textures.len() as u32;
+        for slot in &self.textures {
+            if let Some(tex) = &slot.tex {
+                r.texture_bytes +=
+                    (tex.byte_len + tex.palette.as_ref().map_or(0, |p| p.len() * 16)) as u64;
+            }
+        }
+        r.drawlist_words = self.draw_list.words.len() as u32;
+        r.drawlist_capacity_words = self.draw_list.words.capacity() as u32;
+        r.anim_tracks = self.anims.tracks.len() as u32;
+        r
     }
 
     /// Install (or clear) a native line wrapper (text::WrapFn) next to the

--- a/engine/crates/pocket-mod/src/lib.rs
+++ b/engine/crates/pocket-mod/src/lib.rs
@@ -26,6 +26,16 @@ use rquickjs::{CatchResultExt, Context, Ctx, Function, Object, Runtime};
 // Surface crates implement ops against the same rquickjs the guest uses.
 pub use rquickjs as qjs;
 
+/// QuickJS heap summary for receipts (`malloc_bytes` includes allocator
+/// overhead; `used_bytes` is net payload).
+#[derive(Clone, Copy, Debug)]
+pub struct QuickjsMemory {
+    pub malloc_bytes: i64,
+    pub used_bytes: i64,
+    pub obj_count: i64,
+    pub str_bytes: i64,
+}
+
 /// One QuickJS realm hosting one guest program.
 pub struct Guest {
     rt: Runtime,
@@ -52,6 +62,21 @@ impl Guest {
         ctx.with(|ctx| install_console(&ctx))
             .map_err(|e| anyhow!("pocket-mod: installing console: {e}"))?;
         Ok(Guest { rt, ctx })
+    }
+
+    /// Collect garbage, then return the realm's QuickJS heap stats
+    /// (`malloc_bytes` = payload + allocator overhead, `used_bytes` = net
+    /// payload). Receipts want the settled number: a busy guest can hold
+    /// cyclic garbage the collector has not run on yet.
+    pub fn gc_and_memory(&self) -> QuickjsMemory {
+        self.rt.run_gc();
+        let m = self.rt.memory_usage();
+        QuickjsMemory {
+            malloc_bytes: m.malloc_size,
+            used_bytes: m.memory_used_size,
+            obj_count: m.obj_count,
+            str_bytes: m.str_size,
+        }
     }
 
     /// Run `f` with the realm's [`Ctx`]. Surface crates use this to build

--- a/hosts/desktop/src/main.rs
+++ b/hosts/desktop/src/main.rs
@@ -1351,6 +1351,56 @@ impl PocketRoot {
                 self.frames.get(),
                 self.frames.get() as f64 / self.ticks.max(1) as f64 * 100.0
             );
+            self.print_memory_receipt();
+        }
+    }
+
+    /// Advisory memory breakdown behind the RSS number: the QuickJS guest
+    /// heap (after a full GC) and each mounted core's retained state. Pairs
+    /// with `tools/bench-desktop.ts`, whose RSS medians are the outside view
+    /// of exactly these numbers.
+    fn print_memory_receipt(&self) {
+        const KB: f64 = 1024.0;
+        let kb = |b: u64| format!("{:.0}KB", (b as f64 / KB).round());
+        let core = |r: &pocketjs_core::MemoryReceipt| {
+            format!(
+                "nodes={}/{} taffy={} heap={} fonts={} styles={} tex={}/{} drawlist={}/{}w anims={}",
+                r.tree_alive,
+                r.tree_slots,
+                r.taffy_nodes,
+                kb(r.tree_heap_bytes),
+                kb(r.font_bytes),
+                kb(r.style_bytes),
+                r.texture_slots,
+                kb(r.texture_bytes),
+                r.drawlist_words,
+                r.drawlist_capacity_words,
+                r.anim_tracks,
+            )
+        };
+        let qjs = |g: &Guest| {
+            let m = g.gc_and_memory();
+            format!(
+                "qjs malloc={:.0}KB used={:.0}KB objs={} strs={:.0}KB",
+                m.malloc_bytes as f64 / KB,
+                m.used_bytes as f64 / KB,
+                m.obj_count,
+                m.str_bytes as f64 / KB,
+            )
+        };
+        println!("pocket-desktop-host: mem shell {}", {
+            let c = self.surface.with_ui(|ui| core(&ui.memory_receipt()));
+            format!("{} {}", qjs(&self.guest), c)
+        });
+        for instance in &self.app_supervisor.borrow().instances {
+            let c = instance.surface.with_ui(|ui| core(&ui.memory_receipt()));
+            println!(
+                "pocket-desktop-host: mem {}({}) {} {}",
+                instance.package.plan.app.title,
+                instance.package.plan.app.output,
+                qjs(&instance.guest),
+                c
+            );
         }
     }
 


### PR DESCRIPTION
## Summary

The desktop host's exit receipt printed ticks/frames only — the RSS number sampled by `tools/bench-desktop.ts` had no breakdown behind it.

- `pocketjs-core`: `Ui::memory_receipt()` — advisory breakdown of retained state (tree slots/heap, taffy nodes, baked fonts, style table, textures, draw list words/capacity, animation tracks)
- `pocket-mod`: `Guest::gc_and_memory()` — QuickJS heap stats after a full GC
- `hosts/desktop`: print a `mem` line per mounted core on exit (shell plus every supervisor instance)

## Example output (note app, 300 ticks)

```
pocket-desktop-host: mem shell qjs malloc=1586KB used=1344KB objs=4769 strs=18KB nodes=60/61 taffy=40 heap=3KB fonts=1110KB styles=2KB tex=5/16KB drawlist=301/512w anims=1
```

The desktop editor's resident memory is guest heap + baked fonts; core state is a few tens of KB. This grounds the desktop-editor memory work (virtualization, incremental parse) before it starts.

## Verification

- `cargo test` (engine/core): 129 passed
- `wasm32-unknown-unknown` build of the core: clean
- Receipt verified live on the note app