### PR TITLE
refactor(3ds): acquire native sources without PSP dependencies

### DIFF
--- a/.github/workflows/3ds-runtime.yml
+++ b/.github/workflows/3ds-runtime.yml
@@ -1,10 +1,10 @@
 name: 3DS runtime contracts
 on:
   pull_request:
-    paths: ['hosts/3ds/**', 'contracts/**', 'tools/3ds*.ts', 'tests/3ds*.test.ts', 'tests/fixtures/3ds-*', 'tests/fixtures/3ds-*/**', '.github/workflows/3ds-runtime.yml']
+    paths: ['hosts/3ds/**', 'contracts/**', 'tools/3ds*.ts', 'tools/native-source.ts', 'tools/native-host-build.ts', 'tests/native-source.test.ts', 'tests/3ds*.test.ts', 'tests/fixtures/3ds-*', 'tests/fixtures/3ds-*/**', '.github/workflows/3ds-runtime.yml']
   push:
     branches: [main]
-    paths: ['hosts/3ds/**', 'contracts/**', 'tools/3ds*.ts', 'tests/3ds*.test.ts', 'tests/fixtures/3ds-*', 'tests/fixtures/3ds-*/**', '.github/workflows/3ds-runtime.yml']
+    paths: ['hosts/3ds/**', 'contracts/**', 'tools/3ds*.ts', 'tools/native-source.ts', 'tools/native-host-build.ts', 'tests/native-source.test.ts', 'tests/3ds*.test.ts', 'tests/fixtures/3ds-*', 'tests/fixtures/3ds-*/**', '.github/workflows/3ds-runtime.yml']
 permissions:
   contents: read
 jobs:
@@ -17,4 +17,4 @@ jobs:
         with:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile
-      - run: bun test tests/3ds-profile.test.ts tests/3ds-runtime-state.test.ts tests/3ds-runtime-wire.test.ts tests/3ds-soc.test.ts
+      - run: bun test tests/3ds-profile.test.ts tests/3ds-runtime-state.test.ts tests/3ds-runtime-wire.test.ts tests/3ds-soc.test.ts tests/native-source.test.ts tests/blackberry-classic.test.ts

--- a/hosts/3ds/README.md
+++ b/hosts/3ds/README.md
@@ -450,3 +450,16 @@ The New 3DS C-stick is exposed as the optional right analog lane. Applications
 read `rightAnalogX()` / `rightAnalogY()` from the framework lifecycle API, using
 the same normalized axes and deadzone as the left stick. Older hardware returns
 centered values. IRRST scanning stays in the host input adapter.
+
+## Native QuickJS sources
+
+`tools/3ds-toolchain.ts` prepares a verified QuickJS checkout through
+`tools/native-source.ts`, shared with the BlackBerry native hosts. The 3DS pin
+specifies a repository, full commit and source version. **Source preparation
+does not resolve the PSP Cargo dependency graph.** `ensureQuickJs` calls this
+preparation step before checking its compiler/source/image cache stamp.
+
+Standalone native hosts can import `ensureQuickJsSources` to prepare the C
+sources before a build. It has no guest compiler or package-manifest dependency.
+The default checkout is `~/.cache/pocketjs/sources/quickjs-<revision>`; an existing
+directory with a different revision, version or modified files is rejected.

--- a/tests/native-source.test.ts
+++ b/tests/native-source.test.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  ensureQuickJsCheckout, mustRunCommand, quickJsCheckout,
+  quickJsCheckoutStatus,
+} from "../tools/native-source.ts";
+
+test("native sources verify the pinned revision/version and preserve modified checkouts", () => {
+  const temp = mkdtempSync(join(tmpdir(), "native source "));
+  try {
+    const source = join(temp, "upstream");
+    const checkout = join(temp, "checkout with spaces");
+    const git = (args: string[]) => mustRunCommand("source fixture", "git", args, source);
+    mkdirSync(quickJsCheckout(source).source, { recursive: true });
+    writeFileSync(join(quickJsCheckout(source).source, "VERSION"), "fixture-version\n");
+    git(["init", "--quiet"]);
+    git(["add", "."]);
+    git(["-c", "user.name=Source Fixture", "-c", "user.email=fixture@example.invalid", "commit", "-qm", "fixture"]);
+    const pin = { repository: source, revision: git(["rev-parse", "HEAD"]), version: "fixture-version" };
+    ensureQuickJsCheckout("source fixture", checkout, pin);
+    expect(quickJsCheckoutStatus(checkout, pin).ok).toBe(true);
+    // A verified warm cache needs no usable remote or network.
+    ensureQuickJsCheckout("source fixture", checkout, { ...pin, repository: join(temp, "missing") });
+    expect(quickJsCheckoutStatus(checkout, { ...pin, revision: "0".repeat(40) }).ok).toBe(false);
+    expect(quickJsCheckoutStatus(checkout, { ...pin, version: "wrong" }).ok).toBe(false);
+    const file = join(quickJsCheckout(checkout).source, "VERSION");
+    writeFileSync(file, "local change\n");
+    expect(() => ensureQuickJsCheckout("source fixture", checkout, pin)).toThrow("refusing to replace");
+    expect(readFileSync(file, "utf8")).toBe("local change\n");
+  } finally {
+    rmSync(temp, { recursive: true, force: true });
+  }
+});

