### PR TITLE
bench(core): add allocator-independent memory receipts

### DIFF
--- a/docs/bench/core-memory-ppsspp-2026-09-05.json
+++ b/docs/bench/core-memory-ppsspp-2026-09-05.json
@@ -1,4 +1,5 @@
 {
+  "schema_version": 1,
   "status": "BLOCKED",
   "selected_app": "stats",
   "framework": "solid",
@@ -6,8 +7,23 @@
   "report_path": null,
   "checksum": null,
   "commands": {
-    "baseline": "PSP_SDK=\"$PSP_SDK\" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3",
-    "memory_scan": "PSP_SDK=\"$PSP_SDK\" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3 --memory-scan"
+    "baseline": {
+      "command": "PSP_SDK=\"$PSP_SDK\" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3",
+      "status": "BLOCKED",
+      "exit_status": 1,
+      "blocker": "PPSSPPHeadless not found at /Users/quake/ppsspp-src/build/PPSSPPHeadless"
+    },
+    "memory_scan": {
+      "command": "PSP_SDK=\"$PSP_SDK\" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3 --memory-scan",
+      "status": "BLOCKED",
+      "exit_status": 1,
+      "blocker": "PPSSPPHeadless not found at /Users/quake/ppsspp-src/build/PPSSPPHeadless"
+    }
+  },
+  "execution_context": {
+    "checkout": "git checkout --detach 2e93828",
+    "git_revision_used_for_both_attempts": "2e93828",
+    "later_metadata_commits_benchmarked": false
   },
   "revisions": {
     "git_revision": "2e93828",
@@ -25,8 +41,13 @@
   },
   "blocker": {
     "psp_sdk": "unset",
+    "ppsspp_headless_override": "unset/unknown",
     "ppsspp_headless": "/Users/quake/ppsspp-src/build/PPSSPPHeadless",
     "reason": "Required PSP_SDK and PPSSPPHeadless dependencies are unavailable; both commands failed before the benchmark ran."
+  },
+  "field_definitions": {
+    "report_path": "Expected generated JSON report path under dist/bench/ (ppsspp-bench-<timestamp>.json); null means no report was generated.",
+    "checksum": "Checksum of the benchmark drawlist used by the run; null means no benchmark ran."
   },
   "caveat": "PPSSPP measurements are emulator evidence, not real PSP hardware proof. Arena high-water is a practical allocator capacity requirement, not a precise live-object heap profile."
 }

--- a/docs/bench/core-memory-ppsspp-2026-09-05.json
+++ b/docs/bench/core-memory-ppsspp-2026-09-05.json
@@ -3,6 +3,8 @@
   "selected_app": "stats",
   "framework": "solid",
   "samples": 3,
+  "report_path": null,
+  "checksum": null,
   "commands": {
     "baseline": "PSP_SDK=\"$PSP_SDK\" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3",
     "memory_scan": "PSP_SDK=\"$PSP_SDK\" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3 --memory-scan"

--- a/docs/bench/core-memory-ppsspp-2026-09-05.json
+++ b/docs/bench/core-memory-ppsspp-2026-09-05.json
@@ -2,6 +2,7 @@
   "schema_version": 1,
   "status": "BLOCKED",
   "selected_app": "stats",
+  "workload_role": "representative workload for the shared workload profile; not a byte-identical event sequence",
   "framework": "solid",
   "samples": 3,
   "report_path": null,
@@ -47,7 +48,7 @@
   },
   "field_definitions": {
     "report_path": "Expected generated JSON report path under dist/bench/ (ppsspp-bench-<timestamp>.json); null means no report was generated.",
-    "checksum": "Checksum of the benchmark drawlist used by the run; null means no benchmark ran."
+    "checksum": "Checksum of the representative workload drawlist used by the run; null means no benchmark ran. Compare with the Rust profile and report differences explicitly."
   },
   "caveat": "PPSSPP measurements are emulator evidence, not real PSP hardware proof. Arena high-water is a practical allocator capacity requirement, not a precise live-object heap profile."
 }

--- a/docs/bench/core-memory-ppsspp-2026-09-05.json
+++ b/docs/bench/core-memory-ppsspp-2026-09-05.json
@@ -1,0 +1,30 @@
+{
+  "status": "BLOCKED",
+  "selected_app": "stats",
+  "framework": "solid",
+  "samples": 3,
+  "commands": {
+    "baseline": "PSP_SDK=\"$PSP_SDK\" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3",
+    "memory_scan": "PSP_SDK=\"$PSP_SDK\" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3 --memory-scan"
+  },
+  "revisions": {
+    "git_revision": "2e93828",
+    "ppsspp_revision": null
+  },
+  "metrics": {
+    "arena_bump_bytes": null,
+    "arena_tail_free_bytes": null,
+    "avg_tick_us": null,
+    "avg_work_us": null,
+    "max_work_us": null,
+    "uncapped_arena_bump_bytes": null,
+    "min_pass_arena_bytes": null,
+    "safe_arena_bytes": null
+  },
+  "blocker": {
+    "psp_sdk": "unset",
+    "ppsspp_headless": "/Users/quake/ppsspp-src/build/PPSSPPHeadless",
+    "reason": "Required PSP_SDK and PPSSPPHeadless dependencies are unavailable; both commands failed before the benchmark ran."
+  },
+  "caveat": "PPSSPP measurements are emulator evidence, not real PSP hardware proof. Arena high-water is a practical allocator capacity requirement, not a precise live-object heap profile."
+}

--- a/docs/bench/core-memory-ppsspp-2026-09-05.md
+++ b/docs/bench/core-memory-ppsspp-2026-09-05.md
@@ -2,11 +2,23 @@
 
 Status: **BLOCKED**
 
+Receipt schema version: **1**
+
+**No measurements were recorded.** All metric fields remain `null` because no
+benchmark command reached the PSP app.
+
 The canonical target workload is **`stats`**, using the existing fixed input
 script and the existing PSP JSONL schema. No second demo or Taffy A/B run was
 added.
 
 ## Commands
+
+Both commands were attempted with the repository checked out at the detached
+revision `2e93828`. The later receipt metadata commits were not benchmarked.
+
+```bash
+git checkout --detach 2e93828
+```
 
 Baseline:
 
@@ -14,10 +26,26 @@ Baseline:
 PSP_SDK="$PSP_SDK" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3
 ```
 
+Status: **BLOCKED**; exit status: `1`.
+
+Error:
+
+```text
+PPSSPPHeadless not found at /Users/quake/ppsspp-src/build/PPSSPPHeadless
+```
+
 Memory scan:
 
 ```bash
 PSP_SDK="$PSP_SDK" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3 --memory-scan
+```
+
+Status: **BLOCKED**; exit status: `1`.
+
+Error:
+
+```text
+PPSSPPHeadless not found at /Users/quake/ppsspp-src/build/PPSSPPHeadless
 ```
 
 ## Revisions
@@ -29,21 +57,28 @@ PSP_SDK="$PSP_SDK" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stat
 | selected app | `stats` |
 | framework | `solid` |
 | samples | `3` |
-| report path | `null` (unavailable) |
-| checksum | `null` (unavailable) |
+| report path | `null` |
+| checksum | `null` |
+
+`report_path` is the expected generated JSON report path under `dist/bench/`,
+using `ppsspp-bench-<timestamp>.json`; it is `null` because no report was
+generated. `checksum` is the checksum of the benchmark drawlist; it is `null`
+because no benchmark ran.
 
 ## Metrics
 
-No measurements were recorded. The following requested fields are therefore
-**null**, not fabricated: `arena_bump_bytes`, `arena_tail_free_bytes`,
+The following requested fields are therefore **null**, not fabricated:
+`arena_bump_bytes`, `arena_tail_free_bytes`,
 `avg_tick_us`, `avg_work_us`, `max_work_us`, `uncapped_arena_bump_bytes`,
 `min_pass_arena_bytes`, and `safe_arena_bytes`.
 
 ## Blocker
 
-`PSP_SDK` was unset and
-`/Users/quake/ppsspp-src/build/PPSSPPHeadless` was not present. Both commands
-failed in `tools/bench-ppsspp.ts` before the PSP app was built or run:
+`PSP_SDK` was **unset**. The `PPSSPP_HEADLESS` override was **unset/unknown**;
+the runner therefore used the default path
+`/Users/quake/ppsspp-src/build/PPSSPPHeadless`, which was not present. Both
+commands failed in `tools/bench-ppsspp.ts` before the PSP app was built or run.
+No measurements were recorded:
 
 ```text
 PPSSPPHeadless not found at /Users/quake/ppsspp-src/build/PPSSPPHeadless

--- a/docs/bench/core-memory-ppsspp-2026-09-05.md
+++ b/docs/bench/core-memory-ppsspp-2026-09-05.md
@@ -7,9 +7,11 @@ Receipt schema version: **1**
 **No measurements were recorded.** All metric fields remain `null` because no
 benchmark command reached the PSP app.
 
-The canonical target workload is **`stats`**, using the existing fixed input
-script and the existing PSP JSONL schema. No second demo or Taffy A/B run was
-added.
+The PSP target is the **`stats` representative workload**, using the existing
+fixed input script and PSP JSONL schema. It corresponds to phases in the Rust
+synthetic workload profile; the two journeys are not byte-identical event
+sequences. No second demo or Taffy A/B run was added. Any checksum difference
+must be reported explicitly when measurements are available.
 
 ## Commands
 
@@ -62,7 +64,7 @@ PPSSPPHeadless not found at /Users/quake/ppsspp-src/build/PPSSPPHeadless
 
 `report_path` is the expected generated JSON report path under `dist/bench/`,
 using `ppsspp-bench-<timestamp>.json`; it is `null` because no report was
-generated. `checksum` is the checksum of the benchmark drawlist; it is `null`
+generated. `checksum` is the checksum of the representative workload drawlist; it is `null`
 because no benchmark ran.
 
 ## Metrics

--- a/docs/bench/core-memory-ppsspp-2026-09-05.md
+++ b/docs/bench/core-memory-ppsspp-2026-09-05.md
@@ -29,6 +29,8 @@ PSP_SDK="$PSP_SDK" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stat
 | selected app | `stats` |
 | framework | `solid` |
 | samples | `3` |
+| report path | `null` (unavailable) |
+| checksum | `null` (unavailable) |
 
 ## Metrics
 

--- a/docs/bench/core-memory-ppsspp-2026-09-05.md
+++ b/docs/bench/core-memory-ppsspp-2026-09-05.md
@@ -1,0 +1,57 @@
+# Core Memory PSP Receipt
+
+Status: **BLOCKED**
+
+The canonical target workload is **`stats`**, using the existing fixed input
+script and the existing PSP JSONL schema. No second demo or Taffy A/B run was
+added.
+
+## Commands
+
+Baseline:
+
+```bash
+PSP_SDK="$PSP_SDK" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3
+```
+
+Memory scan:
+
+```bash
+PSP_SDK="$PSP_SDK" BENCH_PPSSPP_TIMEOUT=60 bun tools/bench-ppsspp.ts --apps=stats --samples=3 --memory-scan
+```
+
+## Revisions
+
+| item | value |
+|---|---|
+| git revision | `2e93828` |
+| PPSSPP revision | unavailable |
+| selected app | `stats` |
+| framework | `solid` |
+| samples | `3` |
+
+## Metrics
+
+No measurements were recorded. The following requested fields are therefore
+**null**, not fabricated: `arena_bump_bytes`, `arena_tail_free_bytes`,
+`avg_tick_us`, `avg_work_us`, `max_work_us`, `uncapped_arena_bump_bytes`,
+`min_pass_arena_bytes`, and `safe_arena_bytes`.
+
+## Blocker
+
+`PSP_SDK` was unset and
+`/Users/quake/ppsspp-src/build/PPSSPPHeadless` was not present. Both commands
+failed in `tools/bench-ppsspp.ts` before the PSP app was built or run:
+
+```text
+PPSSPPHeadless not found at /Users/quake/ppsspp-src/build/PPSSPPHeadless
+```
+
+Human follow-up: provide a valid `PSP_SDK` and build or set
+`PPSSPP_HEADLESS`, then rerun both commands and replace this blocked receipt
+with the resulting samples and arena scan values.
+
+**PPSSPP results, when available, are emulator evidence rather than real PSP
+hardware proof.** `arena_bump_bytes` is a practical allocator capacity
+requirement and includes size-class fragmentation; it is not a precise
+live-object heap profile.

--- a/docs/superpowers/plans/2026-09-05-core-memory-benchmark.md
+++ b/docs/superpowers/plans/2026-09-05-core-memory-benchmark.md
@@ -2,7 +2,7 @@
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
 
