### PR TITLE
feat(pocket3d): add contact-based surface locomotion and occluder fading

### DIFF
--- a/.github/workflows/pocket3d.yml
+++ b/.github/workflows/pocket3d.yml
@@ -1,0 +1,43 @@
+name: Pocket3D
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/pocket3d.yml'
+      - 'engine/pocket3d/crates/pocket3d/**'
+      - 'engine/pocket3d/crates/pocket3d-world/**'
+      - 'engine/pocket3d/crates/pocket3d-bsp/**'
+      - 'engine/Cargo.toml'
+      - 'engine/Cargo.lock'
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/pocket3d.yml'
+      - 'engine/pocket3d/crates/pocket3d/**'
+      - 'engine/pocket3d/crates/pocket3d-world/**'
+      - 'engine/pocket3d/crates/pocket3d-bsp/**'
+      - 'engine/Cargo.toml'
+      - 'engine/Cargo.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+concurrency:
+  group: pocket3d-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contracts:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.97.0
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine
+      - run: cargo fmt --manifest-path engine/Cargo.toml -p pocket3d-world -p pocket3d -- --check
+      - run: cargo test --locked --manifest-path engine/Cargo.toml -p pocket3d-world -p pocket3d --lib
+      - run: cargo clippy --locked --manifest-path engine/Cargo.toml -p pocket3d-world -p pocket3d --all-targets -- -D warnings

--- a/engine/pocket3d/crates/pocket3d-world/README.md
+++ b/engine/pocket3d/crates/pocket3d-world/README.md
@@ -13,7 +13,7 @@ Each call to `World::step` performs the same ordered phases:
 1. Consume queued cuts, impulses, ignition, and water inputs.
 2. Synchronize attached entities with their parents.
 3. Integrate environmental exchange, heat transfer, evaporation, and fuel.
-4. Integrate dynamic bodies and solve ground and body contacts.
+4. Integrate dynamic bodies, advance kinematic locomotion, and solve contacts.
 5. Apply contact damage, resynchronize attachments, and commit fractures.
 6. Return ordered events and the state hash.
 
@@ -47,3 +47,35 @@ The current narrow phase is a single discrete sphere/capsule pass, and reactive
 pair checks are quadratic in active entity count. High-speed continuous
 collision, stable large stacks, spatial partitioning, and cross-architecture
 bitwise replay are outside the current contract.
+
+
+## Surface locomotion
+
+Add `Locomotion::default()` to a kinematic sphere or capsule and submit
+`LocomotionInput` before `World::step`. The world owns movement, contact
+projection, gravity, slope limits, surface anchors and normalized stamina.
+Inputs, configuration and state are included in snapshots and state hashes;
+old snapshots default to no motor. Apps own key bindings and animation selection.
+
+**Movement is tangent to an available support and cannot enter nearby solid
+geometry.** Walkable normals use `min_ground_dot`; steeper surfaces require
+held grip and sufficient support force. Grip acceleration times surface friction
+must support tangential gravity. Retained moisture (or ambient moisture on
+terrain) reduces effective grip by up to 85%; temperatures above the configured
+threshold prevent grip. These are geometry/material rules, independent of names,
+tags, recipes or scenarios. Sphere and rotated capsule surfaces share the rigid
+body narrow-phase geometry. Terrain coefficients come from `Environment::surface`.
+
+Release, jump, missing support or exhausted stamina return to gravity-driven
+movement. Grounded contact replenishes stamina. A local support anchor follows
+translation and rotation; jumping consumes an edge command and temporarily
+prevents regripping. Radius-bounded substeps and iterative projections prevent
+ordinary high-speed motor movement from tunneling through thin spheres/capsules.
+The motor is Y-up, uses a heightfield for terrain, and remains kinematic: it
+blocks against rigid bodies rather than transferring a physically simulated
+actor mass. Full rigid-body CCD and arbitrary concave terrain are outside this
+contract. Teleporting supports should be handled as explicit world edits.
+
+`locomotion::tests` covers sphere/capsule actors, capsule/terrain climbing,
+walk/slide limits, wet/hot supports, jump, exhaustion, moving/removed support,
+fast motion and exact snapshot replay. It runs without a renderer or GPU.

--- a/engine/pocket3d/crates/pocket3d-world/src/lib.rs
+++ b/engine/pocket3d/crates/pocket3d-world/src/lib.rs
@@ -4,10 +4,12 @@
 //! interactions, advance one fixed turn, consume ordered events, and map the
 //! resulting entity snapshot to any presentation backend.
 
+mod locomotion;
 mod rng;
 mod types;
 mod world;
 
+pub use locomotion::*;
 pub use rng::WorldRng;
 pub use types::*;
 pub use world::{SpawnError, World};

