### PR TITLE
feat(pocket3d): host themed PocketJS control overlays

### DIFF
--- a/.github/workflows/pocket-ui-overlay.yml
+++ b/.github/workflows/pocket-ui-overlay.yml
@@ -1,0 +1,45 @@
+name: PocketJS UI overlay
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/pocket-ui-overlay.yml'
+      - 'framework/src/desktop-pointer.ts'
+      - 'framework/src/overlay-host.ts'
+      - 'framework/src/themes/**'
+      - 'framework/compiler/subpaths.ts'
+      - 'tests/desktop-pointer.test.ts'
+      - 'engine/crates/pocket-ui-wgpu/**'
+      - 'engine/crates/pocket-ui-surface/**'
+      - 'engine/pocket3d/crates/pocket3d/src/app.rs'
+      - 'engine/pocket3d/crates/pocket3d/src/input.rs'
+      - 'engine/Cargo.toml'
+      - 'engine/Cargo.lock'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+concurrency:
+  group: pocket-ui-overlay-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contracts:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - run: bun test tests/desktop-pointer.test.ts
+      - uses: dtolnay/rust-toolchain@1.97.0
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine
+      - run: cargo fmt --manifest-path engine/Cargo.toml -p pocket3d -p pocket-ui-wgpu -- --check
+      - run: cargo test --locked --manifest-path engine/Cargo.toml -p pocket3d -p pocket-ui-wgpu --lib
+      - run: cargo clippy --locked --manifest-path engine/Cargo.toml -p pocket3d -p pocket-ui-wgpu --all-targets -- -D warnings

--- a/docs/POCKET3D-UI-OVERLAY.md
+++ b/docs/POCKET3D-UI-OVERLAY.md
@@ -1,0 +1,51 @@
+# PocketJS UI over Pocket3D
+
+`pocket-ui-wgpu::UiOverlay` mounts a compiled PocketJS JS/pak pair in a QuickJS
+guest and draws it over the scene through `Game::overlay`. The UI uses the
+existing native core, layout, font atlases, hit testing, focus and `onPress`.
+Game rules stay with the application.
+
+**The application declares cursor ownership.** `Game::cursor_mode` returns
+`Visible` while a control window is open and `Captured` for mouse look.
+`Legacy` preserves `AppConfig` and the Escape/click behavior of existing games.
+A change clears held keys, buttons and mouse deltas before fixed ticks consume
+input. Visible UI clicks cannot recapture the cursor. Focus loss releases capture
+and sends cancellation; returning focus does not invent a press.
+
+`Game::resized` receives physical pixels and OS scale before input at the new
+viewport. Pass them to `UiOverlay::resize`; layout uses logical pixels and both
+pointer coordinates and draw output use the same scale. Raster density belongs
+to the pak and can differ from the current display scale.
+
+**Pointer edges retain their order within a rendered frame.** `Input` records
+movement, button edges and cancellation. `UiOverlay::frame` forwards them over
+the in-process `pocket.overlay` service alongside application JSON state. The
+host declares that exact service before mounting the guest; other services stay
+denied. Each frame returns the JSON commands sent by the UI.
+
+The UI connects with `connectOverlay<State, Command>` from
+`@pocketjs/framework/overlay-host`. Its receiver updates application signals;
+`send(command)` queues an intent for the native game. `control(name, node)`
+registers a semantic diagnostic name and returns a disposer. `drag(node, move)`
+captures a caption or another drag region, reports its start and deltas, and
+returns a disposer. Focusable children own their click before ancestor drags.
+A release activates only the original, still-hit control. Cancellation,
+removal, release outside, and a drag ending over a button cannot activate it.
+
+`UiOverlay::control_bounds` asks the native core for the named control's painted
+screen bounds. Acceptance drivers use those bounds to inject cursor/button
+edges into the same input path as a native window. The query uses the core's
+inspection pass and clears its highlight afterward; it is a cold diagnostic
+operation, not a second hit-test layout.
+
+The `XP_THEME` export from `@pocketjs/framework/themes/desktop` supplies complete
+class literals for windows, captions, close controls, tabs, buttons, disabled
+states, group boxes, wells, status strips, progress bars and checks. Product code
+names semantic parts and supplies behavior. The theme uses authored geometric
+chrome and the bundled fonts, with no dependency on desktop-shell assets.
+
+Applications can embed the built JS/pak so launching the game requires no JS
+build tools. Keep source and artifact hashes beside those files and verify them
+when publishing a new build. A pointer-capable game should block its movement
+and action handlers while the overlay owns input; simulation can continue so
+users can observe reactions behind the controls.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1823,10 +1823,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "bytemuck",
+ "pocket-mod",
  "pocket-ui-surface",
  "pocket3d",
  "pocketjs-core",
+ "serde_json",
  "wgpu",
+ "winit",
 ]
 
 [[package]]

--- a/engine/crates/pocket-ui-wgpu/Cargo.toml
+++ b/engine/crates/pocket-ui-wgpu/Cargo.toml
@@ -8,8 +8,11 @@ description = "The PocketJS `ui` surface on the native desktop base: pak feeding
 
 [dependencies]
 pocket3d = { workspace = true }
+pocket-mod = { workspace = true }
+serde_json = { workspace = true }
 pocket-ui-surface = { workspace = true }
 pocketjs-core = { workspace = true }
 wgpu = { workspace = true }
+winit = { workspace = true }
 bytemuck = { workspace = true }
 anyhow = { workspace = true }

--- a/engine/crates/pocket-ui-wgpu/src/lib.rs
+++ b/engine/crates/pocket-ui-wgpu/src/lib.rs
@@ -14,9 +14,11 @@
 //! 2D and 3D share one base: the same `pocket3d::Gpu` device drives both.
 
 mod blit;
