### PR TITLE
feat(quickjs-c): add external harness hooks

### DIFF
--- a/.github/workflows/native-c-harness.yml
+++ b/.github/workflows/native-c-harness.yml
@@ -1,0 +1,78 @@
+name: Native C harness
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/native-c-harness.yml"
+      - "engine/quickjs-c/**"
+      - "engine/ui-cabi/**"
+      - "engine/core/**"
+      - "framework/src/**"
+      - "framework/compiler/**"
+      - "contracts/**"
+      - "tests/fixtures/quickjs-c-harness/**"
+      - "tests/fixtures/ui-cabi-allocator/**"
+      - "tests/quickjs-c-harness.test.ts"
+      - "tests/ui-cabi-allocator.test.ts"
+      - "tests/renderer.test.ts"
+      - "tests/virtual-list.test.ts"
+      - "tests/vue-vapor-dom.test.ts"
+      - "tools/build.ts"
+      - "package.json"
+      - "bun.lock"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/native-c-harness.yml"
+      - "engine/quickjs-c/**"
+      - "engine/ui-cabi/**"
+      - "engine/core/**"
+      - "framework/src/**"
+      - "framework/compiler/**"
+      - "contracts/**"
+      - "tests/fixtures/quickjs-c-harness/**"
+      - "tests/fixtures/ui-cabi-allocator/**"
+      - "tests/quickjs-c-harness.test.ts"
+      - "tests/ui-cabi-allocator.test.ts"
+      - "tests/renderer.test.ts"
+      - "tests/virtual-list.test.ts"
+      - "tests/vue-vapor-dom.test.ts"
+      - "tools/build.ts"
+      - "package.json"
+      - "bun.lock"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  harness:
+    name: C runtime + allocator (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-latest]
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+      - uses: dtolnay/rust-toolchain@stable
+      - run: bun install --frozen-lockfile
+      - name: Install the UI C ABI's pinned nightly
+        run: |
+          toolchain=$(bun -e 'console.log(Bun.TOML.parse(await Bun.file("engine/ui-cabi/rust-toolchain.toml").text()).toolchain.channel)')
+          rustup toolchain install "$toolchain" --profile minimal
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine/ui-cabi
+      - name: Build renderer test styles
+        run: bun tools/build.ts hero
+      - name: Renderer and runtime stage/dispatcher contracts
+        run: bun test --conditions=browser tests/quickjs-c-harness.test.ts tests/renderer.test.ts tests/virtual-list.test.ts tests/vue-vapor-dom.test.ts
+      - name: UI singleton access and alignment policy
+        run: cargo test --locked --manifest-path engine/ui-cabi/Cargo.toml --features harness-access
+      - name: Link and execute the real C allocator
+        run: bun test tests/ui-cabi-allocator.test.ts
+      - name: Contract drift
+        run: bun tests/contract.ts

--- a/engine/quickjs-c/README.md
+++ b/engine/quickjs-c/README.md
@@ -1,0 +1,33 @@
+# Portable QuickJS C runtime
+
+`pocket_runtime.c` owns one QuickJS runtime and context, installs the native
+`ui` operations, evaluates an application bundle, and advances its frame
+function, pending jobs, and native core ticks in that order. Native C hosts
+compile this source directly against `engine/ui-cabi` and their pinned QuickJS.
+
+## Harness integration
+
+Defining `POCKET_RUNTIME_STAGE_HOOKS` makes the embedding program provide
+`pocket_bench_stage(int stage)`. The runtime reports the boundaries of bundle
+evaluation, the guest frame call, the pending-job drain, and native core ticks.
+It returns to `POCKET_BENCH_STAGE_IDLE` before handing control back, including
+failure paths entered after a measured stage begins.
+
+Defining the separate `POCKET_RUNTIME_HARNESS` capability exposes
+`pocket_runtime_harness_bind` and `pocket_runtime_harness_call`. A harness binds
+one global dispatcher after boot; subsequent calls pass an integer opcode and
+argument directly through `JS_Call`, with an optional integer result. The
+runtime caches and releases the dispatcher with the guest realm. It neither
+changes the current stage nor drains pending jobs.
+
+The embedding owns attribution: it must enter the intended stage before a call
+whose synchronous work belongs to a measurement. Jobs queued by the dispatcher
+run in the next guest turn and are attributed to that turn's `JOBS` stage. The
+runtime knows nothing about the opcode protocol; the external harness owns the
+dispatcher implementation and its command/result meanings.
+
+Rust harness crates that must inspect the matching retained UI singleton enable
+the `harness-access` feature on `pocketjs-ui-cabi` and use the unsafe
+`with_initialized_ui_unchecked` accessor under its documented no-reentrancy and
+lifecycle contract. Production hosts leave all opt-ins disabled and continue
+to use only the C ABI.

--- a/engine/quickjs-c/README.md
+++ b/engine/quickjs-c/README.md
@@ -31,3 +31,21 @@ the `harness-access` feature on `pocketjs-ui-cabi` and use the unsafe
 `with_initialized_ui_unchecked` accessor under its documented no-reentrancy and
 lifecycle contract. Production hosts leave all opt-ins disabled and continue
 to use only the C ABI.
+
+## Validation
+
+The `Native C harness` pull-request workflow runs on Linux and macOS. It builds
+and executes all four stage/dispatcher switch combinations against QuickJS/UI
+stubs, runs renderer contracts, and tests `ui-cabi` with `harness-access` enabled.
+The stubs cover runtime control flow; they do not replace a real QuickJS
+benchmark run.
+
+`bun test tests/ui-cabi-allocator.test.ts` builds the real UI C ABI static library
+with `bare-platform,software-only` using the nightly pinned in
+`engine/ui-cabi/rust-toolchain.toml`. A C executable uploads textures through
+both the C `malloc` path and the `host-allocator` callback path, exercises table
+growth, and releases textures through free and shutdown. The host callback
+fixture checks 16-byte alignment, allocation/reallocation calls, and cleanup.
+This test needs `rustup`, the pinned nightly, and a C compiler. The Rust unit
+texture test uses the default allocator and covers upload behavior, not the
+`CAllocator` allocation path.

--- a/engine/quickjs-c/pocket_runtime.c
+++ b/engine/quickjs-c/pocket_runtime.c
@@ -27,6 +27,16 @@ extern void pocket_host_boot_stage(int stage);
 #define REPORT_BOOT_STAGE(stage) ((void)(stage))
 #endif
 
