### PR TITLE
feat(ios): stamp application versions and native build receipts

### DIFF
--- a/docs/IPODTOUCH4.md
+++ b/docs/IPODTOUCH4.md
@@ -127,3 +127,22 @@ action — a receipt that a gesture interaction completed on the hardware.
 `dist/ipodtouch4/device-frame.png`.
 
 User application icons use **opaque 57×57 and 114×114 artwork**. SpringBoard applies the rounded mask and shadow; `UIPrerenderedIcon` suppresses the stock gloss. The System application path uses a precomposed transparent mask instead. Baking that mask into a User icon adds an inset rim under the native mask. Icon filenames include the artwork revision so an update selects a fresh SpringBoard cache entry.
+
+## Versions for manual store publication
+
+The build reads **`version` from the app's `pocket.json`** and writes it to
+`CFBundleShortVersionString`. This target requires a numeric `MAJOR.MINOR.PATCH`
+product version. **`POCKETJS_IOS_BUILD_NUMBER` supplies `CFBundleVersion`** as a
+positive integer; it defaults to `1` for local development. Increase the counter
+for every rebuild that will be published, including revisions of the same product
+version:
+
+```sh
+POCKETJS_IOS_BUILD_NUMBER=1 bun ipodtouch4 build
+```
+
+The generated `build-receipt.json` includes `productVersion` and
+`nativeBuildNumber`. Its file hashes cover the generated Info.plist and executable;
+the build ID includes the rendered Info.plist. Changing the native build number
+therefore changes both the receipt and the build ID. The same metadata flow applies
+to built-in and external application descriptors. No application CI is required.

--- a/tests/ipodtouch4-profile.test.ts
+++ b/tests/ipodtouch4-profile.test.ts
@@ -191,3 +191,27 @@ describe("private iPod touch 4 profile", () => {
     ).toBe(false);
   });
 });
+
+describe("application versions and native build receipts", () => {
+  test("stamps manifest version and an independent build counter for multiple app identities", async () => {
+    const { resolveIOSAppVersion, renderIPodTouch4InfoPlist } = await import("../tools/ipodtouch4.ts");
+    const source = readFileSync(join(repository, "hosts/ipodtouch4/Info.plist"), "utf8");
+    const first = renderIPodTouch4InfoPlist(source, IPODTOUCH4_APPS.clear, resolveIOSAppVersion("1.2.3", "42"));
+    expect(first).toMatch(/<key>CFBundleShortVersionString<\/key>\s*<string>1.2.3<\/string>/);
+    expect(first).toMatch(/<key>CFBundleVersion<\/key>\s*<string>42<\/string>/);
+    const second = renderIPodTouch4InfoPlist(source, { ...IPODTOUCH4_APPS.clear, bundleId: "dev.example.notes", executable: "Notes", title: "Notes & Lists", scheme: "example-notes" }, resolveIOSAppVersion("2.0.0", "43"));
+    expect(second).toContain("<string>dev.example.notes</string>");
+    expect(second).toContain("<string>Notes &amp; Lists</string>");
+    expect(second).toMatch(/<key>CFBundleVersion<\/key>\s*<string>43<\/string>/);
+    expect(() => renderIPodTouch4InfoPlist(source.replace("CFBundleVersion", "MissingVersion"), IPODTOUCH4_APPS.clear, resolveIOSAppVersion("1.0.0"))).toThrow("one CFBundleVersion");
+  });
+  test("rejects invalid native version metadata before building", async () => {
+    const { resolveIOSAppVersion } = await import("../tools/ipodtouch4.ts");
+    expect(resolveIOSAppVersion("1.2.3")).toEqual({ productVersion: "1.2.3", buildNumber: "1" });
+    for (const version of [undefined, 12, "1.2", "1.2.3-beta", "01.2.3", "<invalid>"]) expect(() => resolveIOSAppVersion(version)).toThrow();
+    for (const build of ["0", "-1", "01", "1.0", "abc", "1000000000"]) expect(() => resolveIOSAppVersion("1.2.3", build)).toThrow();
+    const receipt = { schema: 1 as const, buildId: "a", bundleId: "native.notes", target: "ios", hostAbi: 1, deploymentTarget: "6.0", files: {}, productVersion: "1.2.3", nativeBuildNumber: "42" };
+    expect(buildReceiptsMatch(receipt, { ...receipt, nativeBuildNumber: "43" })).toBe(false);
+    expect(buildReceiptsMatch(receipt, { ...receipt, productVersion: "1.2.4" })).toBe(false);
+  });
+});