+mod overlay;
 mod render;
 
 pub use blit::Blit;
+pub use overlay::UiOverlay;
 pub use render::UiRenderer;
 // The backend-agnostic surface (UiSurface + pak walk) — re-exported so desktop
 // consumers (uihost, OpenStrike) stay source-compatible after the split.

--- a/engine/crates/pocket-ui-wgpu/src/overlay.rs
+++ b/engine/crates/pocket-ui-wgpu/src/overlay.rs
@@ -1,0 +1,237 @@
+//! A PocketJS guest over a Pocket3D frame. Applications provide JSON state
+//! and consume JSON commands; the adapter owns viewport and pointer transport.
+
+use crate::{UiRenderer, UiSurface};
+use anyhow::{Context, Result, anyhow};
+use pocket_mod::{Guest, qjs::Function};
+use pocket3d::{
+    gpu::Gpu,
+    input::{Input, PointerEvent},
+};
+use serde_json::{Value, json};
+use std::collections::BTreeMap;
+use winit::event::MouseButton;
+
+pub struct UiOverlay {
+    controls: BTreeMap<String, i32>,
+    guest: Guest,
+    surface: UiSurface,
+    renderer: Option<(wgpu::TextureFormat, UiRenderer)>,
+    size: (u32, u32),
+    scale: f32,
+}
+
+impl UiOverlay {
+    pub fn new(
+        bundle: &str,
+        pak: &[u8],
+        size: (u32, u32),
+        scale: f32,
+        density: u32,
+    ) -> Result<Self> {
+        let scale = valid_scale(scale);
+        let surface =
+            UiSurface::new_with_density((size.0 as f32 / scale, size.1 as f32 / scale), density);
+        surface.set_svc_allowlist(["pocket.overlay"]);
+        surface.feed_pak(pak);
+        let guest = Guest::new()?;
+        surface.mount(&guest)?;
+        guest.eval("overlay", bundle)?;
+        anyhow::ensure!(
+            guest.has_frame(),
+            "PocketJS overlay bundle installed no frame handler"
+        );
+        surface.tick();
+        Ok(Self {
+            controls: BTreeMap::new(),
+            guest,
+            surface,
+            renderer: None,
+            size,
+            scale,
+        })
+    }
+
+    /// Resize layout and input together. Pak raster density is independent of
+    /// the OS scale, so a density-2 bundle also works at 1x and fractional DPI.
+    pub fn resize(&mut self, size: (u32, u32), scale: f32) -> Result<()> {
+        let size = (size.0.max(1), size.1.max(1));
+        let scale = valid_scale(scale);
+        if self.size == size && self.scale == scale {
+            return Ok(());
+        }
+        self.cancel_pointer();
+        self.size = size;
+        self.scale = scale;
+        let (width, height) = (size.0 as f32 / scale, size.1 as f32 / scale);
+        self.surface.with_ui(|ui| ui.set_viewport(width, height));
+        self.guest.with(|ctx| -> Result<()> {
+            let hook: Option<Function> = ctx.globals().get("__pocketResizeViewport")?;
+            if let Some(hook) = hook {
+                hook.call::<_, ()>((width, height))
+                    .map_err(|e| anyhow!("overlay resize: {e}"))?;
+            }
+            Ok(())
+        })?;
+        self.surface.tick();
+        Ok(())
+    }
+
+    pub fn logical_size(&self) -> (f32, f32) {
+        (
+            self.size.0 as f32 / self.scale,
+            self.size.1 as f32 / self.scale,
+        )
+    }
+
+    pub fn cancel_pointer(&self) {
+        self.surface
+            .svc_push(json!({"type":"pointer", "event":{"kind":"cancel"}}).to_string());
+    }
+
+    /// Consume each rendered frame once. Ordered edges retain a press and
+    /// release that both arrived between two frames. A closed overlay should
+    /// be cancelled and receive no further game input.
+    pub fn frame(&mut self, input: &Input, state: &Value) -> Result<Vec<Value>> {
+        self.surface
+            .svc_push(json!({"type":"state", "value":state}).to_string());
+        for event in input.pointer_events() {
+            if let Some(event) = pointer_packet(*event, self.scale) {
+                self.surface
+                    .svc_push(json!({"type":"pointer", "event":event}).to_string());
+            }
+        }
+        self.guest.frame(0)?;
+        self.surface.tick();
+        let mut commands = Vec::new();
+        for line in self.surface.svc_drain() {
+            let value: Value =
+                serde_json::from_str(&line).context("invalid PocketJS overlay command")?;
+            if value["type"] == "pocket.overlay.control" {
+                if let (Some(name), Some(node)) = (value["name"].as_str(), value["node"].as_i64()) {
+                    if value["remove"] == true {
+                        if self.controls.get(name) == Some(&(node as i32)) {
+                            self.controls.remove(name);
+                        }
+                    } else {
+                        self.controls.insert(name.to_owned(), node as i32);
+                    }
+                }
+            } else {
+                commands.push(value);
+            }
+        }
+        Ok(commands)
+    }
+
+    /// Screen-space bounds from the core's painted geometry. This cold
+    /// diagnostic query supports coordinate-driven acceptance and inspectors.
+    /// It returns None for controls that are no longer painted.
+    pub fn control_bounds(&self, name: &str) -> Option<(f32, f32, f32, f32)> {
+        let &node = self.controls.get(name)?;
+        self.surface.with_ui(|ui| {
+            ui.debug_inspect(node);
+            ui.draw();
+            let xy = ui.debug_rect_xy();
+            let wh = ui.debug_rect_wh();
+            ui.debug_inspect(0);
+            if wh == -1 {
+                return None;
+            }
+            Some((
+                (xy as i16) as f32 * self.scale,
+                ((xy >> 16) as i16) as f32 * self.scale,
+                (wh & 0xffff) as f32 * self.scale,
+                ((wh >> 16) & 0xffff) as f32 * self.scale,
+            ))
+        })
+    }
+
+    pub fn render(
+        &mut self,
+        gpu: &Gpu,
+        encoder: &mut wgpu::CommandEncoder,
+        view: &wgpu::TextureView,
+        format: wgpu::TextureFormat,
+    ) -> Result<()> {
+        if self.renderer.as_ref().is_none_or(|(old, _)| *old != format) {
+            self.renderer = Some((format, UiRenderer::new(gpu, format)));
+        }
+        let (_, renderer) = self.renderer.as_mut().unwrap();
+        self.surface.with_ui(|ui| {
+            let words = ui.draw().words.clone();
+            renderer.render_words_scaled(
+                gpu,
+                ui,
+                &words,
+                encoder,
+                view,
+                self.size,
+                self.scale,
+                wgpu::LoadOp::Load,
+            )
+        })
+    }
+}
+
+fn valid_scale(scale: f32) -> f32 {
+    if scale.is_finite() && scale > 0.0 {
+        scale
+    } else {
+        1.0
+    }
+}
+
+fn pointer_packet(event: PointerEvent, scale: f32) -> Option<Value> {
+    let (position, kind, down) = match event {
+        PointerEvent::Move(pos) => (pos, "move", None),
+        PointerEvent::Button {
+            position,
+            button: MouseButton::Left,
+            down,
+        } => (position, "button", Some(down)),
+        PointerEvent::Button { .. } => return None,
+        PointerEvent::Cancel => return Some(json!({"kind":"cancel"})),
+    };
+    let mut packet =
+        json!({"kind":kind, "x":position.map(|p| p.x / scale), "y":position.map(|p| p.y / scale)});
+    if let Some(down) = down {
+        packet["down"] = json!(down);
+    }
+    Some(packet)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use pocket3d::input::Input;
+
+    #[test]
+    fn ordered_clicks_and_cancellation_reach_the_guest_at_both_scales() {
+        let bundle = r#"
+            ui.svcOpen("pocket.overlay");
+            globalThis.frame = function() {
+                const batch = ui.svcPoll();
+                if (batch) for (const line of batch.split("\n")) if (line) ui.svcSend(line);
+            };
+        "#;
+        for scale in [1.0, 2.0] {
+            let mut overlay = UiOverlay::new(bundle, &[], (960, 600), scale, 2).unwrap();
+            let mut input = Input::default();
+            input.inject_cursor(200.0, 100.0);
+            input.inject_mouse_button(MouseButton::Left, true);
+            input.inject_mouse_button(MouseButton::Left, false);
+            let received = overlay.frame(&input, &json!({"count":1})).unwrap();
+            assert_eq!(received.len(), 4);
+            assert_eq!(received[1]["event"]["x"], json!(200.0 / scale));
+            assert_eq!(received[2]["event"]["down"], true);
+            assert_eq!(received[3]["event"]["down"], false);
+            input.end_frame();
+            input.clear();
+            let received = overlay.frame(&input, &Value::Null).unwrap();
+            assert_eq!(received[1]["event"]["kind"], "cancel");
+            overlay.resize((1200, 800), scale).unwrap();
+            assert_eq!(overlay.logical_size(), (1200.0 / scale, 800.0 / scale));
+        }
+    }
+}