--- a/engine/pocket3d/crates/pocket3d-world/src/locomotion.rs
+++ b/engine/pocket3d/crates/pocket3d-world/src/locomotion.rs
@@ -1,0 +1,688 @@
+//! Contact-constrained kinematic locomotion. No renderer or content identities.
+use glam::{Vec2, Vec3};
+use serde::{Deserialize, Serialize};
+
+use crate::world::{closest_segment_points, collider_segment};
+use crate::{BodyMode, Entity, EntityId, Environment, World};
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LocomotionConfig {
+    pub walk_speed: f32,
+    pub climb_speed: f32,
+    pub jump_speed: f32,
+    /// Walkable surface normal dot world Y. Steeper surfaces require grip.
+    pub min_ground_dot: f32,
+    pub contact_offset: f32,
+    pub grip_reach: f32,
+    /// Maximum acceleration supplied by hands, multiplied by effective friction.
+    pub grip_acceleration: f32,
+    pub max_temperature_c: f32,
+    pub stamina_seconds: f32,
+    pub recovery_per_second: f32,
+}
+
+impl Default for LocomotionConfig {
+    fn default() -> Self {
+        Self {
+            walk_speed: 3.55,
+            climb_speed: 1.1,
+            jump_speed: 4.0,
+            min_ground_dot: 0.68,
+            contact_offset: 0.01,
+            grip_reach: 0.15,
+            grip_acceleration: 22.0,
+            max_temperature_c: 65.0,
+            stamina_seconds: 12.0,
+            recovery_per_second: 0.28,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]
+pub struct LocomotionInput {
+    /// World-space ground direction; length is clamped to one.
+    pub direction: Vec3,
+    /// Surface-space right/up input; length is clamped to one.
+    pub climb: Vec2,
+    pub grip: bool,
+    /// Edge command consumed by the next fixed turn.
+    pub jump: bool,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LocomotionMode {
+    Grounded,
+    Climbing,
+    Sliding,
+    #[default]
+    Airborne,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SurfaceAnchor {
+    pub entity: EntityId,
+    pub local_point: Vec3,
+    pub world_point: Vec3,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(default)]
+pub struct Locomotion {
+    pub config: LocomotionConfig,
+    pub input: LocomotionInput,
+    pub mode: LocomotionMode,
+    pub normal: Vec3,
+    pub stamina: f32,
+    pub support: Option<SurfaceAnchor>,
+    pub regrip_delay: f32,
+}
+
+impl Default for Locomotion {
+    fn default() -> Self {
+        Self {
+            config: LocomotionConfig::default(),
+            input: LocomotionInput::default(),
+            mode: LocomotionMode::Airborne,
+            normal: Vec3::Y,
+            stamina: 1.0,
+            support: None,
+            regrip_delay: 0.0,
+        }
+    }
+}
+
+/// Signed capsule/sphere separation. Normal points towards the querying body.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct SurfaceContact {
+    pub entity: Option<EntityId>,
+    pub normal: Vec3,
+    pub point: Vec3,
+    pub separation: f32,
+    pub friction: f32,
+    pub temperature_c: f32,
+}
+
+fn tangent(v: Vec3, n: Vec3) -> Vec3 {
+    v - n * v.dot(n)
+}
+fn finite_direction(v: Vec3) -> Vec3 {
+    if v.is_finite() {
+        v.clamp_length_max(1.0)
+    } else {
+        Vec3::ZERO
+    }
+}
+
+impl World {
+    /// Deterministic signed-distance query over the same sphere/capsule geometry
+    /// as rigid contacts. Includes terrain and excludes the actor's attachments.
+    pub fn surface_contacts<E: Environment + ?Sized>(
+        &self,
+        actor: &Entity,
+        environment: &E,
+        reach: f32,
+    ) -> Vec<SurfaceContact> {
+        if actor.collider.is_none() {
+            return Vec::new();
+        }
+        let (a, b, radius) = collider_segment(actor);
+        let mut contacts = Vec::new();
+        // Sample both segment ends: the lower one is not necessarily the support
+        // on a slope or for a rotated capsule.
+        for p in [a, b] {
+            let sample = environment.sample(p);
+            let n = sample.ground_normal.normalize_or(Vec3::Y);
+            let plane = Vec3::new(p.x, sample.ground_height, p.z);
+            let separation = (p - plane).dot(n) - radius;
+            if separation <= reach && separation.is_finite() {
+                contacts.push(SurfaceContact {
+                    entity: None,
+                    normal: n,
+                    point: p - n * (radius + separation),
+                    separation,
+                    friction: environment.surface(p).friction.max(0.0)
+                        * (1.0 - sample.ambient_moisture.clamp(0.0, 1.0) * 0.85),
+                    temperature_c: sample.ambient_temperature_c,
+                });
+            }
+        }
+        for (&id, other) in self.entities() {
+            if id == actor.id
+                || other.collider.is_none()
+                || other.attachment.is_some_and(|a| a.parent == actor.id)
+            {
+                continue;
+            }
+            let (c, d, r) = collider_segment(other);
+            let (pa, pb) = closest_segment_points(a, b, c, d);
+            let delta = pa - pb;
+            let separation = delta.length() - radius - r;
+            if separation <= reach && separation.is_finite() {
+                let n = delta.normalize_or(Vec3::X);
+                let moisture = other.reactive_state.map_or(0.0, |s| s.moisture);
+                contacts.push(SurfaceContact {
+                    entity: Some(id),
+                    normal: n,
+                    point: pb + n * r,
+                    separation,
+                    friction: other.surface.friction.max(0.0)
+                        * (1.0 - moisture.clamp(0.0, 1.0) * 0.85),
+                    temperature_c: other.reactive_state.map_or(20.0, |s| s.temperature_c),
+                });
+            }
+        }
+        contacts
+    }
+
+    pub(crate) fn step_locomotion<E: Environment + ?Sized>(&mut self, environment: &E) {
+        let ids: Vec<_> = self
+            .entities()
+            .filter_map(|(&id, e)| {
+                (e.locomotion.is_some()
+                    && e.collider.is_some()
+                    && e.attachment.is_none()
+                    && e.body.is_some_and(|b| b.mode == BodyMode::Kinematic))
+                .then_some(id)
+            })
+            .collect();
+        for id in ids {
+            let mut actor = self.entity(id).expect("collected actor").clone();
+            let mut motor = actor.locomotion.expect("collected motor");
+            let c = motor.config;
+            let dt = self.config().fixed_dt;
+            let gravity = self.config().gravity;
+            let previous = actor.transform.position;
+            let mut velocity = actor.body.expect("collected body").linear_velocity;
+            if !velocity.is_finite() {
+                velocity = Vec3::ZERO;
+            }
+            // Follow the actual support transform, including rotation. Removal
+            // naturally invalidates the anchor; velocity remains for release.
+            if let Some(anchor) = motor.support
+                && let Some(support) = self.entity(anchor.entity)
+            {
+                let displacement =
+                    support.transform.transform_point(anchor.local_point) - anchor.world_point;
+                actor.transform.position += displacement;
+            }
+            let contacts = self.surface_contacts(&actor, environment, c.grip_reach);
+            let ground = contacts
+                .iter()
+                .filter(|p| {
+                    p.normal.y >= c.min_ground_dot && p.separation <= c.contact_offset + 0.06
+                })
+                .min_by(|a, b| a.separation.total_cmp(&b.separation))
+                .copied();
+            motor.regrip_delay = (motor.regrip_delay - dt).max(0.0);
+            let grip = contacts
+                .iter()
+                .filter(|p| {
+                    p.normal.y < c.min_ground_dot
+                        && p.normal.y > -0.1
+                        && p.temperature_c <= c.max_temperature_c
+                        && p.friction * c.grip_acceleration >= tangent(gravity, p.normal).length()
+                        && (motor.mode == LocomotionMode::Climbing
+                            || motor.input.direction.dot(p.normal) < -0.1)
+                })
+                .min_by(|a, b| a.separation.total_cmp(&b.separation))
+                .copied();
+            let mut support = None;
+            if motor.input.grip
+                && motor.stamina > 0.0
+                && motor.regrip_delay <= 0.0
+                && let Some(contact) = grip
+            {
+                motor.mode = LocomotionMode::Climbing;
+                motor.normal = contact.normal;
+                let up = tangent(Vec3::Y, contact.normal).normalize_or(Vec3::Y);
+                let right = up.cross(contact.normal).normalize_or(Vec3::X);
+                let axis = if motor.input.climb.is_finite() {
+                    motor.input.climb.clamp_length_max(1.0)
+                } else {
+                    Vec2::ZERO
+                };
+                velocity = (up * axis.y + right * axis.x) * c.climb_speed;
+                actor.transform.position -=
+                    contact.normal * (contact.separation - c.contact_offset);
+                motor.stamina = (motor.stamina
+                    - dt * (0.35 + axis.length() * 0.65) / c.stamina_seconds.max(dt))
+                .max(0.0);
+                support = Some(contact);
+            } else if let Some(contact) =
+                ground.filter(|_| velocity.y <= 0.5 || motor.mode != LocomotionMode::Airborne)
+            {
+                motor.mode = LocomotionMode::Grounded;
+                motor.normal = contact.normal;
+                let direction = finite_direction(motor.input.direction * Vec3::new(1.0, 0.0, 1.0));
+                velocity = tangent(direction, contact.normal).normalize_or_zero()
+                    * direction.length()
+                    * c.walk_speed;
+                actor.transform.position -=
+                    contact.normal * (contact.separation - c.contact_offset);
+                motor.stamina = (motor.stamina + dt * c.recovery_per_second).min(1.0);
+                support = Some(contact);
+            } else {
+                if motor.mode == LocomotionMode::Climbing {
+                    // Keep inherited support motion on release.
+                    velocity += (actor.transform.position - previous) / dt;
+                    motor.regrip_delay = 0.25;
+                }
+                motor.mode = LocomotionMode::Airborne;
+                velocity += gravity * dt;
+                let control = finite_direction(motor.input.direction * Vec3::new(1.0, 0.0, 1.0));
+                velocity.x += (control.x * c.walk_speed - velocity.x) * (dt * 3.0).min(1.0);
+                velocity.z += (control.z * c.walk_speed - velocity.z) * (dt * 3.0).min(1.0);
+            }
+            if motor.input.jump && support.is_some() {
+                let push = if motor.mode == LocomotionMode::Climbing {
+                    motor.normal * c.jump_speed
+                } else {
+                    Vec3::ZERO
+                };
+                velocity += Vec3::Y * c.jump_speed + push;
+                motor.mode = LocomotionMode::Airborne;
+                motor.regrip_delay = 0.35;
+                support = None;
+            }
+            motor.input.jump = false;
+            // Radius-bounded advances prevent crossing a thin collider in one
+            // move. Reproject after every advance against ALL nearby geometry.
+            let radius = collider_segment(&actor).2;
+            let steps = ((velocity.length() * dt) / (radius * 0.25)).ceil().max(1.0) as usize;
+            for _ in 0..steps {
+                actor.transform.position += velocity * (dt / steps as f32);
+                for _ in 0..6 {
+                    let penetrations = self.surface_contacts(&actor, environment, c.contact_offset);
+                    let Some(contact) = penetrations
+                        .iter()
+                        .min_by(|a, b| a.separation.total_cmp(&b.separation))
+                    else {
+                        break;
+                    };
+                    let depth = c.contact_offset - contact.separation;
+                    if depth <= 0.00001 {
+                        break;
+                    }
+                    actor.transform.position += contact.normal * depth;
+                    let inward = velocity.dot(contact.normal);
+                    if inward < 0.0 {
+                        velocity -= contact.normal * inward;
+                    }
+                    if motor.mode == LocomotionMode::Airborne {
+                        motor.normal = contact.normal;
+                        if contact.normal.y >= c.min_ground_dot {
+                            motor.mode = LocomotionMode::Grounded;
+                            support = Some(*contact);
+                        } else if contact.normal.y > 0.05 {
+                            motor.mode = LocomotionMode::Sliding;
+                        }
+                    }
+                }
+            }
+            motor.support = support
+                .and_then(|contact| contact.entity)
+                .and_then(|entity| {
+                    let transform = self.entity(entity)?.transform;
+                    let world_point = actor.transform.position;
+                    let local_point = transform.rotation.inverse()
+                        * (world_point - transform.position)
+                        / transform.scale;
+                    Some(SurfaceAnchor {
+                        entity,
+                        local_point,
+                        world_point,
+                    })
+                });
+            actor.locomotion = Some(motor);
+            actor.body.as_mut().expect("collected body").linear_velocity = velocity;
+            *self.entity_mut(id).expect("actor remains") = actor;
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        Body, Collider, EntityBundle, EnvironmentSample, FlatEnvironment, ReactiveState, Transform,
+    };
+
+    fn actor(world: &mut World, shape: Collider, p: Vec3) -> EntityId {
+        let mut e = EntityBundle::new(Transform::from_translation(p));
+        let mut body = Body::static_body();
+        body.mode = BodyMode::Kinematic;
+        e.body = Some(body);
+        e.collider = Some(shape);
+        e.locomotion = Some(Locomotion::default());
+        world.spawn(e)
+    }
+    fn obstacle(world: &mut World, shape: Collider, p: Vec3) -> EntityId {
+        let mut e = EntityBundle::new(Transform::from_translation(p));
+        e.collider = Some(shape);
+        e.body = Some(Body::static_body());
+        e.surface.friction = 0.82;
+        world.spawn(e)
+    }
+    fn input(world: &mut World, id: EntityId, i: LocomotionInput) {
+        world
+            .entity_mut(id)
+            .unwrap()
+            .locomotion
+            .as_mut()
+            .unwrap()
+            .input = i;
+    }
+    fn shapes() -> [Collider; 2] {
+        [
+            Collider::Sphere { radius: 0.28 },
+            Collider::CapsuleY {
+                radius: 0.28,
+                half_height: 0.55,
+            },
+        ]
+    }
+    struct Slope(f32);
+    impl Environment for Slope {
+        fn sample(&self, p: Vec3) -> EnvironmentSample {
+            EnvironmentSample {
+                ground_height: self.0 * p.x,
+                ground_normal: Vec3::new(-self.0, 1.0, 0.0).normalize(),
+                ..Default::default()
+            }
+        }
+    }
+    #[test]
+    fn walk_and_slide_obey_slope_limit_for_sphere_and_capsule() {
+        for shape in shapes() {
+            for slope in [0.4, 2.0] {
+                let env = Slope(slope);
+                let mut w = World::with_seed(7);
+                let y = shape.half_height() + shape.radius() * (1.0 + slope * slope).sqrt() + 0.01;
+                let id = actor(&mut w, shape, Vec3::new(0.0, y, 0.0));
+                input(
+                    &mut w,
+                    id,
+                    LocomotionInput {
+                        direction: Vec3::X,
+                        ..Default::default()
+                    },
+                );
+                for _ in 0..90 {
+                    w.step(&env);
+                }
+                let e = w.entity(id).unwrap();
+                if slope < 1.0 {
+                    assert!(e.transform.position.x > 3.0, "{shape:?} {e:?}");
+                } else {
+                    assert!(
+                        e.transform.position.x < 0.5,
+                        "steep slope must resist walking: {e:?}"
+                    );
+                }
+                assert!(
+                    w.surface_contacts(e, &env, 0.1)
+                        .iter()
+                        .all(|c| c.separation >= -0.002)
+                );
+            }
+        }
+    }
+    #[test]
+    fn grip_climbs_terrain_and_capsules_then_release_falls() {
+        for shape in shapes() {
+            for terrain in [false, true] {
+                let mut w = World::with_seed(11);
+                let env = Slope(if terrain { 2.0 } else { 0.0 });
+                if !terrain {
+                    obstacle(
+                        &mut w,
+                        Collider::CapsuleY {
+                            radius: 0.5,
+                            half_height: 5.0,
+                        },
+                        Vec3::new(0.0, 5.0, 0.0),
+                    );
+                }
+                let p = if terrain {
+                    Vec3::new(
+                        0.0,
+                        shape.half_height() + shape.radius() * 5.0_f32.sqrt() + 0.01,
+                        0.0,
+                    )
+                } else {
+                    Vec3::new(0.80, 1.0, 0.0)
+                };
+                let id = actor(&mut w, shape, p);
+                input(
+                    &mut w,
+                    id,
+                    LocomotionInput {
+                        direction: if terrain { Vec3::X } else { Vec3::NEG_X },
+                        climb: Vec2::Y,
+                        grip: true,
+                        ..Default::default()
+                    },
+                );
+                for _ in 0..120 {
+                    w.step(&env);
+                }
+                let e = w.entity(id).unwrap();
+                assert_eq!(e.locomotion.unwrap().mode, LocomotionMode::Climbing);
+                let top = e.transform.position.y;
+                assert!(top > p.y + 1.5, "{e:?}");
+                input(&mut w, id, LocomotionInput::default());
+                for _ in 0..60 {
+                    w.step(&env);
+                }
+                assert!(w.entity(id).unwrap().transform.position.y < top - 0.3);
+            }
+        }
+    }
+    #[test]
+    fn wet_and_hot_surfaces_cannot_support_grip_across_colliders() {
+        for support_shape in [
+            Collider::Sphere { radius: 5.0 },
+            Collider::CapsuleY {
+                radius: 5.0,
+                half_height: 4.0,
+            },
+        ] {
+            for (moisture, temperature) in [(0.0, 20.0), (1.0, 20.0), (0.0, 100.0)] {
+                let mut w = World::with_seed(3);
+                let env = FlatEnvironment::default();
+                let surface = obstacle(&mut w, support_shape, Vec3::new(0.0, 6.0, 0.0));
+                w.entity_mut(surface).unwrap().reactive_state =
+                    Some(ReactiveState::new(temperature, moisture, 1.0));
+                let id = actor(&mut w, shapes()[0], Vec3::new(5.30, 6.0, 0.0));
+                input(
+                    &mut w,
+                    id,
+                    LocomotionInput {
+                        direction: Vec3::NEG_X,
+                        climb: Vec2::Y,
+                        grip: true,
+                        ..Default::default()
+                    },
+                );
+                for _ in 0..20 {
+                    w.step(&env);
+                }
+                assert_eq!(
+                    w.entity(id).unwrap().locomotion.unwrap().mode == LocomotionMode::Climbing,
+                    moisture == 0.0 && temperature < 65.0
+                );
+            }
+        }
+    }
+    #[test]
+    fn anchor_follows_support_removal_releases_and_snapshot_replays() {
+        for shape in shapes() {
+            let mut w = World::with_seed(8);
+            let env = FlatEnvironment::default();
+            let surface = obstacle(
+                &mut w,
+                Collider::CapsuleY {
+                    radius: 0.5,
+                    half_height: 5.0,
+                },
+                Vec3::new(0.0, 5.0, 0.0),
+            );
+            let id = actor(&mut w, shape, Vec3::new(0.8, 3.0, 0.0));
+            input(
+                &mut w,
+                id,
+                LocomotionInput {
+                    direction: Vec3::NEG_X,
+                    climb: Vec2::Y,
+                    grip: true,
+                    ..Default::default()
+                },
+            );
+            w.step(&env);
+            let before = w.entity(id).unwrap().transform.position;
+            w.entity_mut(surface).unwrap().transform.position += Vec3::X * 0.3;
+            w.step(&env);
+            assert!((w.entity(id).unwrap().transform.position.x - before.x - 0.3).abs() < 0.01);
+            let snapshot = w.snapshot();
+            for _ in 0..60 {
+                w.step(&env);
+            }
+            let hash = w.state_hash();
+            w.restore(snapshot);
+            for _ in 0..60 {
+                w.step(&env);
+            }
+            assert_eq!(hash, w.state_hash());
+            w.remove(surface);
+            w.step(&env);
+            assert_eq!(
+                w.entity(id).unwrap().locomotion.unwrap().mode,
+                LocomotionMode::Airborne
+            );
+            assert!(w.entity(id).unwrap().locomotion.unwrap().support.is_none());
+        }
+    }
+    #[test]
+    fn jump_detaches_and_exhaustion_requires_ground_recovery() {
+        for shape in shapes() {
+            let mut w = World::with_seed(2);
+            let env = FlatEnvironment::default();
+            obstacle(
+                &mut w,
+                Collider::CapsuleY {
+                    radius: 0.5,
+                    half_height: 8.0,
+                },
+                Vec3::new(0.0, 8.0, 0.0),
+            );
+            let id = actor(&mut w, shape, Vec3::new(0.8, 5.0, 0.0));
+            input(
+                &mut w,
+                id,
+                LocomotionInput {
+                    direction: Vec3::NEG_X,
+                    grip: true,
+                    jump: true,
+                    ..Default::default()
+                },
+            );
+            w.step(&env);
+            let e = w.entity(id).unwrap();
+            assert_eq!(e.locomotion.unwrap().mode, LocomotionMode::Airborne);
+            assert!(e.body.unwrap().linear_velocity.x > 2.0);
+            assert!(!e.locomotion.unwrap().input.jump);
+            let e = w.entity_mut(id).unwrap();
+            e.transform.position = Vec3::new(0.8, 5.0, 0.0);
+            let m = e.locomotion.as_mut().unwrap();
+            m.stamina = 0.001;
+            m.regrip_delay = 0.0;
+            for _ in 0..4 {
+                w.step(&env);
+            }
+            assert_eq!(
+                w.entity(id).unwrap().locomotion.unwrap().mode,
+                LocomotionMode::Airborne
+            );
+            assert_eq!(w.entity(id).unwrap().locomotion.unwrap().stamina, 0.0);
+        }
+    }
+    #[test]
+    fn substeps_stop_fast_motion_at_two_obstacle_shapes() {
+        for shape in [
+            Collider::Sphere { radius: 0.15 },
+            Collider::CapsuleY {
+                radius: 0.15,
+                half_height: 2.0,
+            },
+        ] {
+            let mut w = World::with_seed(1);
+            let env = FlatEnvironment::default();
+            obstacle(&mut w, shape, Vec3::new(0.0, 1.0, 0.0));
+            let id = actor(&mut w, shapes()[0], Vec3::new(-2.0, 1.0, 0.0));
+            let e = w.entity_mut(id).unwrap();
+            e.body.as_mut().unwrap().linear_velocity = Vec3::X * 240.0;
+            w.step(&env);
+            assert!(w.entity(id).unwrap().transform.position.x < -0.40);
+        }
+    }
+}
+
+#[cfg(test)]
+mod transition_tests {
+    use super::*;
+    use crate::{Body, Collider, EntityBundle, FlatEnvironment, ReactiveState, Transform};
+    #[test]
+    fn an_existing_grip_releases_when_its_material_becomes_wet_or_hot() {
+        for moisture in [true, false] {
+            let mut w = World::with_seed(19);
+            let mut surface =
+                EntityBundle::new(Transform::from_translation(Vec3::new(0.0, 4.0, 0.0)));
+            surface.collider = Some(Collider::CapsuleY {
+                radius: 0.5,
+                half_height: 4.0,
+            });
+            surface.surface.friction = 0.85;
+            let support = w.spawn(surface);
+            let mut actor =
+                EntityBundle::new(Transform::from_translation(Vec3::new(0.8, 3.0, 0.0)));
+            let mut body = Body::static_body();
+            body.mode = BodyMode::Kinematic;
+            actor.body = Some(body);
+            actor.collider = Some(Collider::Sphere { radius: 0.28 });
+            actor.locomotion = Some(Locomotion {
+                input: LocomotionInput {
+                    direction: Vec3::NEG_X,
+                    grip: true,
+                    ..Default::default()
+                },
+                ..Default::default()
+            });
+            let id = w.spawn(actor);
+            let env = FlatEnvironment::default();
+            w.step(&env);
+            assert_eq!(
+                w.entity(id).unwrap().locomotion.unwrap().mode,
+                LocomotionMode::Climbing
+            );
+            let old_position = w.entity(id).unwrap().transform.position;
+            let rotation = glam::Quat::from_rotation_y(0.25);
+            w.entity_mut(support).unwrap().transform.rotation = rotation;
+            w.step(&env);
+            let expected =
+                Vec3::new(0.0, 4.0, 0.0) + rotation * (old_position - Vec3::new(0.0, 4.0, 0.0));
+            assert!(w.entity(id).unwrap().transform.position.distance(expected) < 0.01);
+            w.entity_mut(support).unwrap().reactive_state = Some(ReactiveState::new(
+                if moisture { 20.0 } else { 100.0 },
+                if moisture { 1.0 } else { 0.0 },
+                1.0,
+            ));
+            w.step(&env);
+            assert_eq!(
+                w.entity(id).unwrap().locomotion.unwrap().mode,
+                LocomotionMode::Airborne
+            );
+            assert!(w.entity(id).unwrap().body.unwrap().linear_velocity.y < 0.0);
+        }
+    }
+}

--- a/engine/pocket3d/crates/pocket3d-world/src/types.rs
+++ b/engine/pocket3d/crates/pocket3d-world/src/types.rs
@@ -269,6 +269,9 @@ pub struct Entity {
     pub body: Option<Body>,
     pub collider: Option<Collider>,
     pub surface: PhysicalSurface,
+    /// Optional fixed-step surface locomotion for a kinematic collider.
+    #[serde(default)]
+    pub locomotion: Option<crate::Locomotion>,
     pub attachment: Option<Attachment>,
     pub structure: Option<Structure>,
     pub reactive_material: Option<ReactiveMaterial>,
@@ -289,6 +292,9 @@ pub struct EntityBundle {
     pub body: Option<Body>,
     pub collider: Option<Collider>,
     pub surface: PhysicalSurface,
+    /// Optional fixed-step surface locomotion for a kinematic collider.
+    #[serde(default)]
+    pub locomotion: Option<crate::Locomotion>,
     pub attachment: Option<Attachment>,
     pub structure: Option<Structure>,
     pub reactive_material: Option<ReactiveMaterial>,
@@ -304,6 +310,7 @@ impl EntityBundle {
             body: None,
             collider: None,
             surface: PhysicalSurface::default(),
+            locomotion: None,
             attachment: None,
             structure: None,
             reactive_material: None,
@@ -351,6 +358,14 @@ impl Default for EnvironmentSample {
 
 pub trait Environment {
     fn sample(&self, position: Vec3) -> EnvironmentSample;
+
+    /// Terrain contact coefficients; height and normal come from `sample`.
+    fn surface(&self, _position: Vec3) -> PhysicalSurface {
+        PhysicalSurface {
+            friction: 0.86,
+            restitution: 0.04,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Default, PartialEq, Serialize, Deserialize)]

--- a/engine/pocket3d/crates/pocket3d-world/src/world.rs
+++ b/engine/pocket3d/crates/pocket3d-world/src/world.rs
@@ -198,6 +198,7 @@ impl World {
         self.sync_attachments();
         self.step_reactions(environment, &mut events);
         self.integrate_bodies();
+        self.step_locomotion(environment);
         let contacts = self.solve_ground(environment);
         let mut pair_contacts = self.solve_pairs();
         let mut contacts = contacts;
@@ -939,6 +940,45 @@ impl World {
                 }
                 None => hash.u8(0),
             }
+            match entity.locomotion {
+                Some(motor) => {
+                    hash.u8(1);
+                    let c = motor.config;
+                    for value in [
+                        c.walk_speed,
+                        c.climb_speed,
+                        c.jump_speed,
+                        c.min_ground_dot,
+                        c.contact_offset,
+                        c.grip_reach,
+                        c.grip_acceleration,
+                        c.max_temperature_c,
+                        c.stamina_seconds,
+                        c.recovery_per_second,
+                    ] {
+                        hash.f32(value);
+                    }
+                    hash.vec3(motor.input.direction);
+                    hash.f32(motor.input.climb.x);
+                    hash.f32(motor.input.climb.y);
+                    hash.u8(motor.input.grip as u8);
+                    hash.u8(motor.input.jump as u8);
+                    hash.u8(motor.mode as u8);
+                    hash.vec3(motor.normal);
+                    hash.f32(motor.stamina);
+                    hash.f32(motor.regrip_delay);
+                    match motor.support {
+                        Some(anchor) => {
+                            hash.u8(1);
+                            hash.u64(anchor.entity.0);
+                            hash.vec3(anchor.local_point);
+                            hash.vec3(anchor.world_point);
+                        }
+                        None => hash.u8(0),
+                    }
+                }
+                None => hash.u8(0),
+            }
             hash.f32(entity.surface.friction);
             hash.f32(entity.surface.restitution);
             match entity.attachment {
@@ -1256,6 +1296,7 @@ fn entity_from_bundle(id: EntityId, bundle: EntityBundle) -> Entity {
         body: bundle.body,
         collider: bundle.collider,
         surface: bundle.surface,
+        locomotion: bundle.locomotion,
         attachment: bundle.attachment,
         structure: bundle.structure,
         reactive_material: bundle.reactive_material,
@@ -1312,7 +1353,7 @@ fn reaction_shape(entity: &Entity) -> (Vec3, Vec3, f32) {
     }
 }
 
-fn collider_segment(entity: &Entity) -> (Vec3, Vec3, f32) {
+pub(crate) fn collider_segment(entity: &Entity) -> (Vec3, Vec3, f32) {
     let collider = entity.collider.expect("caller filters collider");
     match collider {
         Collider::Sphere { .. } => {
@@ -1342,7 +1383,7 @@ fn collider_segment(entity: &Entity) -> (Vec3, Vec3, f32) {
 
 /// Closest points on two finite segments. Based on the standard clamped
 /// two-parameter solution, with explicit degenerate handling for spheres.
-fn closest_segment_points(p1: Vec3, q1: Vec3, p2: Vec3, q2: Vec3) -> (Vec3, Vec3) {
+pub(crate) fn closest_segment_points(p1: Vec3, q1: Vec3, p2: Vec3, q2: Vec3) -> (Vec3, Vec3) {
     let d1 = q1 - p1;
     let d2 = q2 - p2;
     let r = p1 - p2;

--- a/engine/pocket3d/crates/pocket3d/src/app.rs
+++ b/engine/pocket3d/crates/pocket3d/src/app.rs
@@ -224,11 +224,20 @@ impl<G: Game> WinitApp<G> {
         state
             .renderer
             .render(&state.gpu, &view, size, scene, camera, hud);
-        let mut encoder = state
-            .gpu
-            .device
-            .create_command_encoder(&wgpu::CommandEncoderDescriptor { label: Some("overlay") });
-        self.game.overlay(&state.gpu, &mut encoder, &view, state.surface_config.format, size);
+        let mut encoder =
+            state
+                .gpu
+                .device
+                .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                    label: Some("overlay"),
+                });
+        self.game.overlay(
+            &state.gpu,
+            &mut encoder,
+            &view,
+            state.surface_config.format,
+            size,
+        );
         state.gpu.queue.submit([encoder.finish()]);
         state.window.pre_present_notify();
         frame.present();

--- a/engine/pocket3d/crates/pocket3d/src/camera.rs
+++ b/engine/pocket3d/crates/pocket3d/src/camera.rs
@@ -82,3 +82,71 @@ impl Camera {
         (near, (far - near).normalize_or_zero())
     }
 }
+
+/// Intersect a finite camera-to-subject segment with local axis-aligned bounds.
+/// Transform both endpoints into object space before calling for rotated/scaled
+/// models. A segment beginning or ending inside the bounds counts as occluded.
+pub fn segment_intersects_bounds(start: Vec3, end: Vec3, min: Vec3, max: Vec3) -> bool {
+    if !start.is_finite()
+        || !end.is_finite()
+        || !min.is_finite()
+        || !max.is_finite()
+        || min.cmpgt(max).any()
+    {
+        return false;
+    }
+    let delta = end - start;
+    let mut near: f32 = 0.0;
+    let mut far: f32 = 1.0;
+    for axis in 0..3 {
+        if delta[axis].abs() < 1e-8 {
+            if start[axis] < min[axis] || start[axis] > max[axis] {
+                return false;
+            }
+        } else {
+            let a = (min[axis] - start[axis]) / delta[axis];
+            let b = (max[axis] - start[axis]) / delta[axis];
+            near = near.max(a.min(b));
+            far = far.min(a.max(b));
+            if near > far {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+#[cfg(test)]
+mod occlusion_tests {
+    use super::*;
+    use glam::Quat;
+    #[test]
+    fn finite_segments_handle_rotated_and_nonuniform_bounds() {
+        for transform in [
+            Mat4::IDENTITY,
+            Mat4::from_scale_rotation_translation(
+                Vec3::new(2.0, 0.5, 3.0),
+                Quat::from_rotation_y(0.7),
+                Vec3::new(5.0, 2.0, -3.0),
+            ),
+        ] {
+            let inverse = transform.inverse();
+            for (a, b, expected) in [
+                (Vec3::Z * 3.0, Vec3::NEG_Z * 3.0, true),
+                (Vec3::Z * 3.0, Vec3::Z * 2.0, false),
+                (Vec3::new(2.0, 0.0, 3.0), Vec3::new(2.0, 0.0, -3.0), false),
+                (Vec3::ZERO, Vec3::ZERO, true),
+            ] {
+                assert_eq!(
+                    segment_intersects_bounds(
+                        inverse.transform_point3(transform.transform_point3(a)),
+                        inverse.transform_point3(transform.transform_point3(b)),
+                        Vec3::NEG_ONE,
+                        Vec3::ONE
+                    ),
+                    expected
+                );
+            }
+        }
+    }
+}

--- a/engine/pocket3d/crates/pocket3d/src/input.rs
+++ b/engine/pocket3d/crates/pocket3d/src/input.rs
@@ -123,9 +123,8 @@ impl Input {
                     if let Some(k) = named {
                         self.edits.push(k);
                     } else if let Some(text) = &event.text {
-                        self.edits.extend(
-                            text.chars().filter(|c| !c.is_control()).map(EditKey::Char),
-                        );
+                        self.edits
+                            .extend(text.chars().filter(|c| !c.is_control()).map(EditKey::Char));
                     }
                 } else if matches!(&event.logical_key, Key::Named(NamedKey::Super)) {
                     self.super_down = false;
@@ -347,9 +346,7 @@ mod tests {
         });
         input.on_window_event(&WindowEvent::MouseWheel {
             device_id: winit::event::DeviceId::dummy(),
-            delta: MouseScrollDelta::PixelDelta(
-                winit::dpi::PhysicalPosition::new(3.25, -7.5),
-            ),
+            delta: MouseScrollDelta::PixelDelta(winit::dpi::PhysicalPosition::new(3.25, -7.5)),
             phase: winit::event::TouchPhase::Moved,
         });
         assert_eq!(input.scroll(), Vec2::new(33.25, -47.5));

--- a/engine/pocket3d/crates/pocket3d/src/model.rs
+++ b/engine/pocket3d/crates/pocket3d/src/model.rs
@@ -1630,6 +1630,8 @@ fn to_rgba8(img: &gltf::image::Data) -> Vec<u8> {
 pub struct ModelInstance {
     pub asset: Arc<ModelAsset>,
     pub transform: Mat4,
+    /// Color multiplier. Alpha below one selects depth-tested blending,
+    /// including for authored opaque materials; the instance does not write depth.
     pub tint: [f32; 4],
     pub anim: AnimState,
     /// 0..1 how strongly lighting applies (1 = fully lit by sun/ambient).

--- a/engine/pocket3d/crates/pocket3d/src/renderer.rs
+++ b/engine/pocket3d/crates/pocket3d/src/renderer.rs
@@ -443,6 +443,7 @@ fn model_normal_matrix(model: Mat4) -> Mat4 {
 }
 
 pub(crate) struct ModelDraw {
+    instance_blend: bool,
     asset: std::sync::Arc<ModelAsset>,
     inst_offset: u32,
     joints_offset: u32,
@@ -680,6 +681,7 @@ impl ModelPass {
             joint_bytes.extend(std::iter::repeat_n(0u8, pad));
 
             draws.push(ModelDraw {
+                instance_blend: inst.tint[3] < 1.0,
                 asset: inst.asset.clone(),
                 inst_offset: off as u32,
                 joints_offset,
@@ -748,7 +750,8 @@ impl ModelPass {
             pass.set_index_buffer(d.asset.ibuf.slice(..), wgpu::IndexFormat::Uint32);
             let mut overlay_bound = false;
             for (pi, prim) in d.asset.primitives.iter().enumerate() {
-                if (prim.alpha_mode == MaterialAlphaMode::Blend) != blend_phase {
+                if (d.instance_blend || prim.alpha_mode == MaterialAlphaMode::Blend) != blend_phase
+                {
                     continue;
                 }
                 let pipeline = match (blend_phase, prim.double_sided) {

--- a/engine/pocket3d/crates/pocket3d/src/shaders/model.wgsl
+++ b/engine/pocket3d/crates/pocket3d/src/shaders/model.wgsl
@@ -127,9 +127,9 @@ fn distance_fog(world_pos: vec3f) -> f32 {
 
 @fragment
 fn fs_main(in: VsOut, @builtin(front_facing) front_facing: bool) -> @location(0) vec4f {
-    var albedo = textureSample(t_albedo, s_albedo, in.uv)
-        * material.base_color_factor
-        * instance.tint;
+    let material_albedo = textureSample(t_albedo, s_albedo, in.uv)
+        * material.base_color_factor;
+    var albedo = material_albedo * instance.tint;
     if material.style.x > 0.5 {
         // Texture samples are already linearized by the sRGB texture view.
         // Rec. 709 luminance removes hue without changing transparency.
@@ -137,7 +137,7 @@ fn fs_main(in: VsOut, @builtin(front_facing) front_facing: bool) -> @location(0)
         albedo = vec4f(vec3f(luminance), albedo.a);
     }
     let alpha_cutoff = max(instance.params.y, material.params.y);
-    if alpha_cutoff > 0.0 && albedo.a < alpha_cutoff {
+    if alpha_cutoff > 0.0 && material_albedo.a < alpha_cutoff {
         discard;
     }
     var n = normalize(in.normal);
@@ -162,7 +162,8 @@ fn fs_main(in: VsOut, @builtin(front_facing) front_facing: bool) -> @location(0)
             + globals.rim_color.rgb * rim,
         lit_amount,
     );
-    let alpha = select(1.0, albedo.a, material.params.w > 0.5);
+    let alpha = select(1.0, material_albedo.a, material.params.w > 0.5)
+        * clamp(instance.tint.a, 0.0, 1.0);
     let color = mix(
         albedo.rgb * lighting,
         globals.fog_color.rgb,

--- a/engine/pocket3d/crates/pocket3d/tests/instance_opacity.rs
+++ b/engine/pocket3d/crates/pocket3d/tests/instance_opacity.rs
@@ -1,0 +1,83 @@
+//! Run explicitly on a machine with a wgpu adapter.
+use glam::{Mat4, Vec3};
+use pocket3d::{
+    camera::Camera,
+    gpu::{Gpu, OFFSCREEN_FORMAT, OffscreenTarget},
+    hud::Hud,
+    model::{ModelAsset, ModelInstance, ModelVertex},
+    renderer::Renderer,
+    scene::Scene,
+};
+
+#[test]
+#[ignore = "requires a wgpu adapter; run with --ignored"]
+fn opaque_and_cutout_instances_fade_without_hiding_the_background() {
+    let gpu = Gpu::new_headless().unwrap();
+    let mut renderer = Renderer::new(&gpu, OFFSCREEN_FORMAT).unwrap();
+    let verts = [
+        [-1.0, -1.0, 0.0],
+        [1.0, -1.0, 0.0],
+        [1.0, 1.0, 0.0],
+        [-1.0, 1.0, 0.0],
+    ]
+    .map(|pos| ModelVertex {
+        pos,
+        normal: [0.0, 0.0, 1.0],
+        uv: [0.5, 0.5],
+        joints: [0; 4],
+        weights: [1.0, 0.0, 0.0, 0.0],
+    });
+    let asset = ModelAsset::from_geometry(
+        &gpu,
+        &renderer.model_material_layout,
+        &renderer.samplers,
+        "opacity fixture",
+        &verts,
+        &[0, 1, 2, 0, 2, 3],
+        None,
+    );
+    let target = OffscreenTarget::new(&gpu, 32, 32);
+    let camera = Camera {
+        pos: Vec3::new(0.0, 0.0, 3.0),
+        znear: 0.1,
+        ..Default::default()
+    };
+    for cutout in [0.0, 0.5] {
+        for opacity in [0.0, 0.25, 1.0] {
+            let mut scene = Scene {
+                draw_sky: false,
+                ..Default::default()
+            };
+            let mut front = ModelInstance::new(asset.clone());
+            front.tint = [1.0, 0.0, 0.0, opacity];
+            front.lit = 0.0;
+            front.cutout = cutout;
+            let mut back = ModelInstance::new(asset.clone());
+            back.transform = Mat4::from_translation(Vec3::NEG_Z * 0.2);
+            back.tint = [0.0, 0.0, 1.0, 1.0];
+            back.lit = 0.0;
+            // Front-first input order must still draw opaque background first.
+            scene.models = vec![front, back];
+            renderer.render(
+                &gpu,
+                &target.view,
+                (32, 32),
+                &scene,
+                &camera,
+                &Hud::default(),
+            );
+            let rgba = target.read_rgba(&gpu).unwrap();
+            let pixel = &rgba[(16 * 32 + 16) * 4..(16 * 32 + 16) * 4 + 4];
+            if opacity == 0.0 {
+                assert!(pixel[0] < 5 && pixel[2] > 245, "{pixel:?}");
+            } else if opacity == 1.0 {
+                assert!(pixel[0] > 245 && pixel[2] < 5, "{pixel:?}");
+            } else {
+                assert!(
+                    pixel[0] > 30 && pixel[0] < 200 && pixel[2] > 150,
+                    "{cutout}: {pixel:?}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Kinematic actors previously had no shared support or locomotion contract, so applications had to place them directly on terrain and implement obstacle handling themselves. Add an optional fixed-step `Locomotion` component that walks, slides, grips, traverses, jumps and falls using sphere/capsule and heightfield contacts. Inputs, material-dependent grip, stamina and moving-support anchors participate in snapshot/hash replay.

Grip must supply enough acceleration to support tangential gravity. Friction, retained moisture and temperature determine support; solvers never consult content names, tags, recipes or scenarios. Radius-bounded advances constrain motion against nearby geometry. The motor remains Y-up and kinematic; arbitrary concave terrain, full rigid-body CCD and dynamic actor mass transfer are outside this contract.

Climbing also exposes camera occlusion. Add a finite-segment bounds query and instance opacity for opaque/cutout models, retaining cutout coverage and drawing translucent instances after opaque geometry without writing depth. Applications choose which visual occluders to fade.

Validation:
- 54 CPU tests across `pocket3d-world` and `pocket3d`, including two actor shapes, terrain/capsule climbing, dry/wet/hot support, rotation/removal, jump/exhaustion, thin obstacles and replay.
- Explicit GPU pixel test verifies opacity 0/0.25/1 for opaque and cutout instances over a background, independent of instance submission order.
- Format and Clippy with warnings denied, Rust 1.97.0, locked dependencies.
- New path-filtered Pocket3D CI lane covers the two crates and WGSL validation.