--- a/tools/ipodtouch4.ts
+++ b/tools/ipodtouch4.ts
@@ -208,6 +208,9 @@ interface BuildReceipt {
   readonly target: string;
   readonly hostAbi: number;
   readonly deploymentTarget: string;
+  /** Absent in older development receipts. New builds stamp both native fields. */
+  readonly productVersion?: string;
+  readonly nativeBuildNumber?: string;
   readonly files: Readonly<Record<string, string>>;
   /** The plan's presented surface; absent in receipts written before the
    *  landscape viewport existed (those are the portrait Clear build). */
@@ -329,7 +332,9 @@ export function buildReceiptsMatch(left: BuildReceipt, right: BuildReceipt): boo
     left.bundleId !== right.bundleId ||
     left.target !== right.target ||
     left.hostAbi !== right.hostAbi ||
-    left.deploymentTarget !== right.deploymentTarget
+    left.deploymentTarget !== right.deploymentTarget ||
+    left.productVersion !== right.productVersion ||
+    left.nativeBuildNumber !== right.nativeBuildNumber
   ) return false;
   const leftFiles = Object.entries(left.files).sort(([a], [b]) => a.localeCompare(b));
   const rightFiles = Object.entries(right.files).sort(([a], [b]) => a.localeCompare(b));
@@ -359,20 +364,41 @@ function guestDirectory(): string {
   return join(REPOSITORY, `dist/ipodtouch4/${APP.id}/guest`);
 }
 