--- a/engine/crates/pocket-ui-wgpu/src/render.rs
+++ b/engine/crates/pocket-ui-wgpu/src/render.rs
@@ -404,9 +404,8 @@ impl UiRenderer {
                 ((w >> 16) as u16 as i16) as f32 * s,
             )
         };
-        let wh = |w: u32| -> (f32, f32) {
-            ((w & 0xffff) as f32 * s, ((w >> 16) & 0xffff) as f32 * s)
-        };
+        let wh =
+            |w: u32| -> (f32, f32) { ((w & 0xffff) as f32 * s, ((w >> 16) & 0xffff) as f32 * s) };
 
         let quad = |verts: &mut Vec<UiVertex>,
                     p0: [f32; 2],
@@ -731,7 +730,11 @@ impl UiRenderer {
         // Wider grids for big (CJK-extended) atlases keep the texture under
         // dimension limits: 16 cols x 3500 density-2 cells would be ~8000 px
         // tall; 64 cols stays square-ish.
-        let max_cols = if atlas.glyph_count > 512 { 64u32 } else { 16u32 };
+        let max_cols = if atlas.glyph_count > 512 {
+            64u32
+        } else {
+            16u32
+        };
         let cols = max_cols.min(atlas.glyph_count.max(1) as u32);
         let rows = (atlas.glyph_count as u32).div_ceil(cols).max(1);
         let tex_w = cols * cov_w;
@@ -804,7 +807,14 @@ impl UiRenderer {
         }
     }
 