--- a/tests/npm-package.test.ts
+++ b/tests/npm-package.test.ts
@@ -187,6 +187,7 @@ describe("published npm artifacts", () => {
       "engine/pocket3d/crates/pocket3d-mesh/src/colored.rs",
       "engine/pocket3d/crates/pocket3d-mesh/src/rigid.rs",
       "tools/3ds-toolchain.ts",
+      "tools/native-source.ts",
       "assets/brand/pocketjs-avatar-white-minimal.png",
       "apps/hero/app.tsx",
       "apps/iphone2g-demo/pocket.json",

--- a/tools/3ds-toolchain.ts
+++ b/tools/3ds-toolchain.ts
@@ -7,11 +7,14 @@ import { join, resolve as resolvePath } from "node:path";
 const repository = fileURLToPath(new URL("..", import.meta.url));
 export const THREE_DS_CONTAINER_IMAGE =
   "devkitpro/devkitarm@sha256:116afba8df8453961de2936ffab20dd441edf4d682856c1ec8b0e53d7ed0bbf5";
-// The QuickJS revision hosts/psp/Cargo.toml pins, unpacked by cargo into the
-// git checkout cache. libquickjs-sys's build.rs is bypassed: it would need the
-// `cc` crate to find a 3DS-capable compiler on macOS, and there is none.
-const QUICKJS_CHECKOUT =
-  "git/checkouts/quickjs-rs-1bf011a924d415f9/ba5bdd0/libquickjs-sys/embed/quickjs";
+import { ensureQuickJsCheckout, quickJsCheckout, type QuickJsPin } from "./native-source.ts";
+
+// Pin native C sources without resolving another device's Rust dependencies.
+export const THREE_DS_QUICKJS_PIN: QuickJsPin = {
+  repository: "https://github.com/pocket-stack/quickjs-rs.git",
+  revision: "ba5bdd0dc013518768e76cd9e05cd30ed53dd35b",
+  version: "2026-06-04",
+};
 const QUICKJS_SOURCES = [
   "quickjs.c",
   "cutils.c",
@@ -138,14 +141,13 @@ export async function runContainer(
   }
 }
 
-function quickJsSourceDirectory(): string {
-  const pinned = join(process.env.CARGO_HOME ?? join(homedir(), ".cargo"), QUICKJS_CHECKOUT);
-  if (existsSync(join(pinned, "quickjs.c"))) return pinned;
-  throw new Error(
-    `PocketJS 3ds: the pinned QuickJS sources are absent at ${pinned}. ` +
-      "They arrive with the PSP host's dependencies — run `cargo fetch` in hosts/psp/ " +
-      "(or `bun run bootstrap`) and retry.",
-  );
+/** Prepare the same verified checkout mechanism used by other native hosts. */
+export function ensureQuickJsSources(
+  checkout = join(homedir(), ".cache", "pocketjs", "sources", `quickjs-${THREE_DS_QUICKJS_PIN.revision}`),
+): string {
+  const root = resolvePath(checkout);
+  ensureQuickJsCheckout("PocketJS 3ds", root, THREE_DS_QUICKJS_PIN);
+  return quickJsCheckout(root).source;
 }
 
 /**
@@ -158,7 +160,7 @@ export async function ensureQuickJs(
   imageId: string,
   mounts: readonly Mount[],
 ): Promise<void> {
-  const sources = quickJsSourceDirectory();
+  const sources = ensureQuickJsSources();
   const files = [...QUICKJS_SOURCES, ...QUICKJS_HEADERS];
   const digest = createHash("sha256");
   digest.update(imageId);
@@ -210,4 +212,3 @@ export async function ensureQuickJs(
   }
   writeFileSync(stampPath, `${stamp}\n`);
 }
-

--- a/tools/native-host-build.ts
+++ b/tools/native-host-build.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto";
+import { mustRunCommand } from "./native-source.ts";
 import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 import {
@@ -14,52 +15,11 @@ import type { ResolvedBuildPlan } from "../framework/src/manifest/plan.ts";
  * from that plan. Used by the BlackBerry Classic tools today.
  */
 
-export interface CommandResult {
-  readonly exitCode: number;
-  readonly stdout: string;
-  readonly stderr: string;
-}
-
-export function runCommand(
-  program: string,
-  args: readonly string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv = process.env,
-): CommandResult {
-  const result = Bun.spawnSync({
-    cmd: [program, ...args],
-    cwd,
-    env,
-    stdout: "pipe",
-    stderr: "pipe",
-  });
-  return {
-    exitCode: result.exitCode,
-    stdout: result.stdout.toString(),
-    stderr: result.stderr.toString(),
-  };
-}
-
-export function mustRunCommand(
-  label: string,
-  program: string,
-  args: readonly string[],
-  cwd: string,
-  env: NodeJS.ProcessEnv = process.env,
-): string {
-  const result = runCommand(program, args, cwd, env);
-  if (result.exitCode !== 0) {
-    const detail = [result.stdout.trim(), result.stderr.trim()]
-      .filter(Boolean)
-      .join("\n");
-    throw new Error(
-      `${label}: ${program} ${args.join(" ")} failed (${result.exitCode})${
-        detail ? `:\n${detail}` : ""
-      }`,
-    );
-  }
-  return result.stdout.trim();
-}
+export {
+  runCommand, mustRunCommand, quickJsCheckout, quickJsCheckoutStatus,
+  ensureQuickJsCheckout,
+  type CommandResult, type QuickJsPin, type QuickJsCheckout,
+} from "./native-source.ts";
 
 export function sha256File(path: string): string {
   return createHash("sha256").update(readFileSync(path)).digest("hex");
@@ -68,88 +28,6 @@ export function sha256File(path: string): string {
 export function printCheck(label: string, ok: boolean, detail: string): boolean {
   console.log(`${ok ? "[ok]" : "[missing]"} ${label}: ${detail}`);
   return ok;
-}
-
-export interface QuickJsPin {
-  readonly version: string;
-  readonly repository: string;
-  readonly revision: string;
-}
-
-export interface QuickJsCheckout {
-  readonly root: string;
-  /** `libquickjs-sys/embed/quickjs` — the C sources both hosts compile. */
-  readonly source: string;
-  readonly staticFunctions: string;
-}
-
-export function quickJsCheckout(root: string): QuickJsCheckout {
-  return {
-    root,
-    source: join(root, "libquickjs-sys/embed/quickjs"),
-    staticFunctions: join(root, "libquickjs-sys/embed/static-functions.c"),
-  };
-}
-
-/** The checkout is usable only at the pinned revision with a clean tree. */
-export function quickJsCheckoutStatus(
-  root: string,
-  pin: QuickJsPin,
-): { ok: boolean; detail: string } {
-  if (!existsSync(join(root, ".git"))) {
-    return { ok: false, detail: root };
-  }
-  const revision = runCommand("git", ["-C", root, "rev-parse", "HEAD"], root);
-  const changes = runCommand(
-    "git",
-    ["-C", root, "status", "--porcelain=v1", "--untracked-files=all"],
-    root,
-  );
-  const versionPath = join(quickJsCheckout(root).source, "VERSION");
-  const version = existsSync(versionPath)
-    ? readFileSync(versionPath, "utf8").trim()
-    : "";
-  const ok =
-    revision.exitCode === 0 &&
-    revision.stdout.trim() === pin.revision &&
-    changes.exitCode === 0 &&
-    changes.stdout.trim() === "" &&
-    version === pin.version;
-  return {
-    ok,
-    detail: `${root} (${revision.stdout.trim() || "missing"}, ${version || "no VERSION"})`,
-  };
-}
-
-export function ensureQuickJsCheckout(
-  label: string,
-  root: string,
-  pin: QuickJsPin,
-): void {
-  const status = quickJsCheckoutStatus(root, pin);
-  if (status.ok) return;
-  if (existsSync(root)) {
-    throw new Error(
-      `${label}: refusing to replace an unverified QuickJS directory: ${status.detail}`,
-    );
-  }
-  mkdirSync(dirname(root), { recursive: true });
-  mustRunCommand(
-    label,
-    "git",
-    ["clone", "--filter=blob:none", "--no-checkout", pin.repository, root],
-    dirname(root),
-  );
-  mustRunCommand(
-    label,
-    "git",
-    ["-C", root, "checkout", "--detach", pin.revision],
-    root,
-  );
-  const verified = quickJsCheckoutStatus(root, pin);
-  if (!verified.ok) {
-    throw new Error(`${label}: QuickJS verification failed: ${verified.detail}`);
-  }
 }
 
 export interface GuestBundle {

--- a/tools/native-source.ts
+++ b/tools/native-source.ts
@@ -1,0 +1,133 @@
+// Native source acquisition has no guest compiler or manifest dependency.
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+export interface CommandResult {
+  readonly exitCode: number;
+  readonly stdout: string;
+  readonly stderr: string;
+}
+
+export function runCommand(
+  program: string,
+  args: readonly string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): CommandResult {
+  const result = Bun.spawnSync({
+    cmd: [program, ...args],
+    cwd,
+    env,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  return {
+    exitCode: result.exitCode,
+    stdout: result.stdout.toString(),
+    stderr: result.stderr.toString(),
+  };
+}
+
+export function mustRunCommand(
+  label: string,
+  program: string,
+  args: readonly string[],
+  cwd: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const result = runCommand(program, args, cwd, env);
+  if (result.exitCode !== 0) {
+    const detail = [result.stdout.trim(), result.stderr.trim()]
+      .filter(Boolean)
+      .join("\n");
+    throw new Error(
+      `${label}: ${program} ${args.join(" ")} failed (${result.exitCode})${
+        detail ? `:\n${detail}` : ""
+      }`,
+    );
+  }
+  return result.stdout.trim();
+}
+
+export interface QuickJsPin {
+  readonly version: string;
+  readonly repository: string;
+  readonly revision: string;
+}
+
+export interface QuickJsCheckout {
+  readonly root: string;
+  /** `libquickjs-sys/embed/quickjs` — the C sources both hosts compile. */
+  readonly source: string;
+  readonly staticFunctions: string;
+}
+
+export function quickJsCheckout(root: string): QuickJsCheckout {
+  return {
+    root,
+    source: join(root, "libquickjs-sys/embed/quickjs"),
+    staticFunctions: join(root, "libquickjs-sys/embed/static-functions.c"),
+  };
+}
+
+/** The checkout is usable only at the pinned revision with a clean tree. */
+export function quickJsCheckoutStatus(
+  root: string,
+  pin: QuickJsPin,
+): { ok: boolean; detail: string } {
+  if (!existsSync(join(root, ".git"))) {
+    return { ok: false, detail: root };
+  }
+  const revision = runCommand("git", ["-C", root, "rev-parse", "HEAD"], root);
+  const changes = runCommand(
+    "git",
+    ["-C", root, "status", "--porcelain=v1", "--untracked-files=all"],
+    root,
+  );
+  const versionPath = join(quickJsCheckout(root).source, "VERSION");
+  const version = existsSync(versionPath)
+    ? readFileSync(versionPath, "utf8").trim()
+    : "";
+  const ok =
+    revision.exitCode === 0 &&
+    revision.stdout.trim() === pin.revision &&
+    changes.exitCode === 0 &&
+    changes.stdout.trim() === "" &&
+    version === pin.version;
+  return {
+    ok,
+    detail: `${root} (${revision.stdout.trim() || "missing"}, ${version || "no VERSION"})`,
+  };
+}
+
+export function ensureQuickJsCheckout(
+  label: string,
+  root: string,
+  pin: QuickJsPin,
+): void {
+  const status = quickJsCheckoutStatus(root, pin);
+  if (status.ok) return;
+  if (existsSync(root)) {
+    throw new Error(
+      `${label}: refusing to replace an unverified QuickJS directory: ${status.detail}`,
+    );
+  }
+  mkdirSync(dirname(root), { recursive: true });
+  mustRunCommand(
+    label,
+    "git",
+    ["clone", "--filter=blob:none", "--no-checkout", pin.repository, root],
+    dirname(root),
+  );
+  mustRunCommand(
+    label,
+    "git",
+    ["-C", root, "checkout", "--detach", pin.revision],
+    root,
+  );
+  const verified = quickJsCheckoutStatus(root, pin);
+  if (!verified.ok) {
+    throw new Error(`${label}: QuickJS verification failed: ${verified.detail}`);
+  }
+}
+


### PR DESCRIPTION
Standalone 3DS setup used the PSP Cargo manifest to obtain QuickJS C sources. On a clean CI runner this also fetched rust-psp's Rust and LLVM submodules; the previous Island main run spent 10m46s in dependency preparation.

Move the existing verified checkout/process helpers from `native-host-build.ts` to dependency-free `native-source.ts`, retaining the existing exports for native guest hosts. The 3DS toolchain now acquires a full-commit/version-pinned QuickJS checkout through that same mechanism. It no longer needs Cargo's PSP checkout cache or guest compiler/manifest imports. `ensureQuickJsSources` is available to standalone setup tools; archive compilation still verifies its source/flags/container stamp.

Validation: 48 native source, BlackBerry, 3DS transport/profile and npm package tests pass. A local Git fixture checks cold acquisition, offline warm reuse, wrong revision/version, paths with spaces and preservation of modified directories. A real empty-cache checkout of the pinned source completed in 2.458s. A fresh devkitARM compilation produced the same 1,307,942-byte `libquickjs.a` as the previous Cargo-backed build, SHA-256 `fa1426d87a9c97ddd8f759845355985bd7b2726970c93cb74e26a90b7b1b4a85`.