-**Goal:** Add a deterministic allocator-independent core memory receipt and connect the same structural-relayout workload to the existing PSP/PPSSPP arena benchmark without merging the Taffy rebuild candidate.
+**Goal:** Add a deterministic allocator-independent core memory receipt and connect its shared workload profile to the existing PSP/PPSSPP representative arena benchmark without merging the Taffy rebuild candidate.
 
 **Architecture:** The host benchmark is a standalone `pocketjs-core` example with a counting global allocator. All fixture and harness allocations are completed before measurement, and the measured phase emits JSON only after counting is disabled. PSP evidence continues to come from `tools/bench-ppsspp.ts` and `hosts/psp` stats, so canonical requested bytes and target arena high-water remain separate metrics.
 
@@ -152,21 +152,22 @@ git add engine/core/examples/membench_baseline.json engine/core/examples/membenc
 git commit -m "bench(core): record baseline memory receipt"
 ```
 
-### Task 3: Align The PSP Workload And Timing Receipt
+### Task 3: Align The PSP Representative Workload And Timing Receipt
 
 **Files:**
-- Modify: `tools/bench-ppsspp.ts:81-100` to expose the existing `stats` workload as the canonical structural-memory run
+- Modify: `tools/bench-ppsspp.ts:81-100` to expose the existing `stats` workload as the representative structural-memory run
 - Modify: `skills/pocketjs-psp-benchmark/references/metrics.md` for any new fields
 - Create: `docs/bench/core-memory-ppsspp-2026-09-05.json`
 - Create: `docs/bench/core-memory-ppsspp-2026-09-05.md`
 
 - [ ] **Step 1: Define the shared workload profile without changing existing app defaults**
 
-Use the existing `stats` app and its fixed input script as the target workload.
+Use the existing `stats` app and its fixed input script as the representative workload.
 Keep `stats` as the default app and preserve all existing app scripts. Align
 the host benchmark phases with the stats app's initial dashboard construction,
 style-only counter/bar animation, deterministic tab switch, and repeated text
-updates. Do not add a second demo app solely for memory measurement.
+updates. These are corresponding phases in a shared workload profile, not a
+byte-identical event sequence. Do not add a second demo app solely for memory measurement.
 
 - [ ] **Step 2: Verify PSP JSONL fields before changing the schema**
 
@@ -195,7 +196,8 @@ PSP_SDK="$PSP_SDK" BENCH_PPSSPP_TIMEOUT=60 \
 
 Record the report path, PPSSPP revision, git revision, selected app, sample
 count, `arena_bump_bytes`, `avg_tick_us`, `avg_work_us`, and checksum. The
-receipt must state that the target workload is `stats`.
+receipt must state that the target is the representative `stats` workload and
+must report any checksum difference explicitly.
 
 - [ ] **Step 4: Run the capped arena scan**
 

--- a/docs/superpowers/plans/2026-09-05-core-memory-benchmark.md
+++ b/docs/superpowers/plans/2026-09-05-core-memory-benchmark.md
@@ -128,11 +128,14 @@ The test must fail if fixture construction or report formatting becomes part of
 the measured allocation window. It must assert that all required fields are
 present and non-negative.
 
-- [ ] **Step 2: Record a baseline from latest `origin/main`**
+- [ ] **Step 2: Record a baseline from a harness based on latest `origin/main`**
 
 Generate a JSON receipt from the benchmark and a short Markdown table that
-labels the values as allocator-independent requested-byte metrics. Include the
-exact command, Rust toolchain, git revision, workload shape, and checksum.
+labels the values as allocator-independent requested-byte metrics. The harness
+may be based on the latest `origin/main`, but the receipt is measured at the
+harness's own `git_revision`, not from `origin/main`; record
+`origin_main_revision` separately. Include the benchmark implementation
+revision, exact command, Rust toolchain, workload shape, and checksum.
 
 - [ ] **Step 3: Run core verification**
 

--- a/docs/superpowers/plans/2026-09-05-core-memory-benchmark.md
+++ b/docs/superpowers/plans/2026-09-05-core-memory-benchmark.md
@@ -1,0 +1,260 @@
+# Core Memory Benchmark Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a deterministic allocator-independent core memory receipt and connect the same structural-relayout workload to the existing PSP/PPSSPP arena benchmark without merging the Taffy rebuild candidate.
+
+**Architecture:** The host benchmark is a standalone `pocketjs-core` example with a counting global allocator. All fixture and harness allocations are completed before measurement, and the measured phase emits JSON only after counting is disabled. PSP evidence continues to come from `tools/bench-ppsspp.ts` and `hosts/psp` stats, so canonical requested bytes and target arena high-water remain separate metrics.
+
+**Tech Stack:** Rust `pocketjs-core` example, `std::alloc::GlobalAlloc`, `std::time::Instant`, Bun/TypeScript PPSSPP runner, PSP JSONL stats, Cargo tests.
+
+---
+
+### Task 1: Add The Isolated Core Benchmark Harness
+
+**Files:**
+- Create: `engine/core/examples/membench.rs`
+
+- [ ] **Step 1: Define the machine-readable report contract**
+
+Create a Rust report struct or fixed output writer with these exact fields:
+
+```text
+peak_requested_bytes
+final_requested_bytes
+allocation_count
+total_allocated_bytes
+avg_layout_us
+max_layout_us
+nodes
+structural_relayouts
+text_mode
+texture_mode
+drawlist_checksum
+```
+
+Keep output deterministic: stable field order, no timestamps, no process IDs,
+and no allocator addresses.
+
+- [ ] **Step 2: Add counting allocator scope controls**
+
+Implement a `GlobalAlloc` wrapper around `System` that tracks requested sizes
+for `alloc`, `alloc_zeroed`, `realloc`, and `dealloc`. Add a scoped boolean or
+counter with these semantics:
+
+```rust
+fn begin_measurement() {
+    LIVE.store(0, Ordering::Relaxed);
+    PEAK.store(0, Ordering::Relaxed);
+    TOTAL.store(0, Ordering::Relaxed);
+    COUNT.store(0, Ordering::Relaxed);
+    COUNTING.store(true, Ordering::Relaxed);
+}
+
+fn end_measurement() {
+    COUNTING.store(false, Ordering::Relaxed);
+}
+```
+
+When counting is disabled, allocator calls must still delegate to `System` but
+must not change any counters. The report formatter must run after
+`end_measurement()`.
+
+- [ ] **Step 3: Prebuild all fixture and harness storage**
+
+Construct style blobs, atlas blobs, source strings, node-handle vectors, and
+input/churn data while counting is disabled. Reserve the exact capacities of
+all vectors that are mutated during the measured phase. Do not retain a
+`HashMap`/`HashSet` mirror of the core tree unless its allocations are created
+before measurement and never grow afterward.
+
+The measured phase must contain only calls through the public core API plus
+pre-reserved benchmark bookkeeping.
+
+- [ ] **Step 4: Implement the deterministic five-phase workload**
+
+Use the following phase order and counters:
+
+1. build the initial tree and resources;
+2. run steady style-only ticks;
+3. create and destroy fixed-size subtrees;
+4. update text and force structural relayouts at fixed intervals;
+5. run one fixed burst that exercises the peak path.
+
+Count a structural relayout at the call site that changes the tree or text
+structure. Measure layout duration around the core tick/layout call with
+`Instant::now()` and accumulate `avg_layout_us` and `max_layout_us`.
+
+- [ ] **Step 5: Preserve semantic output checks**
+
+Accumulate a deterministic drawlist checksum after each draw. Keep the final
+checksum in the report so memory-only benchmark changes cannot silently alter
+rendered behavior.
+
+- [ ] **Step 6: Run the example twice and verify deterministic output**
+
+Run:
+
+```bash
+cargo run --manifest-path engine/core/Cargo.toml --example membench --quiet
+cargo run --manifest-path engine/core/Cargo.toml --example membench --quiet
+```
+
+Expected result: all canonical memory fields and the checksum are identical.
+Timing fields are parsed but excluded from byte-for-byte comparison because
+host scheduling can vary. Timing is compared statistically in the PSP runner.
+
+- [ ] **Step 7: Commit the standalone harness**
+
+```bash
+git add engine/core/examples/membench.rs
+git commit -m "bench(core): add isolated memory receipt"
+```
+
+### Task 2: Add Benchmark Checks And Baseline Receipt
+
+**Files:**
+- Create: `engine/core/examples/membench_baseline.json`
+- Create: `engine/core/examples/membench_baseline.md`
+- Create: `tests/core-memory-bench.test.ts`
+
+- [ ] **Step 1: Add a deterministic receipt check**
+
+Use Bun's `$` command runner to invoke the Rust example twice, parse each
+newline-delimited field, and compare the canonical memory fields and checksum.
+Do not compare wall-clock timing fields byte-for-byte.
+
+The test must fail if fixture construction or report formatting becomes part of
+the measured allocation window. It must assert that all required fields are
+present and non-negative.
+
+- [ ] **Step 2: Record a baseline from latest `origin/main`**
+
+Generate a JSON receipt from the benchmark and a short Markdown table that
+labels the values as allocator-independent requested-byte metrics. Include the
+exact command, Rust toolchain, git revision, workload shape, and checksum.
+
+- [ ] **Step 3: Run core verification**
+
+Run:
+
+```bash
+cargo test --manifest-path engine/core/Cargo.toml
+cargo run --manifest-path engine/core/Cargo.toml --example membench --quiet
+```
+
+Expected result: all core tests pass and the receipt check passes.
+
+- [ ] **Step 4: Commit the baseline receipt**
+
+```bash
+git add engine/core/examples/membench_baseline.json engine/core/examples/membench_baseline.md tests/
+git commit -m "bench(core): record baseline memory receipt"
+```
+
+### Task 3: Align The PSP Workload And Timing Receipt
+
+**Files:**
+- Modify: `tools/bench-ppsspp.ts:81-100` to expose the existing `stats` workload as the canonical structural-memory run
+- Modify: `skills/pocketjs-psp-benchmark/references/metrics.md` for any new fields
+- Create: `docs/bench/core-memory-ppsspp-2026-09-05.json`
+- Create: `docs/bench/core-memory-ppsspp-2026-09-05.md`
+
+- [ ] **Step 1: Define the shared workload profile without changing existing app defaults**
+
+Use the existing `stats` app and its fixed input script as the target workload.
+Keep `stats` as the default app and preserve all existing app scripts. Align
+the host benchmark phases with the stats app's initial dashboard construction,
+style-only counter/bar animation, deterministic tab switch, and repeated text
+updates. Do not add a second demo app solely for memory measurement.
+
+- [ ] **Step 2: Verify PSP JSONL fields before changing the schema**
+
+Use the existing fields first:
+
+```text
+arena_bump_bytes
+arena_tail_free_bytes
+avg_tick_us
+avg_work_us
+max_work_us
+```
+
+`avg_tick_us` is the existing combined core tick, animation, and layout timing
+metric. Use it as the PSP-side layout proxy, and preserve the existing JSONL
+schema in this benchmark branch.
+
+- [ ] **Step 3: Run a focused PPSSPP baseline**
+
+Run:
+
+```bash
+PSP_SDK="$PSP_SDK" BENCH_PPSSPP_TIMEOUT=60 \
+  bun tools/bench-ppsspp.ts --apps=stats --samples=3
+```
+
+Record the report path, PPSSPP revision, git revision, selected app, sample
+count, `arena_bump_bytes`, `avg_tick_us`, `avg_work_us`, and checksum. The
+receipt must state that the target workload is `stats`.
+
+- [ ] **Step 4: Run the capped arena scan**
+
+Run:
+
+```bash
+PSP_SDK="$PSP_SDK" BENCH_PPSSPP_TIMEOUT=60 \
+  bun tools/bench-ppsspp.ts --apps=stats --samples=3 --memory-scan
+```
+
+Record `uncapped_arena_bump_bytes`, `min_pass_arena_bytes`, and
+`safe_arena_bytes`. Report this as PPSSPP evidence, not real hardware proof.
+
+- [ ] **Step 5: Update metric documentation and commit evidence**
+
+Document any new fields in `skills/pocketjs-psp-benchmark/references/metrics.md`
+and write the JSON/Markdown receipt under `docs/bench/`. Commit with:
+
+```bash
+git add tools/bench-ppsspp.ts \
+  skills/pocketjs-psp-benchmark/references/metrics.md \
+  docs/bench/core-memory-ppsspp-2026-09-05.json \
+  docs/bench/core-memory-ppsspp-2026-09-05.md
+git commit -m "bench(psp): record core memory arena receipt"
+```
+
+### Task 4: Final Verification And Handoff
+
+**Files:**
+- No Taffy rebuild implementation files are modified in this task
+
+- [ ] **Step 1: Verify the branch contains no candidate optimization**
+
+Run:
+
+```bash
+git diff origin/main...HEAD -- engine/core/src/layout.rs engine/core/src/tree.rs
+```
+
+Expected result: no diff in either file.
+
+- [ ] **Step 2: Run final checks**
+
+Run:
+
+```bash
+cargo test --manifest-path engine/core/Cargo.toml
+git diff --check
+git status --short --branch
+```
+
+Expected result: tests pass, no whitespace errors, and the working tree is
+clean.
+
+- [ ] **Step 3: Review benchmark evidence**
+
+Confirm that the final report separates:
+
+- canonical core requested-byte metrics;
+- PSP arena high-water metrics;
+- timing metrics;
+- PPSSPP limitations.

--- a/docs/superpowers/specs/2026-09-05-core-memory-benchmark-design.md
+++ b/docs/superpowers/specs/2026-09-05-core-memory-benchmark-design.md
@@ -1,0 +1,114 @@
+# Core Memory Benchmark Design
+
+## Purpose
+
+Measure core memory changes independently from host allocator behavior, then
+validate the operational result on PSP/PPSSPP using the existing arena
+high-water metrics.
+
+The benchmark must not claim that a host allocator's requested-byte count is a
+PSP memory requirement. The two measurements answer different questions.
+
+## Scope
+
+This work covers:
+
+- a deterministic, host-side `pocketjs-core` memory and layout benchmark;
+- corrected separation between benchmark workload allocations and harness
+  allocations;
+- machine-readable canonical memory and layout metrics;
+- PSP/PPSSPP collection of `arena_bump_bytes` and layout timing for the same
+  workload;
+- baseline receipts from the latest `origin/main`.
+
+This work does not merge the Taffy storage rebuild strategy. That strategy is
+an A/B candidate for a later change and will consume the benchmark receipts.
+
+## Metrics
+
+### Canonical core metrics
+
+The host benchmark reports:
+
+- `peak_requested_bytes`: maximum simultaneously-live allocation bytes
+  requested by the measured core workload;
+- `final_requested_bytes`: requested bytes still live after the workload;
+- `allocation_count`: number of measured allocation operations;
+- `total_allocated_bytes`: cumulative requested allocation bytes;
+- `avg_layout_us`: average measured layout duration;
+- `max_layout_us`: maximum measured layout duration;
+- workload shape: live node count, structural relayout count, and text/texture
+  mode.
+
+The benchmark excludes fixture construction, result formatting, and reporting
+allocations. It must prebuild and reserve harness data before measurement and
+disable counting before formatting the report.
+
+These metrics are allocator-independent requested-byte metrics. They are used
+to compare core revisions, not to estimate a PSP arena capacity.
+
+### PSP metrics
+
+The existing PSP stats and PPSSPP runner remain authoritative for target
+behavior:
+
+- `arena_bump_bytes`;
+- `arena_tail_free_bytes`;
+- `avg_tick_us` and `avg_work_us`;
+- structural relayout/layout timing where the host exposes it;
+- `min_pass_arena_bytes` and `safe_arena_bytes` when `--memory-scan` runs.
+
+PPSSPP output is reported as emulator evidence. It is not presented as real
+PSP hardware proof.
+
+## Workload
+
+Use one deterministic UI journey with explicit phases:
+
+1. boot and initial tree construction;
+2. steady ticks with style-only animation;
+3. structural churn with subtree creation and destruction;
+4. text updates and relayout;
+5. optional burst phase for peak allocation behavior.
+
+The journey must keep its input data and output buffers outside the measured
+allocation window. The same logical workload must be runnable by the host
+benchmark and the PSP/PPSSPP benchmark, with target-specific launch wrappers
+only where required.
+
+## A/B Boundary
+
+The benchmark defines, but does not yet merge, two layout implementations:
+
+- baseline: clear and reuse the existing Taffy storage;
+- candidate: rebuild Taffy storage using the structural subtree capacity.
+
+Both variants must use identical workload inputs and produce the same drawlist
+checksum. Candidate acceptance requires no regression in canonical peak bytes,
+PSP arena high-water, average/max layout timing, or frame work timing.
+
+## Implementation Shape
+
+Prefer a host-side counting allocator around the existing core API rather than
+adding production-only accounting fields to core data structures. Keep the
+measurement interface local to the benchmark so normal host allocators and
+target ABI remain unchanged.
+
+The PSP side should reuse `tools/bench-ppsspp.ts`, PSP JSON stats, and the
+existing `--memory-scan` protocol. Add only the smallest wiring needed to
+identify the structural-relayout workload and preserve the existing report
+schema.
+
+## Verification
+
+The implementation is complete when:
+
+- the canonical benchmark is deterministic across repeated runs;
+- harness allocations do not change canonical metrics;
+- core tests and benchmark checks pass;
+- baseline canonical receipts are recorded;
+- PPSSPP reports include `arena_bump_bytes` and layout timing for the same
+  workload;
+- no Taffy rebuild code is included in this branch;
+- the report clearly separates canonical core metrics from PSP operational
+  metrics.

--- a/docs/superpowers/specs/2026-09-05-core-memory-benchmark-design.md
+++ b/docs/superpowers/specs/2026-09-05-core-memory-benchmark-design.md
@@ -17,8 +17,8 @@ This work covers:
 - corrected separation between benchmark workload allocations and harness
   allocations;
 - machine-readable canonical memory and layout metrics;
-- PSP/PPSSPP collection of `arena_bump_bytes` and layout timing for the same
-  workload;
+- PSP/PPSSPP collection of `arena_bump_bytes` and layout timing for a
+  representative workload with the shared workload profile;
 - baseline receipts from the latest `origin/main`.
 
 This work does not merge the Taffy storage rebuild strategy. That strategy is
@@ -72,9 +72,11 @@ Use one deterministic UI journey with explicit phases:
 5. optional burst phase for peak allocation behavior.
 
 The journey must keep its input data and output buffers outside the measured
-allocation window. The same logical workload must be runnable by the host
-benchmark and the PSP/PPSSPP benchmark, with target-specific launch wrappers
-only where required.
+allocation window. The host benchmark defines a shared workload profile. PSP/
+PPSSPP uses the existing stats app as a representative workload with
+corresponding phases and target-specific launch wrappers. The two journeys are
+not required to use byte-identical event sequences; acceptance requires
+reporting any drawlist checksum difference explicitly.
 
 ## A/B Boundary
 
@@ -84,7 +86,8 @@ The benchmark defines, but does not yet merge, two layout implementations:
 - candidate: rebuild Taffy storage using the structural subtree capacity.
 
 Both variants must use identical workload inputs and produce the same drawlist
-checksum. Candidate acceptance requires no regression in canonical peak bytes,
+checksum. The host and PSP representative workloads report their checksums
+separately. Candidate acceptance requires no regression in canonical peak bytes,
 PSP arena high-water, average/max layout timing, or frame work timing.
 
 ## Implementation Shape

--- a/engine/core/examples/membench.rs
+++ b/engine/core/examples/membench.rs
@@ -1,4 +1,6 @@
 use std::alloc::{GlobalAlloc, Layout, System};
+use std::cell::UnsafeCell;
+use std::ops::{Deref, DerefMut};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::time::Instant;
 
@@ -12,17 +14,150 @@ static PEAK: AtomicUsize = AtomicUsize::new(0);
 static TOTAL: AtomicUsize = AtomicUsize::new(0);
 static COUNT: AtomicUsize = AtomicUsize::new(0);
 
+const LEDGER_CAPACITY: usize = 4096;
+
+#[derive(Clone, Copy)]
+struct LedgerEntry {
+    ptr: usize,
+    size: usize,
+    measured: bool,
+}
+
+struct AllocationLedger {
+    entries: [LedgerEntry; LEDGER_CAPACITY],
+}
+
+impl AllocationLedger {
+    const EMPTY: LedgerEntry = LedgerEntry {
+        ptr: 0,
+        size: 0,
+        measured: false,
+    };
+
+    const fn new() -> Self {
+        Self {
+            entries: [Self::EMPTY; LEDGER_CAPACITY],
+        }
+    }
+
+    fn alloc(&mut self, ptr: usize, size: usize, measured: bool) {
+        let slot = self
+            .entries
+            .iter_mut()
+            .find(|entry| entry.ptr == 0)
+            .expect("allocation ledger capacity exceeded");
+        *slot = LedgerEntry {
+            ptr,
+            size,
+            measured,
+        };
+    }
+
+    fn realloc(
+        &mut self,
+        old_ptr: usize,
+        new_ptr: usize,
+        new_size: usize,
+    ) -> Option<(usize, bool)> {
+        let entry = self.entries.iter_mut().find(|entry| entry.ptr == old_ptr);
+        let Some(entry) = entry else {
+            self.alloc(new_ptr, new_size, false);
+            return None;
+        };
+        let old = (entry.size, entry.measured);
+        entry.ptr = new_ptr;
+        entry.size = new_size;
+        Some(old)
+    }
+
+    fn dealloc(&mut self, ptr: usize) -> Option<(usize, bool)> {
+        let entry = self.entries.iter_mut().find(|entry| entry.ptr == ptr)?;
+        let result = (entry.size, entry.measured);
+        *entry = Self::EMPTY;
+        Some(result)
+    }
+
+    fn begin_measurement(&mut self) {
+        for entry in &mut self.entries {
+            if entry.ptr != 0 {
+                entry.measured = false;
+            }
+        }
+    }
+}
+
+struct LedgerLock {
+    locked: AtomicBool,
+    ledger: UnsafeCell<AllocationLedger>,
+}
+
+unsafe impl Sync for LedgerLock {}
+
+struct LedgerGuard<'a> {
+    lock: &'a LedgerLock,
+}
+
+impl LedgerLock {
+    const fn new() -> Self {
+        Self {
+            locked: AtomicBool::new(false),
+            ledger: UnsafeCell::new(AllocationLedger::new()),
+        }
+    }
+
+    fn lock(&self) -> LedgerGuard<'_> {
+        while self
+            .locked
+            .compare_exchange_weak(false, true, Ordering::Acquire, Ordering::Relaxed)
+            .is_err()
+        {
+            std::hint::spin_loop();
+        }
+        LedgerGuard { lock: self }
+    }
+}
+
+impl Deref for LedgerGuard<'_> {
+    type Target = AllocationLedger;
+
+    fn deref(&self) -> &Self::Target {
+        // The guard owns the lock for the lifetime of this reference.
+        unsafe { &*self.lock.ledger.get() }
+    }
+}
+
+impl DerefMut for LedgerGuard<'_> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        // The guard owns the lock, so no other mutable reference exists.
+        unsafe { &mut *self.lock.ledger.get() }
+    }
+}
+
+impl Drop for LedgerGuard<'_> {
+    fn drop(&mut self) {
+        self.lock.locked.store(false, Ordering::Release);
+    }
+}
+
+static ALLOCATION_LEDGER: LedgerLock = LedgerLock::new();
+
 #[global_allocator]
 static ALLOCATOR: CountingAlloc = CountingAlloc;
 
 impl CountingAlloc {
-    fn record_alloc(size: usize) {
-        if !COUNTING.load(Ordering::Relaxed) {
+    fn record_alloc(ptr: *mut u8, size: usize) {
+        let measured = COUNTING.load(Ordering::Relaxed);
+        ALLOCATION_LEDGER.lock().alloc(ptr as usize, size, measured);
+        if !measured {
             return;
         }
         LIVE.fetch_add(size, Ordering::Relaxed);
         TOTAL.fetch_add(size, Ordering::Relaxed);
         COUNT.fetch_add(1, Ordering::Relaxed);
+        Self::record_peak();
+    }
+
+    fn record_peak() {
         let live = LIVE.load(Ordering::Relaxed);
         let mut peak = PEAK.load(Ordering::Relaxed);
         while live > peak {
@@ -33,9 +168,11 @@ impl CountingAlloc {
         }
     }
 
-    fn record_dealloc(size: usize) {
-        if COUNTING.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(size, Ordering::Relaxed);
+    fn record_dealloc(ptr: *mut u8) {
+        if let Some((size, measured)) = ALLOCATION_LEDGER.lock().dealloc(ptr as usize) {
+            if measured {
+                LIVE.fetch_sub(size, Ordering::Relaxed);
+            }
         }
     }
 }
@@ -44,7 +181,7 @@ unsafe impl GlobalAlloc for CountingAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
         let ptr = System.alloc(layout);
         if !ptr.is_null() {
-            Self::record_alloc(layout.size());
+            Self::record_alloc(ptr, layout.size());
         }
         ptr
     }
@@ -52,27 +189,39 @@ unsafe impl GlobalAlloc for CountingAlloc {
     unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
         let ptr = System.alloc_zeroed(layout);
         if !ptr.is_null() {
-            Self::record_alloc(layout.size());
+            Self::record_alloc(ptr, layout.size());
         }
         ptr
     }
 
     unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
         System.dealloc(ptr, layout);
-        Self::record_dealloc(layout.size());
+        Self::record_dealloc(ptr);
     }
 
     unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
         let new_ptr = System.realloc(ptr, layout, new_size);
-        if !new_ptr.is_null() && COUNTING.load(Ordering::Relaxed) {
-            LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
-            Self::record_alloc(new_size);
+        if !new_ptr.is_null() {
+            if let Some((old_size, measured)) =
+                ALLOCATION_LEDGER
+                    .lock()
+                    .realloc(ptr as usize, new_ptr as usize, new_size)
+            {
+                if measured {
+                    LIVE.fetch_sub(old_size, Ordering::Relaxed);
+                    LIVE.fetch_add(new_size, Ordering::Relaxed);
+                    TOTAL.fetch_add(new_size, Ordering::Relaxed);
+                    COUNT.fetch_add(1, Ordering::Relaxed);
+                    Self::record_peak();
+                }
+            }
         }
         new_ptr
     }
 }
 
 fn begin_measurement() {
+    ALLOCATION_LEDGER.lock().begin_measurement();
     LIVE.store(0, Ordering::Relaxed);
     PEAK.store(0, Ordering::Relaxed);
     TOTAL.store(0, Ordering::Relaxed);
@@ -244,13 +393,15 @@ fn main() {
     ui.set_viewport(spec::SCREEN_W as f32, spec::SCREEN_H as f32);
     assert!(ui.load_styles(&styles));
     assert!(ui.load_font_atlas(&font_atlas));
+    let font = ui.font_atlas(0).unwrap();
+    let (workload_gid, _) = font
+        .lookup('P' as u32)
+        .expect("workload glyph must be mapped");
     assert!(
-        ui.font_atlas(0)
-            .unwrap()
-            .glyph_rows(1)
+        font.glyph_rows(workload_gid)
             .iter()
             .any(|&coverage| coverage != 0),
-        "benchmark font atlas must contain non-zero glyph coverage"
+        "benchmark font atlas must contain non-zero coverage for P"
     );
     handles.push(ui.upload_texture(&atlas, 16, 16, spec::psm::PSM_8888));
     let texture = handles[0];
@@ -345,6 +496,7 @@ fn main() {
 
     let nodes = 1 + 1 + 1 + 32 * 3;
     end_measurement();
+    // Ui::tick includes animation bookkeeping, so this is a tick/layout proxy.
     let avg_layout_us = total_us / timings.len() as u128;
     println!("peak_requested_bytes={}", PEAK.load(Ordering::Relaxed));
     println!("final_requested_bytes={}", LIVE.load(Ordering::Relaxed));
@@ -357,11 +509,15 @@ fn main() {
     println!("text_mode=atlas");
     println!("texture_mode=atlas");
     println!("drawlist_checksum={checksum:016x}");
+    assert_eq!(
+        checksum, 0xcc6a0b00efdba151,
+        "deterministic benchmark drawlist changed"
+    );
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{font_atlas_blob, structural_tick, timing_capacity};
+    use super::{font_atlas_blob, structural_tick, timing_capacity, AllocationLedger};
     use pocketjs_core::Ui;
 
     #[test]
@@ -379,14 +535,28 @@ mod tests {
     fn fixture_atlas_loads_and_has_workload_glyphs() {
         let mut ui = Ui::new();
         assert!(ui.load_font_atlas(&font_atlas_blob()));
-        assert!(ui.font_atlas(0).unwrap().lookup('P' as u32).is_some());
-        assert!(
-            ui.font_atlas(0)
-                .unwrap()
-                .glyph_rows(1)
-                .iter()
-                .any(|&coverage| coverage != 0)
-        );
+        let font = ui.font_atlas(0).unwrap();
+        let (workload_gid, _) = font.lookup('P' as u32).unwrap();
+        assert!(font
+            .glyph_rows(workload_gid)
+            .iter()
+            .any(|&coverage| coverage != 0));
         assert_eq!(ui.measure_text("P", 0), 8.0);
+    }
+
+    #[test]
+    fn ledger_preserves_pre_measurement_realloc_state() {
+        let mut ledger = AllocationLedger::new();
+        ledger.alloc(0x1000, 16, false);
+        ledger.begin_measurement();
+
+        let event = ledger.realloc(0x1000, 0x2000, 32);
+        assert_eq!(event, Some((16, false)));
+        assert_eq!(ledger.dealloc(0x2000), Some((32, false)));
+
+        ledger.alloc(0x3000, 8, true);
+        let event = ledger.realloc(0x3000, 0x4000, 12);
+        assert_eq!(event, Some((8, true)));
+        assert_eq!(ledger.dealloc(0x4000), Some((12, true)));
     }
 }

--- a/engine/core/examples/membench.rs
+++ b/engine/core/examples/membench.rs
@@ -139,6 +139,47 @@ fn texture_blob() -> Vec<u8> {
     atlas
 }
 
+fn font_atlas_blob() -> Vec<u8> {
+    const FIRST_GLYPH: u32 = 32;
+    const GLYPH_COUNT: u16 = 95;
+    const CELL_W: u8 = 8;
+    const CELL_H: u8 = 16;
+    const BYTES_PER_GLYPH: usize = CELL_W as usize * CELL_H as usize;
+
+    let mut atlas = Vec::with_capacity(
+        spec::font_atlas::HEADER_SIZE
+            + GLYPH_COUNT as usize * spec::font_atlas::CMAP_ENTRY_SIZE
+            + GLYPH_COUNT as usize * BYTES_PER_GLYPH,
+    );
+    push_u32(&mut atlas, spec::font_atlas::MAGIC);
+    push_u16(&mut atlas, spec::font_atlas::VERSION);
+    push_u16(&mut atlas, GLYPH_COUNT);
+    atlas.extend_from_slice(&[CELL_W, CELL_H, 12, 18, 0, 0, 1, 0]);
+    for gid in 0..GLYPH_COUNT {
+        push_u32(&mut atlas, FIRST_GLYPH + u32::from(gid));
+        push_u16(&mut atlas, gid);
+        atlas.extend_from_slice(&[CELL_W, 0]);
+    }
+    atlas.resize(atlas.capacity(), 0);
+    atlas
+}
+
+fn timing_capacity() -> usize {
+    24 + 8 + 16 + 12
+}
+
+fn structural_tick(tick: usize) -> bool {
+    tick % 4 == 0
+}
+
+fn structural_probe(ui: &mut Ui, parent: i32, height: f64) {
+    let node = ui.create_node(spec::NodeType::View as u8);
+    ui.set_style(node, 0);
+    ui.set_prop(node, spec::prop::HEIGHT, height);
+    ui.insert_before(parent, node, 0);
+    ui.destroy_node(node);
+}
+
 fn hash_draw(words: &[u32], checksum: &mut u64) {
     for word in words {
         *checksum ^= u64::from(*word);
@@ -167,10 +208,12 @@ fn main() {
     const TEXT_TICKS: usize = 16;
     const BURST_TICKS: usize = 12;
 
-    // All fixture bytes, source strings, handles, churn ids, and timing state
-    // are allocated before measurement. The capacities cover every mutation.
+    // Fixture bytes, source strings, handles, churn ids, and timing state are
+    // prepared before measurement. Setup allocations are intentionally outside
+    // the workload receipt.
     let styles = style_blob();
     let atlas = texture_blob();
+    let font_atlas = font_atlas_blob();
     let source_strings = [
         String::from("PocketJS memory benchmark"),
         String::from("deterministic retained core workload"),
@@ -178,12 +221,13 @@ fn main() {
     let mut handles = Vec::with_capacity(1 + 1 + 32 + CHURN_SIZE);
     let mut churn_ids = Vec::with_capacity(CHURN_SIZE);
     let mut text_ids = Vec::with_capacity(32);
-    let mut timings = Vec::with_capacity(STEADY_TICKS + TEXT_TICKS + BURST_TICKS);
+    let mut timings = Vec::with_capacity(timing_capacity());
     timings.clear();
 
     let mut ui = Ui::new();
     ui.set_viewport(spec::SCREEN_W as f32, spec::SCREEN_H as f32);
     assert!(ui.load_styles(&styles));
+    assert!(ui.load_font_atlas(&font_atlas));
     handles.push(ui.upload_texture(&atlas, 16, 16, spec::psm::PSM_8888));
     let texture = handles[0];
 
@@ -227,7 +271,7 @@ fn main() {
     }
 
     // Phase 3: fixed-size subtree creation and destruction.
-    let mut structural_relayouts = 1u64 + (1 + 32 * 3) as u64;
+    let mut structural_relayouts = 1u64;
     for round in 0..CHURN_ROUNDS {
         churn_ids.clear();
         for i in 0..CHURN_SIZE {
@@ -236,13 +280,12 @@ fn main() {
             ui.set_prop(node, spec::prop::HEIGHT, (20 + i + round) as f64);
             ui.insert_before(panel, node, 0);
             churn_ids.push(node);
-            structural_relayouts += 1;
         }
         for node in churn_ids.iter().copied() {
             ui.destroy_node(node);
-            structural_relayouts += 1;
         }
         tick_and_measure(&mut ui, &mut checksum, &mut total_us, &mut max_us);
+        structural_relayouts += 1;
         timings.push(STEADY_TICKS + round);
     }
 
@@ -255,7 +298,10 @@ fn main() {
             "steady text update"
         };
         ui.set_text(text, value);
-        structural_relayouts += 1;
+        if structural_tick(i) {
+            structural_probe(&mut ui, panel, 22.0 + i as f64);
+            structural_relayouts += 1;
+        }
         tick_and_measure(&mut ui, &mut checksum, &mut total_us, &mut max_us);
         timings.push(STEADY_TICKS + CHURN_ROUNDS + i);
     }
@@ -265,7 +311,10 @@ fn main() {
         let text = text_ids[(i * 7) % text_ids.len()];
         ui.set_text(text, if i & 1 == 0 { "burst A" } else { "burst B" });
         ui.set_prop(panel, spec::prop::GAP, (i % 5) as f64);
-        structural_relayouts += 1;
+        if structural_tick(i) {
+            structural_probe(&mut ui, panel, 30.0 + i as f64);
+            structural_relayouts += 1;
+        }
         tick_and_measure(&mut ui, &mut checksum, &mut total_us, &mut max_us);
         timings.push(STEADY_TICKS + CHURN_ROUNDS + TEXT_TICKS + i);
     }
@@ -284,4 +333,29 @@ fn main() {
     println!("text_mode=atlas");
     println!("texture_mode=atlas");
     println!("drawlist_checksum={checksum:016x}");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{font_atlas_blob, structural_tick, timing_capacity};
+    use pocketjs_core::Ui;
+
+    #[test]
+    fn reserves_all_measurement_entries() {
+        assert_eq!(timing_capacity(), 60);
+    }
+
+    #[test]
+    fn structural_schedule_is_fixed_and_coalesced() {
+        assert_eq!((0..16).filter(|&tick| structural_tick(tick)).count(), 4);
+        assert_eq!((0..12).filter(|&tick| structural_tick(tick)).count(), 3);
+    }
+
+    #[test]
+    fn fixture_atlas_loads_and_has_workload_glyphs() {
+        let mut ui = Ui::new();
+        assert!(ui.load_font_atlas(&font_atlas_blob()));
+        assert!(ui.font_atlas(0).unwrap().lookup('P' as u32).is_some());
+        assert_eq!(ui.measure_text("P", 0), 8.0);
+    }
 }

--- a/engine/core/examples/membench.rs
+++ b/engine/core/examples/membench.rs
@@ -1,0 +1,287 @@
+use std::alloc::{GlobalAlloc, Layout, System};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::time::Instant;
+
+use pocketjs_core::{spec, Ui};
+
+struct CountingAlloc;
+
+static COUNTING: AtomicBool = AtomicBool::new(false);
+static LIVE: AtomicUsize = AtomicUsize::new(0);
+static PEAK: AtomicUsize = AtomicUsize::new(0);
+static TOTAL: AtomicUsize = AtomicUsize::new(0);
+static COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[global_allocator]
+static ALLOCATOR: CountingAlloc = CountingAlloc;
+
+impl CountingAlloc {
+    fn record_alloc(size: usize) {
+        if !COUNTING.load(Ordering::Relaxed) {
+            return;
+        }
+        LIVE.fetch_add(size, Ordering::Relaxed);
+        TOTAL.fetch_add(size, Ordering::Relaxed);
+        COUNT.fetch_add(1, Ordering::Relaxed);
+        let live = LIVE.load(Ordering::Relaxed);
+        let mut peak = PEAK.load(Ordering::Relaxed);
+        while live > peak {
+            match PEAK.compare_exchange_weak(peak, live, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(current) => peak = current,
+            }
+        }
+    }
+
+    fn record_dealloc(size: usize) {
+        if COUNTING.load(Ordering::Relaxed) {
+            LIVE.fetch_sub(size, Ordering::Relaxed);
+        }
+    }
+}
+
+unsafe impl GlobalAlloc for CountingAlloc {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc(layout);
+        if !ptr.is_null() {
+            Self::record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn alloc_zeroed(&self, layout: Layout) -> *mut u8 {
+        let ptr = System.alloc_zeroed(layout);
+        if !ptr.is_null() {
+            Self::record_alloc(layout.size());
+        }
+        ptr
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        System.dealloc(ptr, layout);
+        Self::record_dealloc(layout.size());
+    }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let new_ptr = System.realloc(ptr, layout, new_size);
+        if !new_ptr.is_null() && COUNTING.load(Ordering::Relaxed) {
+            LIVE.fetch_sub(layout.size(), Ordering::Relaxed);
+            Self::record_alloc(new_size);
+        }
+        new_ptr
+    }
+}
+
+fn begin_measurement() {
+    LIVE.store(0, Ordering::Relaxed);
+    PEAK.store(0, Ordering::Relaxed);
+    TOTAL.store(0, Ordering::Relaxed);
+    COUNT.store(0, Ordering::Relaxed);
+    COUNTING.store(true, Ordering::Relaxed);
+}
+
+fn end_measurement() {
+    COUNTING.store(false, Ordering::Relaxed);
+}
+
+fn push_u16(out: &mut Vec<u8>, value: u16) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn push_u32(out: &mut Vec<u8>, value: u32) {
+    out.extend_from_slice(&value.to_le_bytes());
+}
+
+fn style_blob() -> Vec<u8> {
+    // Three records: view, text, and image. The records use only fixed props,
+    // so parsing them cannot introduce workload-dependent style allocations.
+    let mut out = Vec::with_capacity(12 + 3 * 32);
+    push_u32(&mut out, spec::style_table::MAGIC);
+    push_u16(&mut out, spec::style_table::VERSION);
+    push_u16(&mut out, 3);
+    push_u16(&mut out, 0);
+    push_u16(&mut out, 0);
+
+    let records = [
+        vec![
+            (spec::prop::BG_COLOR, 0xff202830),
+            (spec::prop::PADDING_T, 4.0f32.to_bits()),
+            (spec::prop::PADDING_B, 4.0f32.to_bits()),
+        ],
+        vec![
+            (spec::prop::TEXT_COLOR, 0xffffffff),
+            (spec::prop::HEIGHT, 18.0f32.to_bits()),
+        ],
+        vec![(spec::prop::BG_COLOR, 0xff405060)],
+    ];
+    for props in records {
+        out.push(spec::style_table::VARIANT_BASE);
+        out.push(props.len() as u8);
+        for (prop, value) in props {
+            out.push(prop);
+            out.push(0);
+            push_u32(&mut out, value);
+        }
+    }
+    out
+}
+
+fn texture_blob() -> Vec<u8> {
+    let mut atlas = Vec::with_capacity(16 * 16 * 4);
+    for i in 0..(16 * 16) {
+        atlas.extend_from_slice(&[
+            (i & 0xff) as u8,
+            ((i * 3) & 0xff) as u8,
+            ((i * 7) & 0xff) as u8,
+            0xff,
+        ]);
+    }
+    atlas
+}
+
+fn hash_draw(words: &[u32], checksum: &mut u64) {
+    for word in words {
+        *checksum ^= u64::from(*word);
+        *checksum = checksum.wrapping_mul(0x100000001b3);
+    }
+}
+
+fn draw_and_hash(ui: &mut Ui, checksum: &mut u64) {
+    let words = &ui.draw().words;
+    hash_draw(words, checksum);
+}
+
+fn tick_and_measure(ui: &mut Ui, checksum: &mut u64, total_us: &mut u128, max_us: &mut u128) {
+    let started = Instant::now();
+    ui.tick();
+    let elapsed = started.elapsed().as_micros();
+    *total_us += elapsed;
+    *max_us = (*max_us).max(elapsed);
+    draw_and_hash(ui, checksum);
+}
+
+fn main() {
+    const STEADY_TICKS: usize = 24;
+    const CHURN_ROUNDS: usize = 8;
+    const CHURN_SIZE: usize = 4;
+    const TEXT_TICKS: usize = 16;
+    const BURST_TICKS: usize = 12;
+
+    // All fixture bytes, source strings, handles, churn ids, and timing state
+    // are allocated before measurement. The capacities cover every mutation.
+    let styles = style_blob();
+    let atlas = texture_blob();
+    let source_strings = [
+        String::from("PocketJS memory benchmark"),
+        String::from("deterministic retained core workload"),
+    ];
+    let mut handles = Vec::with_capacity(1 + 1 + 32 + CHURN_SIZE);
+    let mut churn_ids = Vec::with_capacity(CHURN_SIZE);
+    let mut text_ids = Vec::with_capacity(32);
+    let mut timings = Vec::with_capacity(STEADY_TICKS + TEXT_TICKS + BURST_TICKS);
+    timings.clear();
+
+    let mut ui = Ui::new();
+    ui.set_viewport(spec::SCREEN_W as f32, spec::SCREEN_H as f32);
+    assert!(ui.load_styles(&styles));
+    handles.push(ui.upload_texture(&atlas, 16, 16, spec::psm::PSM_8888));
+    let texture = handles[0];
+
+    begin_measurement();
+    let mut checksum = 0xcbf29ce484222325;
+    let mut total_us = 0u128;
+    let mut max_us = 0u128;
+
+    // Phase 1: initial tree and resources.
+    let panel = ui.create_node(spec::NodeType::View as u8);
+    ui.set_style(panel, 0);
+    ui.insert_before(spec::ROOT_ID, panel, 0);
+    let title = ui.create_node(spec::NodeType::Text as u8);
+    ui.set_style(title, 1);
+    ui.set_text(title, &source_strings[0]);
+    ui.insert_before(panel, title, 0);
+    for i in 0..32 {
+        let row = ui.create_node(spec::NodeType::View as u8);
+        ui.set_style(row, 0);
+        ui.set_prop(row, spec::prop::HEIGHT, 24.0 + (i % 3) as f64);
+        ui.insert_before(panel, row, 0);
+        let text = ui.create_node(spec::NodeType::Text as u8);
+        ui.set_style(text, 1);
+        ui.set_text(text, &source_strings[1]);
+        ui.insert_before(row, text, 0);
+        text_ids.push(text);
+        let image = ui.create_node(spec::NodeType::Image as u8);
+        ui.set_style(image, 2);
+        ui.set_prop(image, spec::prop::WIDTH, 16.0);
+        ui.set_prop(image, spec::prop::HEIGHT, 16.0);
+        ui.set_image(image, texture);
+        ui.insert_before(row, image, 0);
+    }
+    draw_and_hash(&mut ui, &mut checksum);
+
+    // Phase 2: steady style-only ticks.
+    for i in 0..STEADY_TICKS {
+        ui.set_prop(panel, spec::prop::OPACITY, 0.85 + (i % 4) as f64 * 0.03);
+        tick_and_measure(&mut ui, &mut checksum, &mut total_us, &mut max_us);
+        timings.push(i);
+    }
+
+    // Phase 3: fixed-size subtree creation and destruction.
+    let mut structural_relayouts = 1u64 + (1 + 32 * 3) as u64;
+    for round in 0..CHURN_ROUNDS {
+        churn_ids.clear();
+        for i in 0..CHURN_SIZE {
+            let node = ui.create_node(spec::NodeType::View as u8);
+            ui.set_style(node, 0);
+            ui.set_prop(node, spec::prop::HEIGHT, (20 + i + round) as f64);
+            ui.insert_before(panel, node, 0);
+            churn_ids.push(node);
+            structural_relayouts += 1;
+        }
+        for node in churn_ids.iter().copied() {
+            ui.destroy_node(node);
+            structural_relayouts += 1;
+        }
+        tick_and_measure(&mut ui, &mut checksum, &mut total_us, &mut max_us);
+        timings.push(STEADY_TICKS + round);
+    }
+
+    // Phase 4: text changes with a structural relayout at a fixed interval.
+    for i in 0..TEXT_TICKS {
+        let text = text_ids[i % text_ids.len()];
+        let value = if i % 4 == 0 {
+            "structural text update"
+        } else {
+            "steady text update"
+        };
+        ui.set_text(text, value);
+        structural_relayouts += 1;
+        tick_and_measure(&mut ui, &mut checksum, &mut total_us, &mut max_us);
+        timings.push(STEADY_TICKS + CHURN_ROUNDS + i);
+    }
+
+    // Phase 5: one fixed burst over the peak path.
+    for i in 0..BURST_TICKS {
+        let text = text_ids[(i * 7) % text_ids.len()];
+        ui.set_text(text, if i & 1 == 0 { "burst A" } else { "burst B" });
+        ui.set_prop(panel, spec::prop::GAP, (i % 5) as f64);
+        structural_relayouts += 1;
+        tick_and_measure(&mut ui, &mut checksum, &mut total_us, &mut max_us);
+        timings.push(STEADY_TICKS + CHURN_ROUNDS + TEXT_TICKS + i);
+    }
+
+    let nodes = 1 + 1 + 1 + 32 * 3;
+    end_measurement();
+    let avg_layout_us = total_us / timings.len() as u128;
+    println!("peak_requested_bytes={}", PEAK.load(Ordering::Relaxed));
+    println!("final_requested_bytes={}", LIVE.load(Ordering::Relaxed));
+    println!("allocation_count={}", COUNT.load(Ordering::Relaxed));
+    println!("total_allocated_bytes={}", TOTAL.load(Ordering::Relaxed));
+    println!("avg_layout_us={avg_layout_us}");
+    println!("max_layout_us={max_us}");
+    println!("nodes={nodes}");
+    println!("structural_relayouts={structural_relayouts}");
+    println!("text_mode=atlas");
+    println!("texture_mode=atlas");
+    println!("drawlist_checksum={checksum:016x}");
+}

--- a/engine/core/examples/membench.rs
+++ b/engine/core/examples/membench.rs
@@ -160,7 +160,19 @@ fn font_atlas_blob() -> Vec<u8> {
         push_u16(&mut atlas, gid);
         atlas.extend_from_slice(&[CELL_W, 0]);
     }
-    atlas.resize(atlas.capacity(), 0);
+    for gid in 0..GLYPH_COUNT {
+        for y in 0..CELL_H as usize {
+            for x in 0..CELL_W as usize {
+                // Keep the space transparent while giving every printable
+                // glyph deterministic coverage to exercise atlas sampling.
+                let covered = gid != 0
+                    && (1..=6).contains(&x)
+                    && (2..=13).contains(&y)
+                    && (x + y + gid as usize) % 3 != 0;
+                atlas.push(if covered { 255 } else { 0 });
+            }
+        }
+    }
     atlas
 }
 
@@ -189,6 +201,10 @@ fn hash_draw(words: &[u32], checksum: &mut u64) {
 
 fn draw_and_hash(ui: &mut Ui, checksum: &mut u64) {
     let words = &ui.draw().words;
+    assert!(
+        words.iter().any(|&word| word == spec::draw_op::GLYPH_RUN),
+        "benchmark draw must emit atlas-backed glyphs"
+    );
     hash_draw(words, checksum);
 }
 
@@ -228,6 +244,14 @@ fn main() {
     ui.set_viewport(spec::SCREEN_W as f32, spec::SCREEN_H as f32);
     assert!(ui.load_styles(&styles));
     assert!(ui.load_font_atlas(&font_atlas));
+    assert!(
+        ui.font_atlas(0)
+            .unwrap()
+            .glyph_rows(1)
+            .iter()
+            .any(|&coverage| coverage != 0),
+        "benchmark font atlas must contain non-zero glyph coverage"
+    );
     handles.push(ui.upload_texture(&atlas, 16, 16, spec::psm::PSM_8888));
     let texture = handles[0];
 
@@ -356,6 +380,13 @@ mod tests {
         let mut ui = Ui::new();
         assert!(ui.load_font_atlas(&font_atlas_blob()));
         assert!(ui.font_atlas(0).unwrap().lookup('P' as u32).is_some());
+        assert!(
+            ui.font_atlas(0)
+                .unwrap()
+                .glyph_rows(1)
+                .iter()
+                .any(|&coverage| coverage != 0)
+        );
         assert_eq!(ui.measure_text("P", 0), 8.0);
     }
 }

--- a/engine/core/examples/membench_baseline.json
+++ b/engine/core/examples/membench_baseline.json
@@ -1,0 +1,27 @@
+{
+  "command": "cargo run --manifest-path engine/core/Cargo.toml --example membench --quiet",
+  "toolchain": {
+    "rustc": "rustc 1.97.1 (8bab26f4f 2026-07-14)",
+    "cargo": "cargo 1.97.1 (c980f4866 2026-06-30)"
+  },
+  "git_revision": "b7dd46f",
+  "origin_main_revision": "2d20ddad228db52fa29ad7d7d06f44e8672164af",
+  "workload": {
+    "shape": "99 nodes; 24 steady ticks; 8 rounds of 4-node subtree churn; 16 text ticks; 12 burst ticks",
+    "text_mode": "atlas",
+    "texture_mode": "atlas"
+  },
+  "receipt": {
+    "peak_requested_bytes": "29591",
+    "final_requested_bytes": "10793",
+    "allocation_count": "11682",
+    "total_allocated_bytes": "6225569",
+    "avg_layout_us": "1210",
+    "max_layout_us": "5163",
+    "nodes": "99",
+    "structural_relayouts": "16",
+    "text_mode": "atlas",
+    "texture_mode": "atlas",
+    "drawlist_checksum": "cc6a0b00efdba151"
+  }
+}

--- a/engine/core/examples/membench_baseline.json
+++ b/engine/core/examples/membench_baseline.json
@@ -6,6 +6,7 @@
   },
   "git_revision": "b7dd46f",
   "origin_main_revision": "2d20ddad228db52fa29ad7d7d06f44e8672164af",
+  "benchmark_implementation_revision": "0821ddf",
   "workload": {
     "shape": "99 nodes; 24 steady ticks; 8 rounds of 4-node subtree churn; 16 text ticks; 12 burst ticks",
     "text_mode": "atlas",

--- a/engine/core/examples/membench_baseline.md
+++ b/engine/core/examples/membench_baseline.md
@@ -1,7 +1,12 @@
 # Core Memory Benchmark Baseline
 
-This receipt was measured at `b7dd46f`, based on `origin/main` revision
-`2d20ddad228db52fa29ad7d7d06f44e8672164af`.
+The benchmark harness was based on the latest `origin/main` revision
+`2d20ddad228db52fa29ad7d7d06f44e8672164af`; the first receipt was measured at
+harness commit `b7dd46f`. The benchmark implementation was introduced
+separately at `0821ddf`. `git_revision` identifies the revision where the
+receipt was measured, while `origin_main_revision` identifies the source
+revision used as the harness base. This receipt was not measured from
+`origin/main` itself.
 
 The byte values below are **allocator-independent requested-byte metrics** from
 the counting allocator. They are not process RSS, committed pages, or PSP arena

--- a/engine/core/examples/membench_baseline.md
+++ b/engine/core/examples/membench_baseline.md
@@ -1,0 +1,34 @@
+# Core Memory Benchmark Baseline
+
+This receipt was measured at `b7dd46f`, based on `origin/main` revision
+`2d20ddad228db52fa29ad7d7d06f44e8672164af`.
+
+The byte values below are **allocator-independent requested-byte metrics** from
+the counting allocator. They are not process RSS, committed pages, or PSP arena
+high-water measurements. Timing values are host measurements and are excluded
+from deterministic receipt comparisons.
+
+## Reproduction
+
+```text
+cargo run --manifest-path engine/core/Cargo.toml --example membench --quiet
+```
+
+Toolchain: `rustc 1.97.1 (8bab26f4f 2026-07-14)`, `cargo 1.97.1 (c980f4866 2026-06-30)`.
+
+Workload shape: 99 nodes; 24 steady ticks; 8 rounds of 4-node subtree churn;
+16 text ticks; 12 burst ticks. Text and texture modes are both `atlas`.
+
+## Receipt
+
+| Field | Value | Meaning |
+| --- | ---: | --- |
+| `peak_requested_bytes` | 29591 | Peak requested bytes |
+| `final_requested_bytes` | 10793 | Final live requested bytes |
+| `allocation_count` | 11682 | Count of measured allocation events |
+| `total_allocated_bytes` | 6225569 | Total requested bytes across measured allocation events |
+| `avg_layout_us` | 1210 | Host timing, excluded from canonical comparison |
+| `max_layout_us` | 5163 | Host timing, excluded from canonical comparison |
+| `nodes` | 99 | Workload node count |
+| `structural_relayouts` | 16 | Structural relayout count |
+| `drawlist_checksum` | `cc6a0b00efdba151` | Deterministic drawlist checksum |

--- a/hosts/psp/src/main.rs
+++ b/hosts/psp/src/main.rs
@@ -32,6 +32,10 @@ use pocketjs_psp::{arena, audio_mod, dbg, ffi, ge, host, pak, svc, switch, veil,
 psp::module!("pocketjs", 1, 1);
 
 const CORE_TICKS_PER_SECOND: u32 = 60;
+#[cfg(feature = "bench")]
+const DRAWLIST_CHECKSUM_OFFSET: u64 = 0xcbf29ce484222325;
+#[cfg(feature = "bench")]
+const DRAWLIST_CHECKSUM_PRIME: u64 = 0x100000001b3;
 // The full launcher originally consumed about 42 ms of CPU work on real PSP
 // hardware. Batching cuts that to about 12 ms, but the texture-heavy GE pass
 // still completes across the third vblank. A multi-app package therefore
@@ -161,6 +165,7 @@ struct BenchState {
     previous_frame_start_us: u64,
     frame_interval_sum_us: u64,
     max_frame_interval_us: u64,
+    drawlist_checksum: u64,
 }
 
 #[cfg(feature = "bench")]
@@ -184,6 +189,7 @@ impl BenchState {
             previous_frame_start_us: 0,
             frame_interval_sum_us: 0,
             max_frame_interval_us: 0,
+            drawlist_checksum: DRAWLIST_CHECKSUM_OFFSET,
         }
     }
 }
@@ -307,6 +313,20 @@ unsafe fn bench_record_frame(
 }
 
 #[cfg(feature = "bench")]
+unsafe fn bench_record_drawlist(frame_count: u32, words: &[u32]) {
+    let (start, n) = bench_window();
+    if frame_count < start || frame_count >= start + n {
+        return;
+    }
+    for word in words {
+        BENCH.drawlist_checksum ^= u64::from(*word);
+        BENCH.drawlist_checksum = BENCH
+            .drawlist_checksum
+            .wrapping_mul(DRAWLIST_CHECKSUM_PRIME);
+    }
+}
+
+#[cfg(feature = "bench")]
 unsafe fn bench_record_gpu(frame_count: u32, gpu_us: u64) {
     let (start, n) = bench_window();
     if frame_count < start || frame_count >= start + n {
@@ -335,7 +355,7 @@ unsafe fn bench_maybe_flush(frame_count: u32) {
     let stack_free_bytes =
         sys::sceKernelGetThreadStackFreeSize(sys::SceUid(sys::sceKernelGetThreadId())).max(0);
     let line = alloc::format!(
-        "{{\"app\":\"{}\",\"sim_hz\":{},\"frames\":{},\"window_start\":{},\"window_n\":{},\"eval_us\":{},\"boot_to_eval_begin_us\":{},\"boot_to_frame0_us\":{},\"avg_frame_interval_us\":{},\"max_frame_interval_us\":{},\"avg_js_us\":{},\"avg_jobs_us\":{},\"avg_tick_us\":{},\"avg_draw_us\":{},\"avg_render_us\":{},\"avg_work_us\":{},\"max_work_us\":{},\"avg_gpu_us\":{},\"max_gpu_us\":{},\"stack_free_bytes\":{},\"bundle_bytes\":{},\"pak_bytes\":{},\"arena_capacity_bytes\":{},\"arena_bump_bytes\":{},\"arena_tail_free_bytes\":{},\"arena_init_free_bytes\":{},\"arena_configured_bytes\":{}}}\n",
+         "{{\"app\":\"{}\",\"sim_hz\":{},\"frames\":{},\"window_start\":{},\"window_n\":{},\"eval_us\":{},\"boot_to_eval_begin_us\":{},\"boot_to_frame0_us\":{},\"avg_frame_interval_us\":{},\"max_frame_interval_us\":{},\"avg_js_us\":{},\"avg_jobs_us\":{},\"avg_tick_us\":{},\"avg_draw_us\":{},\"avg_render_us\":{},\"avg_work_us\":{},\"max_work_us\":{},\"avg_gpu_us\":{},\"max_gpu_us\":{},\"stack_free_bytes\":{},\"bundle_bytes\":{},\"pak_bytes\":{},\"arena_capacity_bytes\":{},\"arena_bump_bytes\":{},\"arena_tail_free_bytes\":{},\"arena_init_free_bytes\":{},\"arena_configured_bytes\":{},\"drawlist_checksum\":\"{:016x}\"}}\n",
         POCKETJS_APP_NAME,
         if switch::multi() { MULTI_APP_SIM_HZ } else { CORE_TICKS_PER_SECOND },
         BENCH.frames,
@@ -363,6 +383,7 @@ unsafe fn bench_maybe_flush(frame_count: u32) {
         arena_stats.tail_free_bytes,
         arena_stats.init_free_bytes,
         arena_stats.configured_bytes,
+        BENCH.drawlist_checksum,
     );
     bench_write(line.as_bytes());
 }
@@ -719,6 +740,8 @@ unsafe fn run_guest(
             let dl = ui.draw();
             (dl.words.as_ptr(), dl.words.len())
         };
+        #[cfg(feature = "bench")]
+        bench_record_drawlist(guest_frame, core::slice::from_raw_parts(words_ptr, words_len));
         #[cfg(feature = "bench")]
         let bench_after_draw = bench_now_us();
         if guest_frame == 0 {

--- a/hosts/psp/src/main.rs
+++ b/hosts/psp/src/main.rs
@@ -392,8 +392,12 @@ unsafe fn bench_maybe_flush(frame_count: u32) {
         BENCH.gpu_sum_us / frames,
         BENCH.max_gpu_us,
         stack_free_bytes,
-        switch::guest_bytes(0).map(|g| g.js.len().saturating_sub(1)).unwrap_or(0),
-        switch::guest_bytes(0).map(|g| g.pak.len()).unwrap_or(0),
+        switch::guest_bytes(switch::current())
+            .map(|g| g.js.len().saturating_sub(1))
+            .unwrap_or(0),
+        switch::guest_bytes(switch::current())
+            .map(|g| g.pak.len())
+            .unwrap_or(0),
         arena_stats.capacity_bytes,
         arena_stats.bump_bytes,
         arena_stats.tail_free_bytes,

--- a/hosts/psp/src/main.rs
+++ b/hosts/psp/src/main.rs
@@ -46,8 +46,6 @@ const MULTI_APP_SIM_HZ: u32 = 20;
 // App bundles live in switch::APPS (build.rs generates the table; entry 0 is
 // the app POCKETJS_APP selected, multi-app builds append the registry). Each
 // entry's js is NUL-terminated there for JS_Eval (input[len] == '\0').
-#[cfg(feature = "bench")]
-static POCKETJS_APP_NAME: &str = env!("POCKETJS_APP");
 static POCKETJS_TRACE: &str = env!("POCKETJS_TRACE");
 
 // Arena bump high-water at the last host-forced collection (frame loop's
@@ -196,6 +194,8 @@ impl BenchState {
 
 #[cfg(feature = "bench")]
 static mut BENCH: BenchState = BenchState::new();
+#[cfg(feature = "bench")]
+static mut BENCH_HAS_GUEST: bool = false;
 
 #[cfg(feature = "bench")]
 #[inline]
@@ -241,6 +241,12 @@ unsafe fn bench_reset_file() {
 #[cfg(feature = "bench")]
 unsafe fn bench_init() {
     bench_reset_file();
+    bench_start_guest();
+    BENCH_HAS_GUEST = false;
+}
+
+#[cfg(feature = "bench")]
+unsafe fn bench_start_guest() {
     BENCH = BenchState::new();
     BENCH.run_start_us = bench_now_us();
 }
@@ -271,6 +277,12 @@ unsafe fn bench_window() -> (u32, u32) {
 }
 
 #[cfg(feature = "bench")]
+#[inline]
+fn bench_in_window(frame_count: u32, start: u32, n: u32) -> bool {
+    frame_count >= start && frame_count - start < n
+}
+
+#[cfg(feature = "bench")]
 #[allow(clippy::too_many_arguments)]
 unsafe fn bench_record_frame(
     frame_count: u32,
@@ -283,7 +295,7 @@ unsafe fn bench_record_frame(
     present_us: u64,
 ) {
     let (start, n) = bench_window();
-    if frame_count < start || frame_count >= start + n {
+    if !bench_in_window(frame_count, start, n) {
         return;
     }
     let js_us = after_js.saturating_sub(t0);
@@ -315,7 +327,7 @@ unsafe fn bench_record_frame(
 #[cfg(feature = "bench")]
 unsafe fn bench_record_drawlist(frame_count: u32, words: &[u32]) {
     let (start, n) = bench_window();
-    if frame_count < start || frame_count >= start + n {
+    if !bench_in_window(frame_count, start, n) {
         return;
     }
     for word in words {
@@ -329,7 +341,7 @@ unsafe fn bench_record_drawlist(frame_count: u32, words: &[u32]) {
 #[cfg(feature = "bench")]
 unsafe fn bench_record_gpu(frame_count: u32, gpu_us: u64) {
     let (start, n) = bench_window();
-    if frame_count < start || frame_count >= start + n {
+    if !bench_in_window(frame_count, start, n) {
         return;
     }
     BENCH.gpu_sum_us = BENCH.gpu_sum_us.saturating_add(gpu_us);
@@ -346,7 +358,11 @@ unsafe fn bench_record_frame0_complete() {
 #[cfg(feature = "bench")]
 unsafe fn bench_maybe_flush(frame_count: u32) {
     let (start, n) = bench_window();
-    if n == 0 || frame_count != start + n - 1 || BENCH.frames == 0 {
+    if n == 0
+        || !bench_in_window(frame_count, start, n)
+        || frame_count - start != n - 1
+        || BENCH.frames == 0
+    {
         return;
     }
     let frames = BENCH.frames as u64;
@@ -356,7 +372,7 @@ unsafe fn bench_maybe_flush(frame_count: u32) {
         sys::sceKernelGetThreadStackFreeSize(sys::SceUid(sys::sceKernelGetThreadId())).max(0);
     let line = alloc::format!(
          "{{\"app\":\"{}\",\"sim_hz\":{},\"frames\":{},\"window_start\":{},\"window_n\":{},\"eval_us\":{},\"boot_to_eval_begin_us\":{},\"boot_to_frame0_us\":{},\"avg_frame_interval_us\":{},\"max_frame_interval_us\":{},\"avg_js_us\":{},\"avg_jobs_us\":{},\"avg_tick_us\":{},\"avg_draw_us\":{},\"avg_render_us\":{},\"avg_work_us\":{},\"max_work_us\":{},\"avg_gpu_us\":{},\"max_gpu_us\":{},\"stack_free_bytes\":{},\"bundle_bytes\":{},\"pak_bytes\":{},\"arena_capacity_bytes\":{},\"arena_bump_bytes\":{},\"arena_tail_free_bytes\":{},\"arena_init_free_bytes\":{},\"arena_configured_bytes\":{},\"drawlist_checksum\":\"{:016x}\"}}\n",
-        POCKETJS_APP_NAME,
+        switch::current_output(),
         if switch::multi() { MULTI_APP_SIM_HZ } else { CORE_TICKS_PER_SECOND },
         BENCH.frames,
         start,
@@ -500,6 +516,12 @@ unsafe fn run_guest(
     last_present_vcount: &mut u32,
 ) -> usize {
     switch::set_current(app_index);
+    #[cfg(feature = "bench")]
+    if BENCH_HAS_GUEST {
+        bench_start_guest();
+    } else {
+        BENCH_HAS_GUEST = true;
+    }
     // Package mode extracts js/pak zero-copy from the entry's embedded
     // `.pocket`; single-app mode reads the classic inline embed. A package
     // that fails to parse routes through the broken-guest rule.
@@ -741,8 +763,6 @@ unsafe fn run_guest(
             (dl.words.as_ptr(), dl.words.len())
         };
         #[cfg(feature = "bench")]
-        bench_record_drawlist(guest_frame, core::slice::from_raw_parts(words_ptr, words_len));
-        #[cfg(feature = "bench")]
         let bench_after_draw = bench_now_us();
         if guest_frame == 0 {
             trace("frame 0: ui draw ok");
@@ -841,6 +861,8 @@ unsafe fn run_guest(
             bench_after_render,
             bench_after_present.saturating_sub(bench_before_sync),
         );
+        #[cfg(feature = "bench")]
+        bench_record_drawlist(guest_frame, core::slice::from_raw_parts(words_ptr, words_len));
         if guest_frame == 0 {
             trace("frame 0: rendered");
         }
@@ -971,13 +993,13 @@ unsafe fn cap_dump_frame(frame_count: u32) {
     // Defaults: skip boot transients + 150 ms mount transitions; 32 frames.
     let cap_start = capture_env_u32(POCKETJS_CAP_START, 16);
     let cap_n = capture_env_u32(POCKETJS_CAP_N, 32);
-    if frame_count < cap_start || frame_count >= cap_start + cap_n {
+    if frame_count < cap_start || frame_count - cap_start >= cap_n {
         return;
     }
     let idx = frame_count - cap_start;
     #[cfg(feature = "bench")]
     if POCKETJS_BENCH_DUMP_FRAMES != "1" {
-        if idx + 1 == cap_n {
+        if idx == cap_n - 1 {
             sys::sceKernelExitGame();
         }
         return;
@@ -1017,7 +1039,7 @@ unsafe fn cap_dump_frame(frame_count: u32) {
         sys::sceIoWrite(fd, addr as *const c_void, 512 * 272 * 4);
         sys::sceIoClose(fd);
     }
-    if idx + 1 == cap_n {
+    if idx == cap_n - 1 {
         sys::sceKernelExitGame();
     }
 }

--- a/hosts/psp/src/switch.rs
+++ b/hosts/psp/src/switch.rs
@@ -83,6 +83,10 @@ pub unsafe fn set_current(index: usize) {
     CURRENT = index;
 }
 
+pub unsafe fn current_output() -> &'static str {
+    APPS[CURRENT].output
+}
+
 pub unsafe fn resume() -> Option<usize> {
     usize::try_from(RESUME).ok()
 }

--- a/skills/pocketjs-psp-benchmark/references/metrics.md
+++ b/skills/pocketjs-psp-benchmark/references/metrics.md
@@ -25,6 +25,7 @@ Read this reference when explaining `tools/bench-ppsspp.ts` output.
 - `arena_tail_free_bytes`: unused tail capacity in the arena at report time. It does not include blocks held on free lists.
 - `arena_init_free_bytes`: PSP user partition max-free value observed when the arena initialized.
 - `arena_configured_bytes`: requested `POCKETJS_ARENA_BYTES`; `0` means the production default of max free memory minus margin.
+- `drawlist_checksum`: deterministic FNV-1a-style checksum over the `u32` draw-list words returned by `ui.draw()` across the measured window. It uses seed `0xcbf29ce484222325` and prime `0x100000001b3`; use it to report rendered-workload differences, not to claim identical input event sequences.
 
 ## Memory Scan Fields
 
@@ -37,3 +38,5 @@ Read this reference when explaining `tools/bench-ppsspp.ts` output.
 ## Caveats
 
 PPSSPP measurements are deterministic and useful for regression tracking, but they are not real PSP hardware proof. The arena high-water is a practical capacity requirement for this allocator, not a precise live-object heap profile, because freed blocks remain reserved in size-class free lists.
+
+The core Rust harness is a deterministic synthetic workload profile. PSP uses the existing `stats` app as a representative workload with corresponding phases. The two journeys are not byte-identical event sequences; reports must state any drawlist checksum difference explicitly.

--- a/tests/core-memory-bench.test.ts
+++ b/tests/core-memory-bench.test.ts
@@ -1,0 +1,95 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+
+const ROOT = new URL("..", import.meta.url).pathname;
+const COMMAND = [
+  "cargo",
+  "run",
+  "--manifest-path",
+  "engine/core/Cargo.toml",
+  "--example",
+  "membench",
+  "--quiet",
+];
+
+const REQUIRED_FIELDS = [
+  "peak_requested_bytes",
+  "final_requested_bytes",
+  "allocation_count",
+  "total_allocated_bytes",
+  "avg_layout_us",
+  "max_layout_us",
+  "nodes",
+  "structural_relayouts",
+  "text_mode",
+  "texture_mode",
+  "drawlist_checksum",
+] as const;
+
+const TIMING_FIELDS = new Set(["avg_layout_us", "max_layout_us"]);
+type Receipt = Record<(typeof REQUIRED_FIELDS)[number], string>;
+
+function parseReceipt(output: string): Receipt {
+  const receipt = Object.fromEntries(
+    output
+      .trim()
+      .split("\n")
+      .filter(Boolean)
+      .map((line) => {
+        const separator = line.indexOf("=");
+        expect(separator).toBeGreaterThan(0);
+        return [line.slice(0, separator), line.slice(separator + 1)];
+      }),
+  ) as Partial<Receipt>;
+
+  for (const field of REQUIRED_FIELDS) {
+    expect(receipt[field]).toBeDefined();
+    expect(receipt[field]).not.toBe("");
+  }
+
+  for (const field of REQUIRED_FIELDS) {
+    if (TIMING_FIELDS.has(field)) continue;
+    if (field === "text_mode" || field === "texture_mode") {
+      expect(receipt[field]).toBe("atlas");
+    } else if (field === "drawlist_checksum") {
+      expect(receipt[field]).toMatch(/^[0-9a-f]{16}$/);
+    } else {
+      expect(receipt[field]).toMatch(/^\d+$/);
+      expect(Number(receipt[field])).toBeGreaterThanOrEqual(0);
+    }
+  }
+
+  for (const field of TIMING_FIELDS) {
+    expect(receipt[field]).toMatch(/^\d+$/);
+    expect(Number(receipt[field])).toBeGreaterThanOrEqual(0);
+  }
+
+  return receipt as Receipt;
+}
+
+function canonicalReceipt(receipt: Receipt): Partial<Receipt> {
+  return Object.fromEntries(
+    REQUIRED_FIELDS.filter((field) => !TIMING_FIELDS.has(field)).map((field) => [
+      field,
+      receipt[field],
+    ]),
+  );
+}
+
+test(
+  "core memory receipt is complete, stable, and matches its baseline",
+  { timeout: 30_000 },
+  async () => {
+    const run = () =>
+      $`${COMMAND[0]} ${COMMAND.slice(1)}`.cwd(ROOT).quiet().text();
+    const first = parseReceipt(await run());
+    const second = parseReceipt(await run());
+
+    expect(canonicalReceipt(first)).toEqual(canonicalReceipt(second));
+
+    const baseline = (await Bun.file(
+      new URL("../engine/core/examples/membench_baseline.json", import.meta.url),
+    ).json()) as { receipt: Receipt };
+    expect(canonicalReceipt(first)).toEqual(canonicalReceipt(baseline.receipt));
+  },
+);

--- a/tests/core-memory-bench.test.ts
+++ b/tests/core-memory-bench.test.ts
@@ -1,7 +1,8 @@
 import { $ } from "bun";
 import { expect, test } from "bun:test";
+import { fileURLToPath } from "node:url";
 
-const ROOT = new URL("..", import.meta.url).pathname;
+const ROOT = fileURLToPath(new URL("..", import.meta.url));
 const COMMAND = [
   "cargo",
   "run",
@@ -30,17 +31,28 @@ const TIMING_FIELDS = new Set(["avg_layout_us", "max_layout_us"]);
 type Receipt = Record<(typeof REQUIRED_FIELDS)[number], string>;
 
 function parseReceipt(output: string): Receipt {
-  const receipt = Object.fromEntries(
-    output
-      .trim()
-      .split("\n")
-      .filter(Boolean)
-      .map((line) => {
-        const separator = line.indexOf("=");
-        expect(separator).toBeGreaterThan(0);
-        return [line.slice(0, separator), line.slice(separator + 1)];
-      }),
-  ) as Partial<Receipt>;
+  const lines = output.endsWith("\n")
+    ? output.slice(0, -1).split("\n")
+    : output.split("\n");
+  expect(lines).toHaveLength(REQUIRED_FIELDS.length);
+
+  const seen = new Set<string>();
+  const entries = lines.map((line) => {
+    const separator = line.indexOf("=");
+    expect(separator).toBeGreaterThan(0);
+    expect(line.indexOf("=", separator + 1)).toBe(-1);
+
+    const field = line.slice(0, separator);
+    const value = line.slice(separator + 1);
+    expect((REQUIRED_FIELDS as readonly string[]).includes(field)).toBe(true);
+    expect(seen.has(field)).toBe(false);
+    expect(value).not.toBe("");
+    seen.add(field);
+    return [field, value];
+  });
+
+  expect(seen.size).toBe(REQUIRED_FIELDS.length);
+  const receipt = Object.fromEntries(entries) as Partial<Receipt>;
 
   for (const field of REQUIRED_FIELDS) {
     expect(receipt[field]).toBeDefined();
@@ -55,17 +67,48 @@ function parseReceipt(output: string): Receipt {
       expect(receipt[field]).toMatch(/^[0-9a-f]{16}$/);
     } else {
       expect(receipt[field]).toMatch(/^\d+$/);
-      expect(Number(receipt[field])).toBeGreaterThanOrEqual(0);
+      const value = Number(receipt[field]);
+      expect(Number.isFinite(value)).toBe(true);
+      expect(Number.isInteger(value)).toBe(true);
+      expect(value).toBeGreaterThanOrEqual(0);
     }
   }
 
   for (const field of TIMING_FIELDS) {
     expect(receipt[field]).toMatch(/^\d+$/);
-    expect(Number(receipt[field])).toBeGreaterThanOrEqual(0);
+    const value = Number(receipt[field]);
+    expect(Number.isFinite(value)).toBe(true);
+    expect(Number.isInteger(value)).toBe(true);
+    expect(value).toBeGreaterThanOrEqual(0);
   }
 
   return receipt as Receipt;
 }
+
+const VALID_RECEIPT = REQUIRED_FIELDS.map((field) => {
+  if (field === "text_mode" || field === "texture_mode") return `${field}=atlas`;
+  if (field === "drawlist_checksum") return `${field}=0000000000000000`;
+  return `${field}=0`;
+}).join("\n");
+
+test("receipt parser rejects unknown and duplicate fields", () => {
+  expect(() => parseReceipt(`${VALID_RECEIPT}\nunknown=0`)).toThrow();
+  expect(() => parseReceipt(`${VALID_RECEIPT}\npeak_requested_bytes=0`)).toThrow();
+});
+
+test("receipt parser rejects non-finite and non-integer numbers", () => {
+  expect(() =>
+    parseReceipt(
+      VALID_RECEIPT.replace(
+        "peak_requested_bytes=0",
+        `peak_requested_bytes=${"9".repeat(400)}`,
+      ),
+    ),
+  ).toThrow();
+  expect(() =>
+    parseReceipt(VALID_RECEIPT.replace("peak_requested_bytes=0", "peak_requested_bytes=1.5")),
+  ).toThrow();
+});
 
 function canonicalReceipt(receipt: Receipt): Partial<Receipt> {
   return Object.fromEntries(

--- a/tests/psp-bench-parser.test.ts
+++ b/tests/psp-bench-parser.test.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "bun:test";
+import { parseBenchOutput } from "../tools/bench-ppsspp-parser.ts";
+
+function row(app: string, checksum?: string, bundle = 10, pak = 20): string {
+  return JSON.stringify({
+    app,
+    frames: 80,
+    window_n: 80,
+    bundle_bytes: bundle,
+    pak_bytes: pak,
+    ...(checksum === undefined ? {} : { drawlist_checksum: checksum }),
+  });
+}
+
+test("selects the requested app from multi-app PSP output", () => {
+  const parsed = parseBenchOutput(
+    `${row("hero", "1111111111111111", 11, 22)}\n${row("cards", undefined, 33, 44)}`,
+    "cards",
+    1,
+  );
+
+  expect(parsed.app).toBe("cards");
+  expect(parsed.bundle_bytes).toBe(33);
+  expect(parsed.pak_bytes).toBe(44);
+  expect(parsed.drawlist_checksum).toBeUndefined();
+});
+
+test("keeps one-line legacy PSP output compatible", () => {
+  const parsed = parseBenchOutput(row("legacy-app"), "stats", 1);
+
+  expect(parsed.app).toBe("legacy-app");
+  expect(parsed.drawlist_checksum).toBeUndefined();
+});
+
+test("reports a missing requested app in multi-app output", () => {
+  expect(() => parseBenchOutput(`${row("hero")}\n${row("cards")}`, "stats", 1)).toThrow(
+    "stats sample 1: requested app not found in PSP bench output (hero, cards)",
+  );
+});

--- a/tests/psp-bench.test.ts
+++ b/tests/psp-bench.test.ts
@@ -1,0 +1,62 @@
+import { $ } from "bun";
+import { expect, test } from "bun:test";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const NUMERIC_FIELDS = [
+  "eval_us",
+  "boot_to_frame0_us",
+  "avg_frame_interval_us",
+  "max_frame_interval_us",
+  "avg_js_us",
+  "avg_jobs_us",
+  "avg_tick_us",
+  "avg_draw_us",
+  "avg_render_us",
+  "avg_work_us",
+  "max_work_us",
+  "stack_free_bytes",
+  "bundle_bytes",
+  "pak_bytes",
+  "arena_capacity_bytes",
+  "arena_bump_bytes",
+  "arena_tail_free_bytes",
+  "arena_init_free_bytes",
+  "arena_configured_bytes",
+] as const;
+
+test("PPSSPP bench report preserves drawlist checksums", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pocketjs-psp-bench-"));
+  const rawPath = join(dir, "input.jsonl");
+  const outDir = join(dir, "out");
+  const row: Record<string, number | string> = {
+    kind: "sample",
+    app: "stats",
+    framework: "solid",
+    sample: 1,
+    sim_hz: 60,
+    frames: 100,
+    window_start: 28,
+    window_n: 100,
+    drawlist_checksum: "0123456789abcdef",
+    host_wall_ms: 1,
+    arena_limit_bytes: 0,
+  };
+  for (const field of NUMERIC_FIELDS) row[field] = 1;
+
+  try {
+    await writeFile(rawPath, `${JSON.stringify(row)}\n`);
+    await $`bun tools/bench-ppsspp.ts --apps=stats --from-raw=${rawPath} --out-dir=${outDir}`.quiet();
+    const reportPath = (await Array.fromAsync(new Bun.Glob("*.json").scan({ cwd: outDir })))[0];
+    const report = JSON.parse(await readFile(join(outDir, reportPath), "utf8"));
+    expect(report.drawlist_checksums.stats.solid).toEqual(["0123456789abcdef"]);
+
+    const markdownPath = reportPath.replace(/\.json$/, ".md");
+    expect(await readFile(join(outDir, markdownPath), "utf8")).toContain(
+      "Drawlist checksums: 0123456789abcdef",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tools/bench-ppsspp-parser.ts
+++ b/tools/bench-ppsspp-parser.ts
@@ -1,0 +1,58 @@
+export interface BenchLine {
+  app: string;
+  sim_hz: number;
+  frames: number;
+  window_start: number;
+  window_n: number;
+  eval_us: number;
+  boot_to_eval_begin_us: number;
+  boot_to_frame0_us: number;
+  avg_frame_interval_us: number;
+  max_frame_interval_us: number;
+  avg_js_us: number;
+  avg_jobs_us: number;
+  avg_tick_us: number;
+  avg_draw_us: number;
+  avg_render_us: number;
+  avg_work_us: number;
+  max_work_us: number;
+  stack_free_bytes: number;
+  bundle_bytes: number;
+  pak_bytes: number;
+  arena_capacity_bytes: number;
+  arena_bump_bytes: number;
+  arena_tail_free_bytes: number;
+  arena_init_free_bytes: number;
+  arena_configured_bytes: number;
+  drawlist_checksum?: string;
+}
+
+function isRequestedApp(row: BenchLine, app: string): boolean {
+  const base = row.app.split(".")[0];
+  return base === `${app}-main` || base === app;
+}
+
+export function parseBenchOutput(output: string, requestedApp: string, sample: number): BenchLine {
+  const lines = output.trim().split("\n").filter(Boolean);
+  let rows: BenchLine[];
+  try {
+    rows = lines.map((line) => JSON.parse(line) as BenchLine);
+  } catch (error) {
+    throw new Error(`${requestedApp} sample ${sample}: invalid PSP bench JSON: ${String(error)}`);
+  }
+
+  if (rows.length === 0) {
+    throw new Error(`${requestedApp} sample ${sample}: PSP bench output was empty`);
+  }
+  // Older PSP hosts emit one row and did not identify the requested app reliably.
+  const parsed = rows.length === 1 ? rows[0] : rows.find((row) => isRequestedApp(row, requestedApp));
+  if (!parsed) {
+    throw new Error(
+      `${requestedApp} sample ${sample}: requested app not found in PSP bench output (${rows.map((row) => row.app).join(", ")})`,
+    );
+  }
+  if (parsed.drawlist_checksum !== undefined && !/^[0-9a-f]{16}$/.test(parsed.drawlist_checksum)) {
+    throw new Error(`${requestedApp} sample ${sample}: invalid drawlist checksum`);
+  }
+  return parsed;
+}

--- a/tools/bench-ppsspp.ts
+++ b/tools/bench-ppsspp.ts
@@ -47,6 +47,7 @@ interface BenchLine {
   arena_tail_free_bytes: number;
   arena_init_free_bytes: number;
   arena_configured_bytes: number;
+  drawlist_checksum?: string;
 }
 
 interface Sample extends BenchLine {
@@ -303,6 +304,7 @@ const report = {
     ]),
   ),
   comparison: frameworks.length > 1 ? buildComparison(samplesOut, selectedSpecs) : undefined,
+  drawlist_checksums: summarizeChecksums(samplesOut, selectedSpecs),
   memory_scan: memoryScanReport,
 };
 writeFileSync(summaryPath, JSON.stringify(report, null, 2));
@@ -364,6 +366,9 @@ async function runBenchSample(
     throw new Error(`${spec.app} sample ${sample}: expected 1 bench line, got ${lines.length}`);
   }
   const parsed = JSON.parse(lines[0]) as BenchLine;
+  if (parsed.drawlist_checksum !== undefined && !/^[0-9a-f]{16}$/.test(parsed.drawlist_checksum)) {
+    throw new Error(`${spec.app} sample ${sample}: invalid drawlist checksum`);
+  }
   if (parsed.frames !== spec.capN || parsed.window_n !== spec.capN) {
     throw new Error(`${spec.app} sample ${sample}: bench window mismatch (${parsed.frames}/${parsed.window_n}, expected ${spec.capN})`);
   }
@@ -559,6 +564,20 @@ function summarizeApp(
   >;
 }
 
+function summarizeChecksums(rows: Sample[], specs: Spec[]) {
+  return Object.fromEntries(
+    specs.map((spec) => [
+      spec.app,
+      Object.fromEntries(
+        frameworks.map((fw) => [
+          fw,
+          [...new Set(rows.filter((r) => isAppRow(r, spec.app, fw)).map((r) => r.drawlist_checksum).filter(Boolean))],
+        ]),
+      ),
+    ]),
+  );
+}
+
 // ---------------------------------------------------------------------------
 // Cross-framework comparison (PR #6 methodology): per metric, the geometric
 // mean over apps of ratio(framework mean / baseline mean), baseline = the
@@ -642,6 +661,7 @@ function renderMarkdown(report: {
   frame_budget_us: number;
   apps: Record<string, Record<string, Record<Metric, ReturnType<typeof summarize>>>>;
   comparison?: ReturnType<typeof buildComparison>;
+  drawlist_checksums: Record<string, Record<string, string[]>>;
   memory_scan?: ReturnType<typeof renderMemoryScanReport>;
 }) {
   const lines = [
@@ -693,6 +713,8 @@ function renderMarkdown(report: {
         );
       }
       lines.push("");
+      const checksums = report.drawlist_checksums[app]?.[fw] ?? [];
+      lines.push(`Drawlist checksums: ${checksums.length ? checksums.join(", ") : "unavailable"}`, "");
     }
   }
 

--- a/tools/bench-ppsspp.ts
+++ b/tools/bench-ppsspp.ts
@@ -13,41 +13,13 @@ import { $ } from "bun";
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { parseFramework, type PocketFramework } from "../framework/compiler/jsx-plugin.ts";
+import { parseBenchOutput, type BenchLine } from "./bench-ppsspp-parser.ts";
 
 interface Spec {
   app: string;
   inputScript: string;
   capStart: number;
   capN: number;
-}
-
-interface BenchLine {
-  app: string;
-  sim_hz: number;
-  frames: number;
-  window_start: number;
-  window_n: number;
-  eval_us: number;
-  boot_to_eval_begin_us: number;
-  boot_to_frame0_us: number;
-  avg_frame_interval_us: number;
-  max_frame_interval_us: number;
-  avg_js_us: number;
-  avg_jobs_us: number;
-  avg_tick_us: number;
-  avg_draw_us: number;
-  avg_render_us: number;
-  avg_work_us: number;
-  max_work_us: number;
-  stack_free_bytes: number;
-  bundle_bytes: number;
-  pak_bytes: number;
-  arena_capacity_bytes: number;
-  arena_bump_bytes: number;
-  arena_tail_free_bytes: number;
-  arena_init_free_bytes: number;
-  arena_configured_bytes: number;
-  drawlist_checksum?: string;
 }
 
 interface Sample extends BenchLine {
@@ -362,13 +334,7 @@ async function runBenchSample(
     throw new Error(`${spec.app} sample ${sample}: ${benchFile} missing`);
   }
   const lines = readFileSync(benchFile, "utf8").trim().split("\n").filter(Boolean);
-  if (lines.length !== 1) {
-    throw new Error(`${spec.app} sample ${sample}: expected 1 bench line, got ${lines.length}`);
-  }
-  const parsed = JSON.parse(lines[0]) as BenchLine;
-  if (parsed.drawlist_checksum !== undefined && !/^[0-9a-f]{16}$/.test(parsed.drawlist_checksum)) {
-    throw new Error(`${spec.app} sample ${sample}: invalid drawlist checksum`);
-  }
+  const parsed = parseBenchOutput(lines.join("\n"), spec.app, sample);
   if (parsed.frames !== spec.capN || parsed.window_n !== spec.capN) {
     throw new Error(`${spec.app} sample ${sample}: bench window mismatch (${parsed.frames}/${parsed.window_n}, expected ${spec.capN})`);
   }


### PR DESCRIPTION
## Summary

- Add an isolated deterministic `pocketjs-core` memory/layout receipt.
- Separate canonical requested-byte metrics from PSP arena metrics.
- Add strict Bun receipt/parser checks and baseline metadata.
- Add PSP drawlist checksum reporting, overflow-safe benchmark windows, and multi-app JSONL selection.

## Verification

- `cargo test --manifest-path engine/core/Cargo.toml`: 129 passed
- `cargo test --manifest-path engine/core/Cargo.toml --example membench`: 4 passed
- `bun test tests/core-memory-bench.test.ts tests/psp-bench-parser.test.ts tests/psp-bench.test.ts`: 7 passed
- `git diff --check`: passed

## Environment limitation

PPSSPP/PSP execution is not included yet: `PSP_SDK` and `PPSSPPHeadless` are unavailable in this environment. The committed PSP receipt explicitly records null metrics and the blocker; no measurements are fabricated.

This branch does not include the Taffy storage rebuild candidate.