-    fn upload_image(&self, gpu: &Gpu, rgba: &[u8], w: u32, h: u32, linear: bool) -> wgpu::BindGroup {
+    fn upload_image(
+        &self,
+        gpu: &Gpu,
+        rgba: &[u8],
+        w: u32,
+        h: u32,
+        linear: bool,
+    ) -> wgpu::BindGroup {
         let tex = gpu.device.create_texture(&wgpu::TextureDescriptor {
             label: Some("pocket-ui image"),
             size: wgpu::Extent3d {
@@ -852,29 +862,6 @@ impl UiRenderer {
                 },
             ],
         })
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{image_cache_hit, ImageVersion};
-
-    #[test]
-    fn image_cache_decision_reuploads_in_place_content_revision() {
-        let cached = ImageVersion { handle: 7, revision: 4 };
-        assert!(image_cache_hit(
-            Some(cached),
-            ImageVersion { handle: 7, revision: 4 },
-        ));
-        assert!(!image_cache_hit(
-            Some(cached),
-            ImageVersion { handle: 7, revision: 5 },
-        ));
-        assert!(!image_cache_hit(
-            Some(cached),
-            ImageVersion { handle: 8, revision: 4 },
-        ));
-        assert!(!image_cache_hit(None, cached));
     }
 }
 
@@ -934,5 +921,40 @@ fn to_rgba8(view: &TexView) -> Option<Vec<u8>> {
             Some(out)
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{ImageVersion, image_cache_hit};
+
+    #[test]
+    fn image_cache_decision_reuploads_in_place_content_revision() {
+        let cached = ImageVersion {
+            handle: 7,
+            revision: 4,
+        };
+        assert!(image_cache_hit(
+            Some(cached),
+            ImageVersion {
+                handle: 7,
+                revision: 4
+            },
+        ));
+        assert!(!image_cache_hit(
+            Some(cached),
+            ImageVersion {
+                handle: 7,
+                revision: 5
+            },
+        ));
+        assert!(!image_cache_hit(
+            Some(cached),
+            ImageVersion {
+                handle: 8,
+                revision: 4
+            },
+        ));
+        assert!(!image_cache_hit(None, cached));
     }
 }

--- a/engine/pocket3d/crates/pocket3d/src/app.rs
+++ b/engine/pocket3d/crates/pocket3d/src/app.rs
@@ -62,6 +62,18 @@ impl Default for AppConfig {
     }
 }
 