+/*
+ * Harness builds provide pocket_bench_stage() and opt into exact boundaries
+ * around bundle evaluation, the guest turn, the job drain and core ticks.
+ */
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+#define BENCH_STAGE(stage) pocket_bench_stage(stage)
+#else
+#define BENCH_STAGE(stage) ((void)(stage))
+#endif
+
 typedef enum {
   HostCreateNode,
   HostDestroyNode,
@@ -65,6 +75,9 @@ static JSRuntime *runtime;
 static JSContext *context;
 static JSValue global;
 static JSValue frame_function;
+#if defined(POCKET_RUNTIME_HARNESS)
+static JSValue harness_function;
+#endif
 static char last_error[512];
 static char reported_action_name[POCKETJS_ACTION_NAME_CAPACITY];
 static int32_t reported_action_value;
@@ -522,6 +535,9 @@ static int drain_jobs(void) {
 
 void pocket_runtime_shutdown(void) {
   if (context != 0) {
+#if defined(POCKET_RUNTIME_HARNESS)
+    if (!JS_IsUndefined(harness_function)) JS_FreeValue(context, harness_function);
+#endif
     if (!JS_IsUndefined(frame_function)) JS_FreeValue(context, frame_function);
     if (!JS_IsUndefined(global)) JS_FreeValue(context, global);
     JS_FreeContext(context);
@@ -532,6 +548,9 @@ void pocket_runtime_shutdown(void) {
   runtime_failed = 0;
   frame_function = JS_UNDEFINED;
   global = JS_UNDEFINED;
+#if defined(POCKET_RUNTIME_HARNESS)
+  harness_function = JS_UNDEFINED;
+#endif
   ui_shutdown();
 }
 
@@ -599,6 +618,7 @@ int pocket_runtime_boot(
   }
   REPORT_BOOT_STAGE(7);
 
+  BENCH_STAGE(POCKET_BENCH_STAGE_EVAL);
   JSValue result = JS_Eval(
     context,
     java_script,
@@ -606,6 +626,7 @@ int pocket_runtime_boot(
     "app.js",
     JS_EVAL_TYPE_GLOBAL
   );
+  BENCH_STAGE(POCKET_BENCH_STAGE_IDLE);
   if (JS_IsException(result)) {
     take_exception(context);
     pocket_runtime_shutdown();
@@ -621,7 +642,10 @@ int pocket_runtime_boot(
     return 0;
   }
   REPORT_BOOT_STAGE(9);
-  if (!drain_jobs()) {
+  BENCH_STAGE(POCKET_BENCH_STAGE_JOBS);
+  int jobs_ok = drain_jobs();
+  BENCH_STAGE(POCKET_BENCH_STAGE_IDLE);
+  if (!jobs_ok) {
     pocket_runtime_shutdown();
     return 0;
   }
@@ -684,20 +708,26 @@ static int run_frame(
     touch_array,
     hit_array,
   };
+  BENCH_STAGE(POCKET_BENCH_STAGE_JS);
   JSValue result = JS_Call(context, frame_function, global, 4, arguments);
   JS_FreeValue(context, hit_array);
   JS_FreeValue(context, touch_array);
   if (JS_IsException(result)) {
     take_exception(context);
     runtime_failed = 1;
+    BENCH_STAGE(POCKET_BENCH_STAGE_IDLE);
     return 0;
   }
   JS_FreeValue(context, result);
+  BENCH_STAGE(POCKET_BENCH_STAGE_JOBS);
   if (!drain_jobs()) {
     runtime_failed = 1;
+    BENCH_STAGE(POCKET_BENCH_STAGE_IDLE);
     return 0;
   }
+  BENCH_STAGE(POCKET_BENCH_STAGE_TICK);
   for (tick = 0; tick < tick_count; ++tick) ui_tick();
+  BENCH_STAGE(POCKET_BENCH_STAGE_IDLE);
   return 1;
 }
 
@@ -760,6 +790,52 @@ int pocket_runtime_frame(int touch_down, int touch_x, int touch_y, int touch_hit
   /* The original iPhone host presents at 30 Hz and advances two 60 Hz ticks. */
   return pocket_runtime_frame_ticks(touch_down, touch_x, touch_y, touch_hit, 2);
 }
+
+#if defined(POCKET_RUNTIME_HARNESS)
+int pocket_runtime_harness_bind(const char *global_function) {
+  JSValue function;
+  if (runtime == 0 || context == 0 || runtime_failed || global_function == 0 ||
+      global_function[0] == '\0') return 0;
+  function = JS_GetPropertyStr(context, global, global_function);
+  if (JS_IsException(function)) {
+    take_exception(context);
+    return 0;
+  }
+  if (!JS_IsFunction(context, function)) {
+    JS_FreeValue(context, function);
+    set_error("harness dispatcher is not a function");
+    return 0;
+  }
+  if (!JS_IsUndefined(harness_function)) JS_FreeValue(context, harness_function);
+  harness_function = function;
+  return 1;
+}
+
+int pocket_runtime_harness_call(int32_t opcode, int32_t argument, int32_t *out) {
+  JSValue arguments[2];
+  JSValue value;
+  int32_t number = 0;
+  if (runtime == 0 || context == 0 || runtime_failed ||
+      JS_IsUndefined(harness_function)) return 0;
+  arguments[0] = JS_NewInt32(context, opcode);
+  arguments[1] = JS_NewInt32(context, argument);
+  value = JS_Call(context, harness_function, global, 2, arguments);
+  JS_FreeValue(context, arguments[1]);
+  JS_FreeValue(context, arguments[0]);
+  if (JS_IsException(value)) {
+    take_exception(context);
+    return 0;
+  }
+  if (out != 0 && JS_ToInt32(context, &number, value) < 0) {
+    JS_FreeValue(context, value);
+    take_exception(context);
+    return 0;
+  }
+  JS_FreeValue(context, value);
+  if (out != 0) *out = number;
+  return 1;
+}
+#endif
 
 int pocket_runtime_hit_test(float x, float y) {
   if (runtime == 0 || context == 0 || runtime_failed) return 0;

--- a/engine/quickjs-c/pocket_runtime.h
+++ b/engine/quickjs-c/pocket_runtime.h
@@ -4,6 +4,21 @@
 #include <stddef.h>
 #include <stdint.h>
 
+/*
+ * Stage ids delivered to pocket_bench_stage() when pocket_runtime.c is
+ * compiled with POCKET_RUNTIME_STAGE_HOOKS. Production hosts do not define
+ * that switch, so the calls compile away.
+ */
+#define POCKET_BENCH_STAGE_IDLE 0
+#define POCKET_BENCH_STAGE_EVAL 1
+#define POCKET_BENCH_STAGE_JS 2
+#define POCKET_BENCH_STAGE_JOBS 3
+#define POCKET_BENCH_STAGE_TICK 4
+
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+void pocket_bench_stage(int stage);
+#endif
+
 int pocket_runtime_boot(
   const char *java_script,
   size_t java_script_length,
@@ -71,6 +86,16 @@ int pocket_runtime_frame_ticks(
   int touch_hit,
   unsigned int tick_count
 );
+#if defined(POCKET_RUNTIME_HARNESS)
+/*
+ * Bind a global harness dispatcher function in the live guest realm, then call
+ * it with two int32 arguments. The result is converted to int32 when `out` is
+ * non-NULL. Neither operation drains jobs or emits a stage callback; the
+ * embedding owns attribution for synchronous work and queued jobs.
+ */
+int pocket_runtime_harness_bind(const char *global_function);
+int pocket_runtime_harness_call(int32_t opcode, int32_t argument, int32_t *out);
+#endif
 int pocket_runtime_hit_test(float x, float y);
 int pocket_runtime_hit_test_bounds(float x, float y);
 const char *pocket_runtime_action_name(void);

--- a/engine/ui-cabi/Cargo.toml
+++ b/engine/ui-cabi/Cargo.toml
@@ -41,6 +41,9 @@ software-only = []
 host-allocator = []
 # Report native boot checkpoints to hosts that expose pocket_host_boot_stage.
 boot-stage = []
+# Allow an in-process harness crate to access an already initialized retained Ui
+# singleton through an explicit unsafe contract. Production hosts leave this disabled.
+harness-access = []
 
 [dependencies]
 pocketjs-core = { path = "../core" }

--- a/engine/ui-cabi/src/lib.rs
+++ b/engine/ui-cabi/src/lib.rs
@@ -888,8 +888,8 @@ mod tests {
             unsafe { with_initialized_ui_unchecked(|ui| ui.viewport()) },
             Some((2.0, 1.0)),
         );
-        // Texture backing is Vec<u128>; this aborts under a C allocator policy
-        // that incorrectly rejects its 16-byte alignment on a 64-bit host.
+        // This unit test uses Rust's default allocator. The linked C fixture in
+        // tests/ui-cabi-allocator.test.ts covers the bare-platform CAllocator.
         let pixel = [0xff, 0x00, 0x00, 0xff];
         assert!(ui_upload_texture(
             pixel.as_ptr(),

--- a/engine/ui-cabi/src/lib.rs
+++ b/engine/ui-cabi/src/lib.rs
@@ -184,6 +184,24 @@ fn ui() -> &'static mut Ui {
     unsafe { UI.get_or_insert_with(Ui::new) }
 }
 
+/// Run `f` against an already initialized C ABI `Ui` singleton.
+///
+/// In-process harness crates enable `harness-access` to inspect DrawList words
+/// or replay mutations against the same core instance as the C guest runtime.
+/// Returns `None` before `ui_init` or after `ui_shutdown`; it never creates an
+/// implicit replacement instance.
+///
+/// # Safety
+///
+/// The caller must ensure there is no concurrent or reentrant UI access, must
+/// not call any `ui_*` C ABI function from `f`, and must prevent `ui_init` and
+/// `ui_shutdown` for the duration of the closure. Violating these requirements
+/// can alias the mutable borrow or drop the borrowed value.
+#[cfg(feature = "harness-access")]
+pub unsafe fn with_initialized_ui_unchecked<R>(f: impl FnOnce(&mut Ui) -> R) -> Option<R> {
+    unsafe { UI.as_mut().map(f) }
+}
+
 #[inline]
 unsafe fn bytes<'a>(ptr: *const u8, len: usize) -> &'a [u8] {
     if ptr.is_null() || len == 0 {
@@ -861,8 +879,15 @@ mod tests {
         assert_eq!(draw_hash(&words), draw_hash(&words));
         assert_ne!(draw_hash(&words), draw_hash(&[0x0102_0304, 0x0506_0709]));
 
+        #[cfg(feature = "harness-access")]
+        assert!(unsafe { with_initialized_ui_unchecked(|_| ()) }.is_none());
         ui_init(1);
         ui_set_viewport(2.0, 1.0);
+        #[cfg(feature = "harness-access")]
+        assert_eq!(
+            unsafe { with_initialized_ui_unchecked(|ui| ui.viewport()) },
+            Some((2.0, 1.0)),
+        );
         // Texture backing is Vec<u128>; this aborts under a C allocator policy
         // that incorrectly rejects its 16-byte alignment on a 64-bit host.
         let pixel = [0xff, 0x00, 0x00, 0xff];
@@ -889,5 +914,7 @@ mod tests {
         let pixels = unsafe { core::slice::from_raw_parts(framebuffer, 8) };
         assert_eq!(pixels, &[0x11, 0x22, 0x33, 0xff, 0x11, 0x22, 0x33, 0xff]);
         ui_shutdown();
+        #[cfg(feature = "harness-access")]
+        assert!(unsafe { with_initialized_ui_unchecked(|_| ()) }.is_none());
     }
 }

--- a/engine/ui-cabi/src/lib.rs
+++ b/engine/ui-cabi/src/lib.rs
@@ -37,8 +37,16 @@ pub mod extension;
 ))]
 mod gl;
 
+/// `malloc` and the supported host allocator ABIs provide `max_align_t`
+/// storage: 16 bytes on their 64-bit targets and 8 on 32-bit ARM. Core texture
+/// storage uses `Vec<u128>`, so rejecting that natural alignment makes every
+/// texture allocation fail on a 64-bit C host.
 #[cfg(any(target_os = "none", feature = "bare-platform", test))]
-const C_MALLOC_ALIGNMENT: usize = 8;
+const C_MALLOC_ALIGNMENT: usize = if cfg!(target_pointer_width = "64") {
+    16
+} else {
+    8
+};
 
 #[cfg(any(target_os = "none", feature = "bare-platform", test))]
 #[inline]
@@ -61,7 +69,9 @@ unsafe extern "C" {
     feature = "host-allocator"
 ))]
 unsafe extern "C" {
+    /// Must return storage aligned to at least `C_MALLOC_ALIGNMENT`.
     fn pocket_host_alloc(size: usize) -> *mut c_void;
+    /// Must preserve alignment of the original allocation.
     fn pocket_host_realloc(ptr: *mut c_void, size: usize) -> *mut c_void;
     fn pocket_host_free(ptr: *mut c_void);
 }
@@ -838,8 +848,9 @@ mod tests {
     use pocketjs_core::spec;
 
     #[test]
-    fn c_allocator_rejects_alignments_above_c_malloc_guarantee() {
+    fn c_allocator_supports_core_texture_alignment() {
         assert!(c_allocator_supports_alignment(1));
+        assert!(c_allocator_supports_alignment(core::mem::align_of::<u128>()));
         assert!(c_allocator_supports_alignment(C_MALLOC_ALIGNMENT));
         assert!(!c_allocator_supports_alignment(C_MALLOC_ALIGNMENT * 2));
     }
@@ -852,6 +863,16 @@ mod tests {
 
         ui_init(1);
         ui_set_viewport(2.0, 1.0);
+        // Texture backing is Vec<u128>; this aborts under a C allocator policy
+        // that incorrectly rejects its 16-byte alignment on a 64-bit host.
+        let pixel = [0xff, 0x00, 0x00, 0xff];
+        assert!(ui_upload_texture(
+            pixel.as_ptr(),
+            pixel.len(),
+            1,
+            1,
+            spec::psm::PSM_8888 as u32,
+        ) >= 0);
         // Packed ABGR: R=0x33, G=0x22, B=0x11, A=0xff.
         ui_set_prop(
             spec::ROOT_ID,

--- a/framework/src/native-tree.ts
+++ b/framework/src/native-tree.ts
@@ -520,12 +520,22 @@ function unlink(node: NodeMirror): void {
 
 export function insertNode(parent: NodeMirror, node: NodeMirror, anchor?: NodeMirror | null): void {
   const ops = getOps();
+  if (anchor && (anchor.parent !== parent || !parent.children.includes(anchor))) {
+    throw new Error("PocketJS: insert anchor is not a child of parent");
+  }
+  if (anchor === node) {
+    // DOM pre-insertion re-anchors on the node's next sibling, so inserting a
+    // child before itself is a positional no-op. Solid's keyed reconciler can
+    // emit this during an adjacent swap; neither the mirror nor the native
+    // host should see a detach followed by a now-invalid anchor.
+    sweepSet.delete(node);
+    return;
+  }
   unlink(node);
   sweepSet.delete(node);
   ops.insertBefore(parent.id, node.id, anchor ? anchor.id : 0);
   if (anchor) {
     const i = parent.children.indexOf(anchor);
-    if (i < 0) throw new Error("PocketJS: insert anchor is not a child of parent");
     parent.children.splice(i, 0, node);
   } else {
     parent.children.push(node);

--- a/tests/fixtures/quickjs-c-harness/quickjs.h
+++ b/tests/fixtures/quickjs-c-harness/quickjs.h
@@ -1,0 +1,74 @@
+#ifndef POCKETJS_TEST_QUICKJS_H
+#define POCKETJS_TEST_QUICKJS_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+typedef struct JSRuntime JSRuntime;
+typedef struct JSContext JSContext;
+typedef int64_t JSValue;
+typedef JSValue JSValueConst;
+typedef JSValue JSCFunctionMagic(JSContext *ctx, JSValueConst this_value,
+                                 int argc, JSValueConst *argv, int magic);
+
+typedef enum {
+  JS_CFUNC_generic_magic = 0,
+} JSCFunctionEnum;
+
+#define JS_UNDEFINED ((JSValue)0)
+#define JS_EXCEPTION ((JSValue) - 1)
+#define JS_EVAL_TYPE_GLOBAL 0
+
+JSRuntime *JS_NewRuntime(void);
+void JS_FreeRuntime(JSRuntime *runtime);
+void JS_SetMaxStackSize(JSRuntime *runtime, size_t size);
+JSContext *JS_NewContext(JSRuntime *runtime);
+void JS_FreeContext(JSContext *context);
+JSValue JS_GetGlobalObject(JSContext *context);
+JSValue JS_GetException(JSContext *context);
+int JS_HasException(JSContext *context);
+int JS_IsException(JSValueConst value);
+int JS_IsUndefined(JSValueConst value);
+int JS_IsFunction(JSContext *context, JSValueConst value);
+void JS_FreeValue(JSContext *context, JSValue value);
+const char *JS_ToCStringLen2(JSContext *context, size_t *length,
+                             JSValueConst value, int cesu8);
+void JS_FreeCString(JSContext *context, const char *value);
+int JS_ToInt32(JSContext *context, int32_t *out, JSValueConst value);
+int JS_ToUint32(JSContext *context, uint32_t *out, JSValueConst value);
+int JS_ToFloat64(JSContext *context, double *out, JSValueConst value);
+JSValue JS_NewInt32(JSContext *context, int32_t value);
+JSValue JS_NewUint32(JSContext *context, uint32_t value);
+JSValue JS_NewFloat64(JSContext *context, double value);
+JSValue JS_NewBool(JSContext *context, int value);
+JSValue JS_NewString(JSContext *context, const char *value);
+JSValue JS_NewObject(JSContext *context);
+JSValue JS_NewArray(JSContext *context);
+JSValue JS_NewArrayBuffer(JSContext *context, uint8_t *buffer, size_t length,
+                          void (*free_func)(JSRuntime *runtime, void *opaque,
+                                            void *pointer),
+                          void *opaque, int shared);
+uint8_t *JS_GetArrayBuffer(JSContext *context, size_t *length,
+                           JSValueConst value);
+JSValue JS_GetTypedArrayBuffer(JSContext *context, JSValueConst value,
+                               size_t *offset, size_t *length,
+                               size_t *bytes_per_element);
+JSValue JS_NewCFunctionMagic(JSContext *context, JSCFunctionMagic *function,
+                             const char *name, int length, JSCFunctionEnum kind,
+                             int magic);
+int JS_SetPropertyStr(JSContext *context, JSValueConst object, const char *name,
+                      JSValue value);
+int JS_SetPropertyUint32(JSContext *context, JSValueConst object,
+                         uint32_t index, JSValue value);
+JSValue JS_GetPropertyStr(JSContext *context, JSValueConst object,
+                          const char *name);
+JSValue JS_Eval(JSContext *context, const char *source, size_t length,
+                const char *filename, int flags);
+JSValue JS_Call(JSContext *context, JSValueConst function,
+                JSValueConst this_value, int argc, JSValueConst *argv);
+int JS_ExecutePendingJob(JSRuntime *runtime, JSContext **context);
+JSValue JS_ThrowTypeError(JSContext *context, const char *format, ...);
+JSValue JS_ThrowRangeError(JSContext *context, const char *format, ...);
+JSValue JS_ThrowInternalError(JSContext *context, const char *format, ...);
+
+#endif

--- a/tests/fixtures/quickjs-c-harness/runtime_harness.c
+++ b/tests/fixtures/quickjs-c-harness/runtime_harness.c
@@ -1,0 +1,438 @@
+#include "pocket_runtime.h"
+
+#include "pocket_ui_cabi.h"
+#include "quickjs.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct JSRuntime {
+  int alive;
+};
+
+struct JSContext {
+  int alive;
+};
+
+enum Scenario {
+  SCENARIO_SUCCESS,
+  SCENARIO_BOOT_EVAL_FAILURE,
+  SCENARIO_BOOT_FRAME_MISSING,
+  SCENARIO_BOOT_JOB_FAILURE,
+  SCENARIO_FRAME_JS_FAILURE,
+  SCENARIO_FRAME_JOB_FAILURE,
+};
+
+enum {
+  VALUE_OBJECT = 0x100,
+  VALUE_FRAME_FUNCTION = 0x101,
+  VALUE_HARNESS_FUNCTION = 0x102,
+};
+
+static struct JSRuntime stub_runtime;
+static struct JSContext stub_context;
+static enum Scenario scenario;
+static int boot_job_calls;
+static int frame_job_calls;
+static int frame_started;
+static int dispatcher_queued_job;
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+static int stages[32];
+static size_t stage_count;
+#endif
+static uint8_t framebuffer[4];
+
+static void reset_stubs(enum Scenario next) {
+  scenario = next;
+  boot_job_calls = 0;
+  frame_job_calls = 0;
+  frame_started = 0;
+  dispatcher_queued_job = 0;
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+  stage_count = 0;
+#endif
+}
+
+static int boot(enum Scenario next) {
+  static const uint8_t pack[1] = {0};
+  reset_stubs(next);
+  return pocket_runtime_boot("bundle", 6, pack, sizeof(pack), 480, 272);
+}
+
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+void pocket_bench_stage(int stage) {
+  if (stage_count >= sizeof(stages) / sizeof(stages[0])) {
+    fputs("too many stage callbacks\n", stderr);
+    exit(1);
+  }
+  stages[stage_count++] = stage;
+}
+
+static int expect_stages(const char *label, const int *expected, size_t count) {
+  size_t index;
+  if (stage_count != count) {
+    fprintf(stderr, "%s: got %zu stages, expected %zu\n", label, stage_count,
+            count);
+    return 0;
+  }
+  for (index = 0; index < count; index += 1) {
+    if (stages[index] != expected[index]) {
+      fprintf(stderr, "%s: stage %zu is %d, expected %d\n", label, index,
+              stages[index], expected[index]);
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static int test_boot_sequences(void) {
+  static const int success[] = {
+      POCKET_BENCH_STAGE_EVAL,
+      POCKET_BENCH_STAGE_IDLE,
+      POCKET_BENCH_STAGE_JOBS,
+      POCKET_BENCH_STAGE_IDLE,
+  };
+  static const int eval_failure[] = {
+      POCKET_BENCH_STAGE_EVAL,
+      POCKET_BENCH_STAGE_IDLE,
+  };
+
+  if (!boot(SCENARIO_SUCCESS) || !expect_stages("boot success", success, 4))
+    return 0;
+  pocket_runtime_shutdown();
+  if (boot(SCENARIO_BOOT_EVAL_FAILURE) ||
+      !expect_stages("boot eval failure", eval_failure, 2))
+    return 0;
+  if (boot(SCENARIO_BOOT_FRAME_MISSING) ||
+      !expect_stages("boot frame missing", eval_failure, 2))
+    return 0;
+  if (boot(SCENARIO_BOOT_JOB_FAILURE) ||
+      !expect_stages("boot job failure", success, 4))
+    return 0;
+  return 1;
+}
+
+static int test_frame_sequences(void) {
+  static const int success[] = {
+      POCKET_BENCH_STAGE_JS,
+      POCKET_BENCH_STAGE_JOBS,
+      POCKET_BENCH_STAGE_TICK,
+      POCKET_BENCH_STAGE_IDLE,
+  };
+  static const int js_failure[] = {
+      POCKET_BENCH_STAGE_JS,
+      POCKET_BENCH_STAGE_IDLE,
+  };
+  static const int job_failure[] = {
+      POCKET_BENCH_STAGE_JS,
+      POCKET_BENCH_STAGE_JOBS,
+      POCKET_BENCH_STAGE_IDLE,
+  };
+  PocketRuntimeInput input = {0};
+
+  if (!boot(SCENARIO_SUCCESS))
+    return 0;
+  stage_count = 0;
+  if (!pocket_runtime_tick(&input) ||
+      !expect_stages("frame success", success, 4))
+    return 0;
+  pocket_runtime_shutdown();
+
+  if (!boot(SCENARIO_FRAME_JS_FAILURE))
+    return 0;
+  stage_count = 0;
+  if (pocket_runtime_tick(&input) ||
+      !expect_stages("frame JS failure", js_failure, 2))
+    return 0;
+  pocket_runtime_shutdown();
+
+  if (!boot(SCENARIO_FRAME_JOB_FAILURE))
+    return 0;
+  stage_count = 0;
+  if (pocket_runtime_tick(&input) ||
+      !expect_stages("frame job failure", job_failure, 3))
+    return 0;
+  pocket_runtime_shutdown();
+  return 1;
+}
+#endif
+
+#if defined(POCKET_RUNTIME_HARNESS)
+static int test_dispatcher_contract(void) {
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+  static const int frame[] = {
+      POCKET_BENCH_STAGE_JS,
+      POCKET_BENCH_STAGE_JOBS,
+      POCKET_BENCH_STAGE_TICK,
+      POCKET_BENCH_STAGE_IDLE,
+  };
+#endif
+  PocketRuntimeInput input = {0};
+  int32_t value = 0;
+
+  if (!boot(SCENARIO_SUCCESS))
+    return 0;
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+  stage_count = 0;
+#endif
+  if (pocket_runtime_harness_call(7, 35, &value))
+    return 0;
+  if (pocket_runtime_harness_bind("missing"))
+    return 0;
+  if (!pocket_runtime_harness_bind("__pocketHarnessDispatch"))
+    return 0;
+  if (!pocket_runtime_harness_call(7, 35, &value) || value != 42)
+    return 0;
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+  if (!expect_stages("harness call", NULL, 0))
+    return 0;
+#endif
+  if (!pocket_runtime_tick(&input))
+    return 0;
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+  if (!expect_stages("dispatcher jobs", frame, 4))
+    return 0;
+#endif
+  pocket_runtime_shutdown();
+  if (pocket_runtime_harness_call(7, 35, &value))
+    return 0;
+  return 1;
+}
+#endif
+
+int main(void) {
+#if defined(POCKET_RUNTIME_STAGE_HOOKS)
+  if (!test_boot_sequences() || !test_frame_sequences())
+    return 1;
+#else
+  PocketRuntimeInput input = {0};
+  if (!boot(SCENARIO_SUCCESS) || !pocket_runtime_tick(&input))
+    return 1;
+  pocket_runtime_shutdown();
+#endif
+#if defined(POCKET_RUNTIME_HARNESS)
+  if (!test_dispatcher_contract())
+    return 1;
+#endif
+  puts("quickjs-c harness: ok");
+  return 0;
+}
+
+JSRuntime *JS_NewRuntime(void) {
+  stub_runtime.alive = 1;
+  return &stub_runtime;
+}
+
+void JS_FreeRuntime(JSRuntime *runtime) { runtime->alive = 0; }
+void JS_SetMaxStackSize(JSRuntime *runtime, size_t size) {}
+
+JSContext *JS_NewContext(JSRuntime *runtime) {
+  stub_context.alive = 1;
+  return &stub_context;
+}
+
+void JS_FreeContext(JSContext *context) { context->alive = 0; }
+JSValue JS_GetGlobalObject(JSContext *context) { return VALUE_OBJECT; }
+JSValue JS_GetException(JSContext *context) { return VALUE_OBJECT; }
+int JS_HasException(JSContext *context) { return 0; }
+int JS_IsException(JSValueConst value) { return value == JS_EXCEPTION; }
+int JS_IsUndefined(JSValueConst value) { return value == JS_UNDEFINED; }
+int JS_IsFunction(JSContext *context, JSValueConst value) {
+  return value == VALUE_FRAME_FUNCTION || value == VALUE_HARNESS_FUNCTION;
+}
+void JS_FreeValue(JSContext *context, JSValue value) {}
+
+const char *JS_ToCStringLen2(JSContext *context, size_t *length,
+                             JSValueConst value, int cesu8) {
+  static const char message[] = "stub exception";
+  *length = sizeof(message) - 1;
+  return message;
+}
+
+void JS_FreeCString(JSContext *context, const char *value) {}
+
+int JS_ToInt32(JSContext *context, int32_t *out, JSValueConst value) {
+  *out = (int32_t)value;
+  return 0;
+}
+
+int JS_ToUint32(JSContext *context, uint32_t *out, JSValueConst value) {
+  *out = (uint32_t)value;
+  return 0;
+}
+
+int JS_ToFloat64(JSContext *context, double *out, JSValueConst value) {
+  *out = (double)value;
+  return 0;
+}
+
+JSValue JS_NewInt32(JSContext *context, int32_t value) { return value; }
+JSValue JS_NewUint32(JSContext *context, uint32_t value) { return value; }
+JSValue JS_NewFloat64(JSContext *context, double value) {
+  return (JSValue)value;
+}
+JSValue JS_NewBool(JSContext *context, int value) { return value; }
+JSValue JS_NewString(JSContext *context, const char *value) {
+  return VALUE_OBJECT;
+}
+JSValue JS_NewObject(JSContext *context) { return VALUE_OBJECT; }
+JSValue JS_NewArray(JSContext *context) { return VALUE_OBJECT; }
+
+JSValue JS_NewArrayBuffer(JSContext *context, uint8_t *buffer, size_t length,
+                          void (*free_func)(JSRuntime *runtime, void *opaque,
+                                            void *pointer),
+                          void *opaque, int shared) {
+  return VALUE_OBJECT;
+}
+
+uint8_t *JS_GetArrayBuffer(JSContext *context, size_t *length,
+                           JSValueConst value) {
+  *length = sizeof(framebuffer);
+  return framebuffer;
+}
+
+JSValue JS_GetTypedArrayBuffer(JSContext *context, JSValueConst value,
+                               size_t *offset, size_t *length,
+                               size_t *bytes_per_element) {
+  *offset = 0;
+  *length = sizeof(framebuffer);
+  *bytes_per_element = 1;
+  return VALUE_OBJECT;
+}
+
+JSValue JS_NewCFunctionMagic(JSContext *context, JSCFunctionMagic *function,
+                             const char *name, int length, JSCFunctionEnum kind,
+                             int magic) {
+  return VALUE_FRAME_FUNCTION;
+}
+
+int JS_SetPropertyStr(JSContext *context, JSValueConst object, const char *name,
+                      JSValue value) {
+  return 0;
+}
+
+int JS_SetPropertyUint32(JSContext *context, JSValueConst object,
+                         uint32_t index, JSValue value) {
+  return 0;
+}
+
+JSValue JS_GetPropertyStr(JSContext *context, JSValueConst object,
+                          const char *name) {
+  if (strcmp(name, "frame") == 0) {
+    return scenario == SCENARIO_BOOT_FRAME_MISSING ? JS_UNDEFINED
+                                                   : VALUE_FRAME_FUNCTION;
+  }
+  if (strcmp(name, "__pocketHarnessDispatch") == 0)
+    return VALUE_HARNESS_FUNCTION;
+  return VALUE_OBJECT;
+}
+
+JSValue JS_Eval(JSContext *context, const char *source, size_t length,
+                const char *filename, int flags) {
+  if (strcmp(filename, "app.js") == 0 &&
+      scenario == SCENARIO_BOOT_EVAL_FAILURE) {
+    return JS_EXCEPTION;
+  }
+  return VALUE_OBJECT;
+}
+
+JSValue JS_Call(JSContext *context, JSValueConst function,
+                JSValueConst this_value, int argc, JSValueConst *argv) {
+  if (function == VALUE_HARNESS_FUNCTION) {
+    dispatcher_queued_job = 1;
+    return argv[0] + argv[1];
+  }
+  frame_started = 1;
+  return scenario == SCENARIO_FRAME_JS_FAILURE ? JS_EXCEPTION : VALUE_OBJECT;
+}
+
+int JS_ExecutePendingJob(JSRuntime *runtime, JSContext **context) {
+  *context = &stub_context;
+  if (!frame_started) {
+    if (scenario == SCENARIO_BOOT_JOB_FAILURE && boot_job_calls == 0)
+      return -1;
+    return boot_job_calls++ == 0 ? 1 : 0;
+  }
+  if (scenario == SCENARIO_FRAME_JOB_FAILURE && frame_job_calls == 0)
+    return -1;
+  if (dispatcher_queued_job) {
+    dispatcher_queued_job = 0;
+    return 1;
+  }
+  return frame_job_calls++ == 0 ? 1 : 0;
+}
+
+JSValue JS_ThrowTypeError(JSContext *context, const char *format, ...) {
+  return JS_EXCEPTION;
+}
+JSValue JS_ThrowRangeError(JSContext *context, const char *format, ...) {
+  return JS_EXCEPTION;
+}
+JSValue JS_ThrowInternalError(JSContext *context, const char *format, ...) {
+  return JS_EXCEPTION;
+}
+
+void ui_init(uint32_t raster_density) {}
+void ui_shutdown(void) {}
+void ui_set_viewport(float width, float height) {}
+int32_t ui_create_node(uint32_t node_type) { return 2; }
+void ui_destroy_node(int32_t id) {}
+void ui_insert_before(int32_t parent, int32_t child, int32_t anchor) {}
+void ui_remove_child(int32_t parent, int32_t child) {}
+void ui_set_style(int32_t id, int32_t style_id) {}
+void ui_set_prop(int32_t id, uint32_t prop, double value) {}
+void ui_set_prop_batch(const uint8_t *bytes, size_t length) {}
+void ui_set_text(int32_t id, const uint8_t *text, size_t length) {}
+void ui_replace_text(int32_t id, const uint8_t *text, size_t length) {}
+int32_t ui_upload_texture(const uint8_t *bytes, size_t length, uint32_t width,
+                          uint32_t height, uint32_t pixel_storage) {
+  return 0;
+}
+int32_t ui_upload_img_entry(const uint8_t *bytes, size_t length) { return 0; }
+void ui_free_texture(int32_t handle) {}
+void ui_set_image(int32_t id, int32_t texture) {}
+void ui_set_sprite(int32_t id, int32_t atlas, uint32_t frames, uint32_t columns,
+                   uint32_t step) {}
+int32_t ui_animate(int32_t id, uint32_t prop, double to, uint32_t duration_ms,
+                   uint32_t easing, uint32_t delay_ms) {
+  return 1;
+}
+void ui_cancel_anim(int32_t animation_id) {}
+void ui_set_focus(int32_t id) {}
+void ui_set_active(int32_t id, int32_t active) {}
+int32_t ui_hit_test(float x, float y) { return 0; }
+int32_t ui_hit_test_bounds(float x, float y) { return 0; }
+void ui_set_cursor(int32_t texture, float hot_x, float hot_y, float width,
+                   float height) {}
+void ui_set_cursor_pos(float x, float y) {}
+int32_t ui_load_styles(const uint8_t *bytes, size_t length) { return 1; }
+int32_t ui_load_font_atlas(const uint8_t *bytes, size_t length) { return 1; }
+float ui_measure_text(const uint8_t *text, size_t length, uint32_t font_slot) {
+  return 0.0f;
+}
+void ui_tick(void) {}
+void ui_debug_inspect(int32_t id) {}
+int32_t ui_debug_rect_xy(void) { return 0; }
+int32_t ui_debug_rect_wh(void) { return 0; }
+void ui_debug_pause(int32_t paused) {}
+void ui_debug_step(void) {}
+const uint8_t *ui_render_incremental(void) { return framebuffer; }
+uint32_t ui_framebuffer_width(void) { return 1; }
+uint32_t ui_framebuffer_height(void) { return 1; }
+uint32_t ui_framebuffer_stride(void) { return 4; }
+size_t ui_framebuffer_len(void) { return sizeof(framebuffer); }
+uint64_t ui_damage_attempts(void) { return 0; }
+uint64_t ui_damage_failures(void) { return 0; }
+uint64_t ui_damage_full_redraws(void) { return 0; }
+uint32_t ui_damage_regions(void) { return 0; }
+uint64_t ui_damage_pixels(void) { return 0; }
+int32_t ui_damage_bounds(int32_t *out) { return 0; }
+int32_t ui_gl_initialize(void) { return 1; }
+void ui_gl_reset_resources(void) {}
+void ui_gl_shutdown(void) {}
+int32_t ui_gl_render(int32_t target_x, int32_t target_y, int32_t target_width,
+                     int32_t target_height, int32_t window_width,
+                     int32_t window_height) {
+  return 1;
+}

--- a/tests/fixtures/ui-cabi-allocator/texture_upload.c
+++ b/tests/fixtures/ui-cabi-allocator/texture_upload.c
@@ -1,0 +1,74 @@
+#include "pocket_ui_cabi.h"
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+/* The no_std archive uses panic=abort. Prebuilt liballoc can still reference
+ * this symbol; an unexpected attempt to unwind must fail the C executable. */
+void rust_eh_personality(void) { abort(); }
+
+#ifdef TEST_HOST_ALLOCATOR
+static size_t allocations;
+static size_t reallocations;
+static size_t live_allocations;
+
+static void *aligned(void *pointer) {
+  if (pointer == NULL || (uintptr_t)pointer % 16 != 0) {
+    fputs("host allocator did not return 16-byte-aligned storage\n", stderr);
+    abort();
+  }
+  return pointer;
+}
+
+void *pocket_host_alloc(size_t size) {
+  allocations++;
+  live_allocations++;
+  return aligned(malloc(size));
+}
+
+void *pocket_host_realloc(void *pointer, size_t size) {
+  reallocations++;
+  if (pointer == NULL) live_allocations++;
+  return aligned(realloc(pointer, size));
+}
+
+void pocket_host_free(void *pointer) {
+  if (pointer != NULL) live_allocations--;
+  free(pointer);
+}
+#endif
+
+int main(void) {
+  /* RGBA8888 is pixel-storage value 3 in contracts/spec/spec.ts. Holding
+   * textures of different sizes also exercises growth of the texture table. */
+  enum { TEXTURES = 100, PSM_8888 = 3 };
+  uint8_t pixels[64 * 4];
+  int32_t handles[TEXTURES];
+  for (size_t i = 0; i < sizeof(pixels); i++) pixels[i] = (uint8_t)i;
+
+  for (int cycle = 0; cycle < 2; cycle++) {
+    ui_init(1);
+    for (int i = 0; i < TEXTURES; i++) {
+      const uint32_t width = 1U << (i % 7);
+      handles[i] = ui_upload_texture(pixels, (size_t)width * 4,
+                                     width, 1, PSM_8888);
+      if (handles[i] < 0) {
+        fprintf(stderr, "texture upload failed: cycle=%d texture=%d\n", cycle, i);
+        return 1;
+      }
+    }
+    /* Release half through the public API; shutdown must release the rest. */
+    for (int i = 0; i < TEXTURES; i += 2) ui_free_texture(handles[i]);
+    ui_shutdown();
+#ifdef TEST_HOST_ALLOCATOR
+    if (allocations < TEXTURES || reallocations == 0 || live_allocations != 0) {
+      fprintf(stderr, "allocator calls: alloc=%zu realloc=%zu live=%zu\n",
+              allocations, reallocations, live_allocations);
+      return 1;
+    }
+#endif
+  }
+  puts("ui-cabi C allocator: 200 texture uploads and shutdown cleanup passed");
+  return 0;
+}

--- a/tests/quickjs-c-harness.test.ts
+++ b/tests/quickjs-c-harness.test.ts
@@ -1,0 +1,68 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repository = fileURLToPath(new URL("..", import.meta.url));
+const build = mkdtempSync(join(tmpdir(), "pocketjs-quickjs-c-harness-"));
+const runtime = join(repository, "engine/quickjs-c/pocket_runtime.c");
+const fixture = join(
+  repository,
+  "tests/fixtures/quickjs-c-harness/runtime_harness.c",
+);
+
+afterAll(() => rmSync(build, { recursive: true, force: true }));
+
+function run(command: string, args: readonly string[]): string {
+  const result = Bun.spawnSync([command, ...args], {
+    cwd: repository,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const stdout = result.stdout.toString();
+  const stderr = result.stderr.toString();
+  expect(
+    result.exitCode,
+    `${command} ${args.join(" ")}\n${stdout}${stderr}`,
+  ).toBe(0);
+  return stdout;
+}
+
+describe("portable QuickJS C harness contract", () => {
+  test("links and executes every capability combination", () => {
+    const cc = Bun.which("cc");
+    expect(cc).not.toBeNull();
+
+    const common = [
+      "-std=c99",
+      "-Wall",
+      "-Wextra",
+      "-Werror",
+      "-Wno-unused-parameter",
+      '-DPOCKETJS_TARGET_ID="harness-test"',
+      "-DPOCKETJS_HOST_ABI=0",
+      "-I",
+      join(repository, "tests/fixtures/quickjs-c-harness"),
+      "-I",
+      join(repository, "engine/quickjs-c"),
+      "-I",
+      join(repository, "engine/ui-cabi/include"),
+      "-I",
+      join(repository, "contracts/generated"),
+    ];
+    const runVariant = (name: string, defines: readonly string[]) => {
+      const binary = join(build, name);
+      run(cc!, [...common, ...defines, runtime, fixture, "-o", binary]);
+      expect(run(binary, [])).toBe("quickjs-c harness: ok\n");
+    };
+
+    runVariant("production", []);
+    runVariant("stages", ["-DPOCKET_RUNTIME_STAGE_HOOKS"]);
+    runVariant("harness", ["-DPOCKET_RUNTIME_HARNESS"]);
+    runVariant("stages-and-harness", [
+      "-DPOCKET_RUNTIME_STAGE_HOOKS",
+      "-DPOCKET_RUNTIME_HARNESS",
+    ]);
+  });
+});

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -283,6 +283,72 @@ describe("basic mount", () => {
 });
 
 describe("<For> reorder — DOM move semantics [R]", () => {
+  test("rejects a foreign anchor before mutating either tree", () => {
+    const parent = createElement("view");
+    const other = createElement("view");
+    const node = createElement("view");
+    const anchor = createElement("view");
+    insertNode(root, parent);
+    insertNode(root, other);
+    insertNode(parent, node);
+    insertNode(other, anchor);
+    host.clear();
+
+    expect(() => insertNode(parent, node, anchor)).toThrow(
+      "PocketJS: insert anchor is not a child of parent",
+    );
+    expect(node.parent).toBe(parent);
+    expect(childIds(parent)).toEqual([node.id]);
+    expect(host.of("insertBefore", "removeChild")).toEqual([]);
+  });
+
+  test("pure reverse never anchors a node on itself (DOM pre-insertion)", () => {
+    interface Row {
+      id: number;
+    }
+    const first: Row[] = Array.from({ length: 6 }, (_, i) => ({ id: i + 1 }));
+    const [rows, setRows] = createSignal(first);
+    const byId = new Map<number, NodeMirror>();
+    const dispose = render(
+      () =>
+        comp(For, {
+          get each() {
+            return rows();
+          },
+          children: (row: Row) => {
+            const el = createElement("view");
+            byId.set(row.id, el);
+            return el;
+          },
+        }),
+      root,
+    );
+    runSweep();
+    host.clear();
+
+    setRows([...first].reverse());
+    runSweep();
+    expect(childIds(root)).toEqual(
+      [6, 5, 4, 3, 2, 1].map((id) => byId.get(id)!.id),
+    );
+    for (const call of host.of("insertBefore")) {
+      expect(call[2]).not.toBe(call[3]);
+    }
+    expect(host.of("createNode")).toEqual([]);
+    expect(host.of("destroyNode")).toEqual([]);
+
+    // Exercise the update-then-reverse shape used by the external benchmark.
+    const second = first.map((row, i) => (i === 2 ? { id: 99 } : row));
+    setRows(second);
+    runSweep();
+    setRows([...second].reverse());
+    runSweep();
+    expect(childIds(root)).toEqual(
+      [...second].reverse().map((row) => byId.get(row.id)!.id),
+    );
+    dispose();
+  });
+
   test("reorder moves nodes without duplicates and without destroys", () => {
     const [items, setItems] = createSignal(["a", "b", "c"]);
     const byLabel = new Map<string, NodeMirror>();

--- a/tests/ui-cabi-allocator.test.ts
+++ b/tests/ui-cabi-allocator.test.ts
@@ -1,0 +1,61 @@
+import { afterAll, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repository = fileURLToPath(new URL("..", import.meta.url));
+const build = mkdtempSync(join(tmpdir(), "pocketjs-ui-cabi-allocator-"));
+const crate = join(repository, "engine/ui-cabi");
+const config = Bun.TOML.parse(readFileSync(join(crate, "rust-toolchain.toml"), "utf8")) as {
+  toolchain: { channel: string };
+};
+
+afterAll(() => rmSync(build, { recursive: true, force: true }));
+
+function run(command: string[], env: NodeJS.ProcessEnv = process.env): string {
+  const result = Bun.spawnSync(command, {
+    cwd: repository,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(
+    result.exitCode,
+    `${command.join(" ")} (signal=${result.signalCode})\n${result.stdout}${result.stderr}`,
+  ).toBe(0);
+  return result.stdout.toString().trim();
+}
+
+test("real CAllocator uploads textures through malloc and host callbacks", () => {
+  // Resolve both binaries: a Homebrew rustc earlier on PATH must not turn a
+  // pinned nightly Cargo invocation into a stable no_std build.
+  const cargo = run(["rustup", "which", "--toolchain", config.toolchain.channel, "cargo"]);
+  const rustc = run(["rustup", "which", "--toolchain", config.toolchain.channel, "rustc"]);
+  const cc = Bun.which("cc");
+  expect(cc).not.toBeNull();
+
+  for (const hostAllocator of [false, true]) {
+    const features = ["bare-platform", "software-only"];
+    if (hostAllocator) features.push("host-allocator");
+    run([
+      cargo, "build", "--locked", "--release",
+      "--manifest-path", join(crate, "Cargo.toml"),
+      "--target-dir", join(build, "target"),
+      "--features", features.join(","),
+    ], { ...process.env, RUSTC: rustc });
+
+    const binary = join(build, hostAllocator ? "host-allocator" : "malloc");
+    run([
+      cc!, "-std=c99", "-Wall", "-Wextra", "-Werror",
+      ...(hostAllocator ? ["-DTEST_HOST_ALLOCATOR"] : []),
+      "-I", join(crate, "include"),
+      join(repository, "tests/fixtures/ui-cabi-allocator/texture_upload.c"),
+      join(build, "target/release/libpocketjs_symbian_core.a"),
+      "-lm", "-o", binary,
+    ]);
+    expect(run([binary])).toBe(
+      "ui-cabi C allocator: 200 texture uploads and shutdown cleanup passed",
+    );
+  }
+}, 180_000);

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -53,6 +53,7 @@ const SUITE: readonly Stage[] = [
       "tests/site-stage.test.ts",
       "tests/host-build-inputs.test.ts",
       "tests/host-layout.test.ts",
+      "tests/quickjs-c-harness.test.ts",
       "tests/3ds-profile.test.ts",
       "tests/3ds-runtime-state.test.ts",
       "tests/3ds-runtime-wire.test.ts",


### PR DESCRIPTION
## Summary

External benchmarks need to attribute guest evaluation, frame execution, pending jobs, and core ticks while driving repeatable actions against the same retained UI instance. This change adds opt-in hooks to `engine/quickjs-c` and `engine/ui-cabi`; the external harness owns action protocols, measurement, and verification.

- `POCKET_RUNTIME_STAGE_HOOKS` reports stage boundaries through `pocket_bench_stage`.
- The separate `POCKET_RUNTIME_HARNESS` capability caches one guest dispatcher and invokes it with two integers through `JS_Call`, without evaluating source text, changing stages, or draining jobs.
- `harness-access` exposes an unsafe closure over the initialized C ABI `Ui`, with a no-concurrency/no-reentrancy lifetime contract.
- Production hosts leave these opt-ins disabled.

Two unconditional correctness fixes support the same workloads: validate foreign insertion anchors before either tree changes, treat insertion before the same node as a positional no-op, and accept the 16-byte texture allocation alignment required by supported 64-bit C hosts.

## Runtime contract

```text
boot success:       EVAL, IDLE, JOBS, IDLE
boot eval failure:  EVAL, IDLE
boot frame missing: EVAL, IDLE
boot job failure:   EVAL, IDLE, JOBS, IDLE
frame success:      JS, JOBS, TICK, IDLE
frame JS failure:   JS, IDLE
frame job failure:  JS, JOBS, IDLE
```

The embedding sets the stage for synchronous dispatcher work. Queued jobs run during the next guest turn's `JOBS` interval. The accessor returns `None` when the singleton is absent and does not create a replacement instance. See `engine/quickjs-c/README.md` for the integration and validation contract.

## Regression coverage

The `Native C harness` workflow runs on pull requests and main changes on Linux and macOS:

- Compile, link, and execute the real `pocket_runtime.c` against deterministic QuickJS/UI stubs in all four stage/dispatcher configurations.
- Run renderer, virtual-list, and Vue DOM contracts.
- Test `ui-cabi` with `harness-access` enabled.
- Build the real `bare-platform,software-only` static library with its pinned nightly, link a C executable, and upload 200 textures per allocator variant through both C `malloc` and host-owned callbacks. Exercise texture-table growth, explicit frees, shutdown, and reinitialization; host callbacks verify alignment, allocator calls, and cleanup.
- Check generated contracts for drift.

The Rust texture unit test uses the default allocator; the linked C fixture is the evidence for the `CAllocator` path. QuickJS stubs establish runtime control flow, not real-engine benchmark parity.

## Validation

Local macOS arm64 validation:

- Runtime/renderer/virtual-list/Vue DOM: 73 tests passed.
- `cargo test --locked --manifest-path engine/ui-cabi/Cargo.toml --features harness-access`: 10 tests passed.
- `bun test tests/ui-cabi-allocator.test.ts`: both real allocator variants passed.
- Negative control: the same linked allocator test aborts on the pre-PR base with the old 8-byte alignment limit.
- `bun tests/contract.ts`, workflow actionlint, and `git diff --check`: passed.
- `bunx tsc --noEmit`: existing TS2353 in `framework/compiler/build-inputs.ts:34` (`BuildConfig.write`), reproduced on base `2d20ddad` with the same dependencies.

Contributor-reported downstream validation (not rerun as part of this CI repair): all three host shells build; 70 benchmark unit tests pass; Solid, Vue Vapor, and Octane match their WASM oracle; incorrect action lists are rejected; full/native/raster share RGBA8 hash `cd14be5e`; guest-tape matches 63,154 operations; native replay has zero return-value mismatches. Benchmark adapters retain the action protocol outside PocketJS, and macro applications receive no dispatcher.