-/**
- * hosts/ipodtouch4/Info.plist is written for Pocket Clear; every other app
- * takes the same plist with its own identity substituted. For Clear the
- * substitution is the identity, so its bundle stays byte-identical.
- */
-function renderInfoPlist(): string {
-  const clear = IPODTOUCH4_APPS.clear;
-  const source = readFileSync(join(REPOSITORY, "hosts/ipodtouch4/Info.plist"), "utf8");
-  return source
-    .replaceAll(`<string>${clear.bundleId}.launch</string>`, `<string>${APP.bundleId}.launch</string>`)
-    .replaceAll(`<string>${clear.bundleId}</string>`, `<string>${APP.bundleId}</string>`)
-    .replaceAll(`<string>${clear.title}</string>`, `<string>${APP.title}</string>`)
-    .replaceAll(`<string>${clear.executable}</string>`, `<string>${APP.executable}</string>`)
-    .replaceAll(`<string>${clear.scheme}</string>`, `<string>${APP.scheme}</string>`);
+export interface IOSAppVersion {
+  readonly productVersion: string;
+  readonly buildNumber: string;
+}
+
+/** Legacy iOS uses a numeric product version and a separate manual build counter. */
+export function resolveIOSAppVersion(version: unknown, buildNumber = "1"): IOSAppVersion {
+  if (typeof version !== "string" || !/^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$/.test(version)) {
+    throw new Error("pocket ipodtouch4: manifest version must be MAJOR.MINOR.PATCH for this iOS target");
+  }
+  if (!/^[1-9][0-9]{0,8}$/.test(buildNumber)) {
+    throw new Error("pocket ipodtouch4: POCKETJS_IOS_BUILD_NUMBER must be a positive integer of at most nine digits");
+  }
+  return { productVersion: version, buildNumber };
+}
+
+export function renderIPodTouch4InfoPlist(source: string, app: IPodTouch4App, version: IOSAppVersion): string {
+  const template = IPODTOUCH4_APPS.clear;
+  const xml = (value: string) => value.replaceAll("&", "&amp;").replaceAll("<", "&lt;").replaceAll(">", "&gt;").replaceAll('"', "&quot;").replaceAll("'", "&apos;");
+  let result = source
+    .replaceAll(`<string>${template.bundleId}.launch</string>`, `<string>${xml(app.bundleId)}.launch</string>`)
+    .replaceAll(`<string>${template.bundleId}</string>`, `<string>${xml(app.bundleId)}</string>`)
+    .replaceAll(`<string>${template.title}</string>`, `<string>${xml(app.title)}</string>`)
+    .replaceAll(`<string>${template.executable}</string>`, `<string>${xml(app.executable)}</string>`)
+    .replaceAll(`<string>${template.scheme}</string>`, `<string>${xml(app.scheme)}</string>`);
+  for (const [key, value] of [["CFBundleShortVersionString", version.productVersion], ["CFBundleVersion", version.buildNumber]]) {
+    const pattern = new RegExp(`(<key>${key}</key>\\s*<string>)[^<]*(</string>)`, "g");
+    if ([...result.matchAll(pattern)].length !== 1) throw new Error(`pocket ipodtouch4: template must contain one ${key}`);
+    result = result.replace(pattern, (_match, prefix, suffix) => `${prefix}${value}${suffix}`);
+  }
+  return result;
+}
+
+function renderInfoPlist(version: IOSAppVersion): string {
+  return renderIPodTouch4InfoPlist(readFileSync(join(REPOSITORY, "hosts/ipodtouch4/Info.plist"), "utf8"), APP, version);
 }
 
 function bundleDirectory(): string {
@@ -610,6 +636,7 @@ async function build(): Promise<void> {
     throw new Error("pocket ipodtouch4: validated iOS 6.1.3 sysroot is absent; run `bun ipodtouch4 prepare-sysroot`");
   }
   const manifest = JSON.parse(readFileSync(manifestPath(), "utf8"));
+  const version = resolveIOSAppVersion(manifest.version, process.env.POCKETJS_IOS_BUILD_NUMBER ?? "1");
   const plan = resolveIPodTouch4BuildPlan(manifest);
   mkdirSync(dirname(planPath()), { recursive: true });
   writeFileSync(planPath(), JSON.stringify(plan, null, 2) + "\n");
@@ -686,7 +713,7 @@ async function build(): Promise<void> {
   const bundle = bundleDirectory();
   rmSync(bundle, { recursive: true, force: true });
   mkdirSync(bundle, { recursive: true });
-  writeFileSync(join(bundle, "Info.plist"), renderInfoPlist());
+  writeFileSync(join(bundle, "Info.plist"), renderInfoPlist(version));
   cpSync(join(REPOSITORY, "hosts/ipodtouch4/PkgInfo"), join(bundle, "PkgInfo"));
   await bakeClassicIPhoneArtwork(bundle, "User");
 
@@ -816,6 +843,8 @@ async function build(): Promise<void> {
     target: inputs.target,
     hostAbi: inputs.hostAbi,
     deploymentTarget: DEPLOYMENT_TARGET,
+    productVersion: version.productVersion,
+    nativeBuildNumber: version.buildNumber,
     files,
     viewport: {
       logical: [inputs.viewport.logical[0], inputs.viewport.logical[1]],
@@ -1104,7 +1133,7 @@ function usage(): void {
   bun ipodtouch4 doctor
   bun ipodtouch4 setup-sources
   bun ipodtouch4 prepare-sysroot
-  bun ipodtouch4 build
+  POCKETJS_IOS_BUILD_NUMBER=1 bun ipodtouch4 build
   bun ipodtouch4 deploy
   bun ipodtouch4 uninstall
   bun ipodtouch4 launch


### PR DESCRIPTION
The iPod touch 4 builder used the template's fixed `0.1.5` values even when an app manifest declared a different version. It now writes the manifest version to `CFBundleShortVersionString`, accepts a manual `POCKETJS_IOS_BUILD_NUMBER` counter for `CFBundleVersion`, and records both values in the build receipt. The rendered plist participates in the build ID, so a new counter produces a distinct build.

This makes manually published IPAs consistent with store metadata and applies to built-in and external application descriptors. Invalid native versions and malformed plist templates fail before packaging.

Validation: `bunx tsc --noEmit`; 17 passing tests across the iPod profile, installation and service-wire suites; a complete local ARMv7 IPA build with product version `0.1.0` and native build `1`. The IPA was imported and published through the local Pocket Store, then verified with Studio's production Rust catalog/cache reader online and offline, including its signature, native identity, artifact digest and icon. Physical device acceptance remains pending.