+/// Cursor ownership requested by a game or an overlay.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub enum CursorMode {
+    /// Use AppConfig's capture setting and the legacy Escape/click behavior.
+    #[default]
+    Legacy,
+    /// The game owns mouse look; mode changes discard held input.
+    Captured,
+    /// A UI owns the visible pointer. Clicking never recaptures the mouse.
+    Visible,
+}
+
 /// What the app loop needs from a game.
 pub trait Game {
     /// Called once after the GPU exists — load assets here.
@@ -70,6 +82,12 @@ pub trait Game {
     fn frame(&mut self, dt: f32, input: &Input);
     /// Fixed-step simulation.
     fn tick(&mut self, dt: f32, input: &Input);
+    /// Input ownership requested by the application, applied after frame/tick.
+    fn cursor_mode(&self) -> CursorMode {
+        CursorMode::Legacy
+    }
+    /// Physical viewport and OS scale, delivered before input in the new size.
+    fn resized(&mut self, _size: (u32, u32), _scale_factor: f64) {}
     /// Provide the frame to draw. `time` is seconds since launch.
     fn compose(&mut self, alpha: f32, time: f32, size: (u32, u32)) -> (&Scene, &Camera, &Hud);
     /// Record extra passes over the finished frame (UI overlays, composite
@@ -117,6 +135,8 @@ struct WindowState {
     start: Instant,
     last_frame: Instant,
     mouse_captured: bool,
+    cursor_mode: CursorMode,
+    focused: bool,
 }
 
 struct WinitApp<G: Game> {
@@ -159,6 +179,8 @@ impl<G: Game> WinitApp<G> {
 
         let mut renderer = Renderer::new(&gpu, surface_config.format)?;
         self.game.init(&gpu, &mut renderer)?;
+        self.game
+            .resized((px.width, px.height), window.scale_factor());
 
         let mut state = WindowState {
             window,
@@ -171,8 +193,10 @@ impl<G: Game> WinitApp<G> {
             start: Instant::now(),
             last_frame: Instant::now(),
             mouse_captured: false,
+            cursor_mode: self.game.cursor_mode(),
+            focused: true,
         };
-        if self.config.capture_mouse {
+        if wants_capture(state.cursor_mode, self.config.capture_mouse) {
             set_mouse_capture(&mut state, true);
         }
         Ok(state)
@@ -188,9 +212,11 @@ impl<G: Game> WinitApp<G> {
         state.last_frame = now;
 
         self.game.frame(dt, &state.input);
+        sync_cursor_mode(state, self.game.cursor_mode(), self.config.capture_mouse);
         let ticks = state.timestep.advance(dt);
         for _ in 0..ticks {
             self.game.tick(state.timestep.step, &state.input);
+            sync_cursor_mode(state, self.game.cursor_mode(), self.config.capture_mouse);
         }
         state.input.end_frame();
 
@@ -286,6 +312,23 @@ fn set_mouse_capture(state: &mut WindowState, captured: bool) {
     }
 }
 
+fn wants_capture(mode: CursorMode, legacy: bool) -> bool {
+    match mode {
+        CursorMode::Legacy => legacy,
+        CursorMode::Captured => true,
+        CursorMode::Visible => false,
+    }
+}
+
+fn sync_cursor_mode(state: &mut WindowState, mode: CursorMode, legacy: bool) {
+    if state.cursor_mode == mode {
+        return;
+    }
+    state.cursor_mode = mode;
+    state.input.clear();
+    set_mouse_capture(state, state.focused && wants_capture(mode, legacy));
+}
+
 impl<G: Game> ApplicationHandler for WinitApp<G> {
     fn resumed(&mut self, event_loop: &ActiveEventLoop) {
         if self.state.is_none() {
@@ -317,9 +360,21 @@ impl<G: Game> ApplicationHandler for WinitApp<G> {
                 state
                     .surface
                     .configure(&state.gpu.device, &state.surface_config);
+                self.game.resized(
+                    (size.width.max(1), size.height.max(1)),
+                    state.window.scale_factor(),
+                );
+            }
+            WindowEvent::ScaleFactorChanged { scale_factor, .. } => {
+                let size = state.window.inner_size();
+                self.game
+                    .resized((size.width.max(1), size.height.max(1)), scale_factor);
             }
             WindowEvent::KeyboardInput { .. } => {
-                if self.config.capture_mouse && state.input.key_pressed(KeyCode::Escape) {
+                if state.cursor_mode == CursorMode::Legacy
+                    && self.config.capture_mouse
+                    && state.input.key_pressed(KeyCode::Escape)
+                {
                     let captured = !state.mouse_captured;
                     set_mouse_capture(state, captured);
                 }
@@ -330,8 +385,15 @@ impl<G: Game> ApplicationHandler for WinitApp<G> {
                 ..
             } => {
                 // Clicking back into the window recaptures the mouse.
-                if self.config.capture_mouse && !state.mouse_captured {
+                if state.focused
+                    && wants_capture(state.cursor_mode, self.config.capture_mouse)
+                    && !state.mouse_captured
+                    && elem_state.is_pressed()
+                {
                     set_mouse_capture(state, true);
+                    if state.cursor_mode != CursorMode::Legacy {
+                        state.input.clear();
+                    }
                 }
                 if self.config.drag_window
                     && button == winit::event::MouseButton::Left
@@ -340,7 +402,12 @@ impl<G: Game> ApplicationHandler for WinitApp<G> {
                     let _ = state.window.drag_window();
                 }
             }
-            WindowEvent::Focused(false) => set_mouse_capture(state, false),
+            WindowEvent::Focused(focused) => {
+                state.focused = focused;
+                if !focused {
+                    set_mouse_capture(state, false);
+                }
+            }
             WindowEvent::RedrawRequested => self.redraw(event_loop),
             _ => {}
         }
@@ -373,6 +440,19 @@ impl<G: Game> ApplicationHandler for WinitApp<G> {
             state.window.request_redraw();
         } else {
             event_loop.set_control_flow(ControlFlow::WaitUntil(due));
+        }
+    }
+}
+
+#[cfg(test)]
+mod cursor_tests {
+    use super::*;
+    #[test]
+    fn explicit_pointer_ownership_overrides_legacy_capture_settings() {
+        for legacy in [true, false] {
+            assert!(!wants_capture(CursorMode::Visible, legacy));
+            assert!(wants_capture(CursorMode::Captured, legacy));
+            assert_eq!(wants_capture(CursorMode::Legacy, legacy), legacy);
         }
     }
 }

--- a/engine/pocket3d/crates/pocket3d/src/input.rs
+++ b/engine/pocket3d/crates/pocket3d/src/input.rs
@@ -47,8 +47,22 @@ pub enum EditKey {
     Escape,
 }
 
+/// Ordered pointer events in physical window pixels. Keep edges even when a
+/// complete click arrives between rendered frames.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum PointerEvent {
+    Move(Option<Vec2>),
+    Button {
+        position: Option<Vec2>,
+        button: MouseButton,
+        down: bool,
+    },
+    Cancel,
+}
+
 #[derive(Default)]
 pub struct Input {
+    pointer_events: Vec<PointerEvent>,
     down: HashSet<KeyCode>,
     pressed: HashSet<KeyCode>,
     mouse_down: HashSet<u8>,
@@ -151,6 +165,11 @@ impl Input {
                 }
             }
             WindowEvent::MouseInput { state, button, .. } => {
+                self.pointer_events.push(PointerEvent::Button {
+                    position: self.cursor,
+                    button: *button,
+                    down: state.is_pressed(),
+                });
                 let id = button_id(*button);
                 match state {
                     ElementState::Pressed => {
@@ -165,8 +184,12 @@ impl Input {
             }
             WindowEvent::CursorMoved { position, .. } => {
                 self.cursor = Some(Vec2::new(position.x as f32, position.y as f32));
+                self.pointer_events.push(PointerEvent::Move(self.cursor));
             }
-            WindowEvent::CursorLeft { .. } => self.cursor = None,
+            WindowEvent::CursorLeft { .. } => {
+                self.cursor = None;
+                self.pointer_events.push(PointerEvent::Move(None));
+            }
             WindowEvent::Focused(false) => self.clear(),
             _ => {}
         }
@@ -185,6 +208,8 @@ impl Input {
 
     /// Forget everything held (focus loss, mode switches).
     pub fn clear(&mut self) {
+        self.pointer_events.clear();
+        self.pointer_events.push(PointerEvent::Cancel);
         self.down.clear();
         self.pressed.clear();
         self.mouse_down.clear();
@@ -201,6 +226,7 @@ impl Input {
 
     /// Call once per simulation turn, after game logic consumed edge state.
     pub fn end_frame(&mut self) {
+        self.pointer_events.clear();
         self.pressed.clear();
         self.mouse_pressed.clear();
         self.mouse_delta = Vec2::ZERO;
@@ -269,6 +295,10 @@ impl Input {
     pub fn mouse_delta(&self) -> Vec2 {
         self.mouse_delta
     }
+
+    pub fn pointer_events(&self) -> &[PointerEvent] {
+        &self.pointer_events
+    }
     // --- synthetic injection (headless scripting/tests) -------------------
 
     pub fn inject_key(&mut self, code: KeyCode, down: bool) {
@@ -282,6 +312,11 @@ impl Input {
     }
 
     pub fn inject_mouse_button(&mut self, button: MouseButton, down: bool) {
+        self.pointer_events.push(PointerEvent::Button {
+            position: self.cursor,
+            button,
+            down,
+        });
         let id = button_id(button);
         if down {
             if self.mouse_down.insert(id) {
@@ -299,6 +334,7 @@ impl Input {
     /// Place the cursor at a window-pixel position (scripted picking).
     pub fn inject_cursor(&mut self, x: f32, y: f32) {
         self.cursor = Some(Vec2::new(x, y));
+        self.pointer_events.push(PointerEvent::Move(self.cursor));
     }
 
     /// Append a text-editing keystroke (scripted typing).
@@ -320,6 +356,24 @@ impl Input {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pointer_stream_keeps_fast_clicks_and_cancels_held_input() {
+        let mut input = Input::default();
+        input.inject_cursor(12.0, 34.0);
+        input.inject_mouse_button(MouseButton::Left, true);
+        input.inject_mouse_button(MouseButton::Left, false);
+        assert_eq!(input.pointer_events().len(), 3);
+        assert!(!input.mouse_button_down(MouseButton::Left));
+        input.end_frame();
+        assert!(input.pointer_events().is_empty());
+        input.inject_key(KeyCode::KeyW, true);
+        input.inject_mouse_delta(20.0, 10.0);
+        input.clear();
+        assert_eq!(input.pointer_events(), &[PointerEvent::Cancel]);
+        assert!(!input.key_down(KeyCode::KeyW));
+        assert_eq!(input.mouse_delta(), Vec2::ZERO);
+    }
 
     #[test]
     fn end_frame_consumes_edges_but_preserves_held_state() {

--- a/framework/compiler/subpaths.ts
+++ b/framework/compiler/subpaths.ts
@@ -88,6 +88,8 @@ export const SUBPATHS: Record<string, SubpathDecl> = {
     aliases: ["vue-vapor"],
   },
   host: { file: "framework/src/host.ts" },
+  "overlay-host": { file: "framework/src/overlay-host.ts" },
+  "themes/desktop": { file: "framework/src/themes/desktop.ts" },
   lifecycle: {
     file: {
       solid: "framework/src/lifecycle.ts",

--- a/framework/src/desktop-pointer.ts
+++ b/framework/src/desktop-pointer.ts
@@ -1,0 +1,70 @@
+// A desktop pointer feeds the existing focus/onPress authority. It keeps a
+// press owner through release; moving onto another control cannot activate it.
+import { focusNode, hitFocusable, hitNode, pressNode, setActiveNode } from "./input.ts";
+import type { NodeMirror } from "./renderer.ts";
+
+export type PointerPacket =
+  | { kind: "move"; x: number | null; y: number | null }
+  | { kind: "button"; x: number | null; y: number | null; down: boolean }
+  | { kind: "cancel" };
+export interface DragPosition { x: number; y: number; dx: number; dy: number; started: boolean }
+export interface PointerAuthority<Node> {
+  hit(x: number, y: number): Node | null;
+  rawHit(x: number, y: number): Node | null;
+  parent(node: Node): Node | null;
+  focus(node: Node): void;
+  active(node: Node | null): void;
+  press(node: Node): void;
+}
+
+export function createPointerController<Node>(authority: PointerAuthority<Node>) {
+  const drags = new Map<Node, (position: DragPosition) => void>();
+  let owner: Node | null = null;
+  let drag: ((position: DragPosition) => void) | undefined;
+  let down = false;
+  let startX = 0, startY = 0;
+  return {
+    registerDrag(node: Node, move: (position: DragPosition) => void): () => void {
+      drags.set(node, move);
+      return () => { drags.delete(node); if (drag === move) this.cancel(); };
+    },
+    cancel() { owner = null; drag = undefined; down = false; authority.active(null); },
+    update(packet: PointerPacket) {
+      if (packet.kind === "cancel") { this.cancel(); return; }
+      const valid = packet.x !== null && packet.y !== null && Number.isFinite(packet.x) && Number.isFinite(packet.y);
+      const hit = valid ? authority.hit(packet.x!, packet.y!) : null;
+      if (packet.kind === "move") {
+        if (down && drag && valid) {
+          drag({ x: packet.x!, y: packet.y!, dx: packet.x! - startX, dy: packet.y! - startY, started:false });
+        } else if (down) authority.active(hit === owner ? owner : null);
+        else if (hit) authority.focus(hit);
+        return;
+      }
+      if (packet.down) {
+        if (down) return;
+        down = true;
+        owner = hit;
+        startX = packet.x ?? 0; startY = packet.y ?? 0;
+        // A focusable child (caption close button) owns its click before an
+        // ancestor's drag region can claim it.
+        if (hit) { authority.focus(hit); authority.active(hit); }
+        else if (valid) {
+          let node = authority.rawHit(packet.x!, packet.y!);
+          while (node) { if (drags.has(node)) { drag = drags.get(node); drag?.({x:startX,y:startY,dx:0,dy:0,started:true}); break; } node = authority.parent(node); }
+        }
+      } else {
+        const activate = down && !drag && owner !== null && owner === hit;
+        const target = owner;
+        this.cancel();
+        if (activate) authority.press(target!);
+      }
+    },
+  };
+}
+
+export function desktopPointer() {
+  return createPointerController<NodeMirror>({
+    hit: hitFocusable, rawHit: hitNode, parent: n => n.parent,
+    focus: focusNode, active: setActiveNode, press: pressNode,
+  });
+}

--- a/framework/src/overlay-host.ts
+++ b/framework/src/overlay-host.ts
@@ -1,0 +1,35 @@
+// Optional in-process overlay channel. The host supplies state and ordered
+// pointer events; the UI emits application commands without owning game state.
+import { getOps } from "./host.ts";
+import { registerServicePump } from "./services.ts";
+import { desktopPointer, type PointerPacket, type DragPosition } from "./desktop-pointer.ts";
+import type { NodeMirror } from "./renderer.ts";
+
+export type { PointerPacket, DragPosition } from "./desktop-pointer.ts";
+export const OVERLAY_SERVICE = "pocket.overlay";
+
+export function connectOverlay<State, Command>(receive: (state: State) => void) {
+  const ops = getOps();
+  const pointer = desktopPointer();
+  if (!ops.svcOpen?.(OVERLAY_SERVICE)) throw new Error("PocketJS overlay host is unavailable");
+  const disposePump = registerServicePump(() => {
+    const batch = ops.svcPoll?.();
+    if (!batch) return;
+    for (const line of batch.split("\n")) {
+      if (!line) continue;
+      const message = JSON.parse(line) as { type: string; value: State; event: PointerPacket };
+      if (message.type === "state") receive(message.value);
+      else if (message.type === "pointer") pointer.update(message.event);
+    }
+  });
+  return {
+    control(name: string, node: NodeMirror) {
+      ops.svcSend?.(JSON.stringify({ type: "pocket.overlay.control", name, node: node.id }));
+      return () => ops.svcSend?.(JSON.stringify({ type: "pocket.overlay.control", name, node: node.id, remove:true }));
+    },
+    send(command: Command) { ops.svcSend?.(JSON.stringify(command)); },
+    drag(node: NodeMirror, move: (position: DragPosition) => void) { return pointer.registerDrag(node, move); },
+    cancel() { pointer.cancel(); },
+    dispose() { pointer.cancel(); disposePump(); },
+  };
+}

--- a/framework/src/themes/desktop.ts
+++ b/framework/src/themes/desktop.ts
@@ -1,0 +1,46 @@
+// Semantic desktop chrome. Applications own content and behavior; these
+// complete class literals keep all XP paint inside the theme boundary.
+export interface DesktopTheme {
+  window: string; caption: string; title: string; close: string; closeText: string;
+  body: string; text: string; muted: string; heading: string;
+  tabs: string; tab(selected: boolean): string; tabText(selected: boolean): string;
+  button: string; primaryButton: string; disabledButton: string; buttonText: string;
+  group: string; groupTitle: string; well: string; status: string;
+  progressTrack: string; progressFill: string; success: string; failure: string;
+  check(checked: boolean): string; separator: string;
+}
+
+/** Original geometric chrome inspired by the XP Luna blue palette. Uses the
+ * framework's bundled fonts; no desktop-shell assets or system fonts. */
+export const XP_THEME: DesktopTheme = {
+  window: "absolute flex-col rounded-[7] border-[2] border-[#174bb8] bg-[#265ac9] shadow-lg overflow-hidden",
+  caption: "h-[32] flex-row items-center px-[8] gap-[7] bg-gradient-to-b from-[#6ba4ff] via-[#2869df] to-[#1551c2]",
+  title: "text-sm font-bold text-white",
+  close: "w-[23] h-[23] items-center justify-center rounded-[4] border border-white bg-gradient-to-b from-[#f59a7b] to-[#c63317] focus:bg-[#e86642] active:bg-[#ac301c]",
+  closeText: "text-sm font-bold text-white",
+  body: "flex-1 flex-col mx-[3] p-[12] gap-[10] bg-[#ece9d8]",
+  text: "text-xs text-[#202020]",
+  muted: "text-xs text-[#5d5d53]",
+  heading: "text-sm font-bold text-[#214795]",
+  tabs: "h-[30] flex-row items-end gap-[3] bg-[#ece9d8]",
+  tab: selected => selected
+    ? "flex-1 h-[30] items-center justify-center rounded-[4] border border-[#8e9298]  bg-[#fcfcf8]"
+    : "flex-1 h-[27] items-center justify-center rounded-[4] border border-[#9c9e98] bg-gradient-to-b from-[#f8f7f1] to-[#dfdfd4] focus:bg-[#fff4cd] active:bg-[#dddccf]",
+  tabText: selected => selected ? "text-xs font-bold text-[#184699]" : "text-xs text-[#3c3c38]",
+  button: "h-[30] flex-1 items-center justify-center rounded-[3] border border-[#7d887d] bg-gradient-to-b from-[#ffffff] via-[#f5f3e9] to-[#e0decf] focus:border-[#d29a2e] active:bg-[#d0cec1]",
+  primaryButton: "h-[34] items-center justify-center rounded-[3] border-[2] border-[#316ac5] bg-gradient-to-b from-[#ffffff] to-[#e3ebfb] focus:border-[#dd9c29] active:bg-[#c4d4ed]",
+  disabledButton: "h-[30] flex-1 items-center justify-center rounded-[3] border border-[#b9b8af] bg-[#e8e6da] opacity-50",
+  buttonText: "text-xs text-[#1c2b42]",
+  group: "relative flex-col gap-[7] p-[9] border border-[#b9b8a8] rounded-[4]",
+  groupTitle: "text-xs font-bold text-[#315697]",
+  well: "flex-col p-[8] gap-[4] border border-[#9c9c88] bg-[#fffffb]",
+  status: "h-[25] mx-[3] mb-[3] px-[8] flex-row items-center border border-[#aaa99e] bg-[#e2dfcf]",
+  progressTrack: "h-[13] border border-[#849081] bg-[#fffffd] rounded-[2] overflow-hidden",
+  progressFill: "h-full bg-gradient-to-b from-[#a2dd72] via-[#6db742] to-[#459329]",
+  success: "text-xs font-bold text-[#277223]",
+  failure: "text-xs font-bold text-[#a52a20]",
+  check: checked => checked
+    ? "w-[14] h-[14] border border-[#507047] bg-gradient-to-b from-[#fbfff5] to-[#b4d49f]"
+    : "w-[14] h-[14] border border-[#859078] bg-white",
+  separator: "h-[1] bg-[#bab9aa]",
+};

--- a/package.json
+++ b/package.json
@@ -165,6 +165,8 @@
     "./fs": "./framework/src/fs-api.ts",
     "./gesture": "./framework/src/gesture.ts",
     "./host": "./framework/src/host.ts",
+    "./overlay-host": "./framework/src/overlay-host.ts",
+    "./themes/desktop": "./framework/src/themes/desktop.ts",
     "./lifecycle": "./framework/src/lifecycle.ts",
     "./hot": "./framework/src/hot.ts",
     "./input": "./framework/src/input-api.ts",

--- a/tests/desktop-pointer.test.ts
+++ b/tests/desktop-pointer.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from "bun:test";
+import { createPointerController } from "../framework/src/desktop-pointer.ts";
+import { compileClasses } from "../framework/compiler/tailwind.ts";
+import { XP_THEME } from "../framework/src/themes/desktop.ts";
+
+function harness() {
+  const a = { id: 1 }, b = { id: 2 }, title = { id: 3 };
+  const pressed: number[] = [], moved: number[] = [];
+  let active: number | null = null;
+  const pointer = createPointerController({
+    hit: (x: number) => x < 0 ? null : x < 100 ? a : x < 200 ? b : null,
+    rawHit: (x: number) => x >= 200 ? title : null,
+    parent: () => null,
+    focus: () => {}, active: n => { active = n?.id ?? null; },
+    press: n => { pressed.push(n.id); },
+  });
+  pointer.registerDrag(title, p => { if (!p.started) moved.push(p.dx); });
+  const down = (x: number) => pointer.update({kind:"button",x,y:10,down:true});
+  const up = (x: number) => pointer.update({kind:"button",x,y:10,down:false});
+  const move = (x: number) => pointer.update({kind:"move",x,y:10});
+  return { pointer, pressed, moved, down, up, move, active: () => active };
+}
+
+describe("desktop pointer ownership", () => {
+  test("fast click fires once on release; moving onto a second button never fires it", () => {
+    const h = harness(); h.down(20); expect(h.active()).toBe(1); h.up(20);
+    expect(h.pressed).toEqual([1]);
+    h.down(20); h.move(140); expect(h.active()).toBeNull(); h.up(140);
+    h.up(140); expect(h.pressed).toEqual([1]);
+  });
+  test("focus loss, closing and pointer leaving cancel without activation", () => {
+    const h = harness(); h.down(20); h.pointer.update({kind:"cancel"}); h.up(20);
+    h.down(20); h.pointer.update({kind:"move",x:null,y:null}); h.up(-1);
+    expect(h.pressed).toEqual([]); expect(h.active()).toBeNull();
+    h.down(140); h.up(140); expect(h.pressed).toEqual([2]);
+  });
+  test("caption drag keeps its owner and does not click a button underneath", () => {
+    const h = harness(); h.down(220); h.move(250); h.move(20); h.up(20);
+    expect(h.moved).toEqual([30, -200]); expect(h.pressed).toEqual([]);
+    h.down(20); h.move(220); h.up(220); expect(h.moved).toEqual([30, -200]);
+  });
+  test("theme exposes distinct control states and a complete shared chrome palette", () => {
+    expect(XP_THEME.tab(true)).not.toBe(XP_THEME.tab(false));
+    expect(XP_THEME.check(true)).not.toBe(XP_THEME.check(false));
+    const classes = Object.values(XP_THEME).flatMap(part => typeof part === "string" ? [part] : [part(true), part(false)]);
+    const compiled = compileClasses(classes);
+    for (const part of classes) expect(compiled.ids[part]).toBeDefined();
+  });
+});


### PR DESCRIPTION
Games need to release mouse capture for clickable controls over their 3D scene. Adds explicit cursor ownership and a PocketJS overlay adapter: opening a UI can show the cursor, consume ordered clicks and drags, and clear held game input before fixed ticks. Existing games retain the legacy Escape/click policy by default.

`UiOverlay` hosts a JS/pak pair through the existing QuickJS, native UI core and wgpu renderer. It transports application JSON state, ordered pointer events and commands through an allowlisted in-process service. Layout, hit testing and rendering share viewport/scale; semantic control registration exposes painted bounds for coordinate-driven acceptance. Pointer release, cancellation and drag ownership reuse framework focus/onPress.

A reusable XP-style theme supplies window chrome, tabs, buttons, groups, status and progress controls. It uses authored geometry and bundled fonts. Application content and comparison sequences stay in Pocket Openworld PR #5. The theme and host contracts are documented in `docs/POCKET3D-UI-OVERLAY.md`.

Validation: 24 Pocket3D and 2 UI renderer/bridge tests, 4 TypeScript pointer/theme tests, TypeScript checking, Rust formatting and Clippy pass. Openworld integration tests exercise actual core hit positions, automated chemistry comparisons, repeated dragging, cancellation, resize and 1x/2x scaling. Adds a scoped overlay CI workflow. The renderer test module moves after its helpers to satisfy the newly enabled all-targets Clippy check; its behavior is unchanged.
