### PR TITLE
feat(sim): add bounded prediction and shared companion sessions

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -1,0 +1,32 @@
+name: Simulation and companion
+on:
+  pull_request:
+    paths: ['engine/crates/pocket-sim/**', 'engine/Cargo.toml', 'engine/Cargo.lock', 'tools/companion-session.ts', 'tools/offload-*.ts', 'tests/companion-session.test.ts', 'tests/offload.test.ts', 'hosts/3ds/src/offload*', '.github/workflows/simulation.yml']
+  push:
+    branches: [main]
+    paths: ['engine/crates/pocket-sim/**', 'engine/Cargo.toml', 'engine/Cargo.lock', 'tools/companion-session.ts', 'tools/offload-*.ts', 'tests/companion-session.test.ts', 'tests/offload.test.ts', 'hosts/3ds/src/offload*', '.github/workflows/simulation.yml']
+permissions:
+  contents: read
+concurrency:
+  group: simulation-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  contracts:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+      - uses: dtolnay/rust-toolchain@1.97.0
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: engine
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14
+      - run: bun install --frozen-lockfile
+      - run: cargo test --locked --manifest-path engine/Cargo.toml -p pocket-sim
+      - run: cargo fmt --manifest-path engine/Cargo.toml -p pocket-sim -- --check
+      - run: cargo clippy --locked --manifest-path engine/Cargo.toml -p pocket-sim --all-targets -- -D warnings
+      - run: bun test tests/companion-session.test.ts tests/offload.test.ts

--- a/docs/SIMULATION.md
+++ b/docs/SIMULATION.md
@@ -1,0 +1,101 @@
+# Predicting and reconciling simulation
+
+PocketJS's [frame transaction](DETERMINISM.md) delivers inputs and effects at
+a frame boundary. **It does not snapshot the JavaScript heap or rewind UI,
+native resources, clocks, or IO.** Applications that need prediction separate
+their simulation state from presentation and external effects.
+
+`engine/crates/pocket-sim` provides a `no_std` + `alloc` implementation for
+native hosts and simulation services. It has no dependency on Pocket3D, a
+device SDK, a transport, or a guest runtime.
+
+## Fixed-step state
+
+The application supplies a reducer `step(&mut state, &input)` with immutable
+configuration. State includes every value the next step reads: position,
+velocity, action phase, cooldowns, seeded randomness, and shared object state
+when those values affect the simulation. Meshes, cameras, UI nodes, sockets,
+and message delivery receipts belong outside it. Time is a fixed step or a
+counter in the state.
+
+`Predictor<State, Input, N>` saves the state after each input. An authority's
+acknowledgement identifies **the last input it consumed**, with the state
+after that input. On equality, confirmation drops acknowledged history with
+zero reducer calls. On difference, the predictor restores the authoritative
+state and replays the remaining inputs in order. The current state and stored
+checkpoints are then replaced by the corrected results.
+
+**N bounds both memory and replay work.** A full history returns `Full` before
+advancing state. The host waits for confirmation or requests a fresh session
+snapshot; it must not overwrite unconfirmed input. Future and stale
+acknowledgements leave state unchanged. Sequence exhaustion requires a new
+session. A new session constructs a new predictor from the authority's full
+snapshot, discarding the preceding session's inputs.
+
+`CommandQueue<Input, N>` admits contiguous commands from one authenticated
+session. It rejects gaps and overload, and ignores duplicates. The authority
+decides how many commands to consume per fixed tick; a packet cannot grant
+extra simulation time. `Timeline<State, N>` brackets a delayed server tick
+with remote snapshots and supplies an interpolation fraction. It holds the
+newest snapshot during missing updates instead of extrapolating without a
+limit.
+
+## Frame integration
+
+One host turn has this order:
+
+1. Copy bounded network deliveries at the frame boundary and validate their
+   protocol version, session, sequence and application state.
+2. Reconcile the local simulation. Queue remote snapshots for presentation.
+3. Predict the current hardware-neutral input and retain it for transmission.
+4. Update presentation from the resulting state, then submit one display frame.
+5. Submit new commands with transport credit. Retry unsent commands from the
+   input history, with the same sequence number.
+
+The reducer performs no network sends, file writes, UI hooks or callback
+deliveries. A one-shot simulation action is an input edge and replays as state.
+An external effect receives an application command ID outside the reducer;
+confirmation and deduplication govern its delivery. **Replaying a reducer
+does not replay the outer PocketJS frame transaction.** These Rust utilities
+do not add JavaScript heap checkpointing or a JavaScript simulation API.
+
+## Companion transport
+
+`tools/companion-session.ts` exposes `connectCompanionSession` over the existing
+[offload worker mailbox](OFFLOAD.md). Both request/reply providers and stateful
+companion rooms use its length framing, paired connection, reconnect and
+backpressure. It opens no second device transport and replays no application
+records on reconnect. A room binds each configured device to its player ID;
+the device cannot select another player's authority.
+
+The device's offload worker owns TCP and key reads. A native display loop calls
+`offload_frame`, takes at most one record, and submits at most two. Each record
+is at most 4096 bytes, with eight incoming and eight outgoing slots fenced by
+connection generation. `send()` on the companion reports missing credit.
+Snapshot producers can replace an unsent snapshot with a newer one; reliable
+commands retain their identity until accepted. DevTools uses its separate
+paired runtime connection.
+
+Pairing authenticates the companion to the device using the existing LAN key
+contract. Device identity comes from the daemon's configured endpoint. This
+transport does not provide encryption or an internet account identity system.
+
+## Networking choices and sources
+
+[GGPO](https://github.com/pond3r/ggpo) predicts inputs and restores saved game
+state when later inputs disagree. Its [sync implementation](https://github.com/pond3r/ggpo/blob/master/src/lib/ggpo/sync.cpp)
+shows the save/load/advance boundary. This informs the bounded simulation
+history; a social room does not need to roll back every participant's UI.
+
+[Valve's prediction implementation](https://github.com/ValveSoftware/source-sdk-2013/blob/master/src/game/client/prediction.cpp)
+compares acknowledged player state, restores prediction state, and executes
+unacknowledged commands. Client prediction with an authoritative companion
+and remote interpolation fits a walking demo without requiring cross-device
+floating-point lockstep.
+
+VRChat documents [object ownership](https://creators.vrchat.com/worlds/udon/networking/ownership/)
+and [late join recovery](https://creators.vrchat.com/worlds/udon/networking/late-joiners/):
+current synchronized state and ownership are restored for a newcomer;
+transient events are not replayed. A companion room therefore needs stable
+player assignment, fresh session epochs, full join snapshots and explicit
+disconnect handling before it adds shared interactive objects.

--- a/engine/Cargo.lock
+++ b/engine/Cargo.lock
@@ -1789,6 +1789,10 @@ dependencies = [
 ]
 
 [[package]]
+name = "pocket-sim"
+version = "0.1.0"
+
+[[package]]
 name = "pocket-stage"
 version = "0.1.0"
 dependencies = [

--- a/engine/Cargo.toml
+++ b/engine/Cargo.toml
@@ -16,6 +16,7 @@ members = [
     "crates/pocket-fs",
     "crates/pocket-mod",
     "crates/pocket-net",
+    "crates/pocket-sim",
     "crates/pocket-ui-surface",
     "crates/pocket-ui-wgpu",
     "crates/pocket-vrm",
@@ -57,6 +58,7 @@ pocket-db = { path = "crates/pocket-db" }
 pocket-fs = { path = "crates/pocket-fs" }
 pocket-mod = { path = "crates/pocket-mod" }
 pocket-net = { path = "crates/pocket-net" }
+pocket-sim = { path = "crates/pocket-sim" }
 pocket-ui-surface = { path = "crates/pocket-ui-surface" }
 pocket-ui-wgpu = { path = "crates/pocket-ui-wgpu" }
 pocket-vrm = { path = "crates/pocket-vrm" }

--- a/engine/crates/pocket-sim/Cargo.toml
+++ b/engine/crates/pocket-sim/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pocket-sim"
+description = "Bounded prediction, reconciliation and snapshot sampling for fixed-step simulations"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+
+[dependencies]

--- a/engine/crates/pocket-sim/src/lib.rs
+++ b/engine/crates/pocket-sim/src/lib.rs
@@ -1,0 +1,327 @@
+//! Simulation history, independent of rendering, transport and a guest heap.
+//! A reducer must depend only on its state, input and immutable configuration.
+//! Deliver network data before predicting a turn. Emit external effects outside
+//! the reducer; reconciliation calls the same reducer without repeating IO.
+#![no_std]
+extern crate alloc;
+use alloc::collections::VecDeque;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Error {
+    Full,
+    Future,
+    Stale,
+    Gap,
+    Exhausted,
+}
+
+#[derive(Clone, Debug)]
+pub struct Turn<S, I> {
+    pub tick: u64,
+    pub input: I,
+    pub state: S,
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Reconciliation {
+    pub corrected: bool,
+    pub replayed: usize,
+}
+
+/// N is both the storage ceiling and the maximum work in one reconciliation.
+/// Full history refuses prediction without changing state. The caller can wait
+/// for an acknowledgement or start a new session from a full snapshot.
+pub struct Predictor<S, I, const N: usize> {
+    state: S,
+    confirmed: u64,
+    tick: u64,
+    turns: VecDeque<Turn<S, I>>,
+}
+impl<S: Clone + PartialEq, I: Clone, const N: usize> Predictor<S, I, N> {
+    pub fn new(tick: u64, state: S) -> Self {
+        assert!(N > 0);
+        Self {
+            state,
+            confirmed: tick,
+            tick,
+            turns: VecDeque::with_capacity(N),
+        }
+    }
+    pub fn state(&self) -> &S {
+        &self.state
+    }
+    pub fn tick(&self) -> u64 {
+        self.tick
+    }
+    pub fn confirmed(&self) -> u64 {
+        self.confirmed
+    }
+    pub fn pending(&self) -> impl ExactSizeIterator<Item = &Turn<S, I>> {
+        self.turns.iter()
+    }
+    pub fn predict(&mut self, input: I, step: impl FnOnce(&mut S, &I)) -> Result<u64, Error> {
+        if self.turns.len() == N {
+            return Err(Error::Full);
+        }
+        let tick = self.tick.checked_add(1).ok_or(Error::Exhausted)?;
+        step(&mut self.state, &input);
+        self.tick = tick;
+        self.turns.push_back(Turn {
+            tick,
+            input,
+            state: self.state.clone(),
+        });
+        Ok(tick)
+    }
+    /// `state` is the authority's state after consuming input `tick`.
+    /// Equality avoids resampling already-correct history. All rejection paths
+    /// leave the current prediction and the confirmation cursor unchanged.
+    pub fn reconcile(
+        &mut self,
+        tick: u64,
+        state: S,
+        step: impl Fn(&mut S, &I),
+    ) -> Result<Reconciliation, Error> {
+        if tick <= self.confirmed {
+            return Err(Error::Stale);
+        }
+        if tick > self.tick {
+            return Err(Error::Future);
+        }
+        let index = self
+            .turns
+            .iter()
+            .position(|t| t.tick == tick)
+            .ok_or(Error::Stale)?;
+        let corrected = self.turns[index].state != state;
+        self.turns.drain(..=index);
+        self.confirmed = tick;
+        let mut replayed = 0;
+        if corrected {
+            self.state = state;
+            for turn in &mut self.turns {
+                step(&mut self.state, &turn.input);
+                turn.state = self.state.clone();
+                replayed += 1;
+            }
+        }
+        Ok(Reconciliation {
+            corrected,
+            replayed,
+        })
+    }
+}
+
+/// In-order commands from one authenticated session. Retransmissions cannot
+/// repeat edge actions. Gaps and overload require retry or a new session.
+pub struct CommandQueue<I, const N: usize> {
+    accepted: u64,
+    queue: VecDeque<(u64, I)>,
+}
+impl<I, const N: usize> CommandQueue<I, N> {
+    pub fn new(tick: u64) -> Self {
+        assert!(N > 0);
+        Self {
+            accepted: tick,
+            queue: VecDeque::with_capacity(N),
+        }
+    }
+    pub fn push(&mut self, tick: u64, input: I) -> Result<bool, Error> {
+        if tick <= self.accepted {
+            return Ok(false);
+        }
+        if tick != self.accepted.checked_add(1).ok_or(Error::Exhausted)? {
+            return Err(Error::Gap);
+        }
+        if self.queue.len() == N {
+            return Err(Error::Full);
+        }
+        self.accepted = tick;
+        self.queue.push_back((tick, input));
+        Ok(true)
+    }
+    pub fn pop(&mut self) -> Option<(u64, I)> {
+        self.queue.pop_front()
+    }
+    pub fn len(&self) -> usize {
+        self.queue.len()
+    }
+    pub fn is_empty(&self) -> bool {
+        self.queue.is_empty()
+    }
+}
+
+pub struct Sample<'a, S> {
+    pub from: &'a S,
+    pub to: &'a S,
+    pub alpha: f32,
+}
+/// Remote presentation history. Never predicts beyond the newest snapshot.
+/// The owner supplies a delayed server clock; sampling never changes simulation.
+pub struct Timeline<S, const N: usize> {
+    snapshots: VecDeque<(u64, S)>,
+}
+impl<S, const N: usize> Default for Timeline<S, N> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+impl<S, const N: usize> Timeline<S, N> {
+    pub fn new() -> Self {
+        assert!(N >= 2);
+        Self {
+            snapshots: VecDeque::with_capacity(N),
+        }
+    }
+    pub fn push(&mut self, tick: u64, state: S) -> bool {
+        if self.snapshots.back().is_some_and(|s| s.0 >= tick) {
+            return false;
+        }
+        if self.snapshots.len() == N {
+            self.snapshots.pop_front();
+        }
+        self.snapshots.push_back((tick, state));
+        true
+    }
+    pub fn latest_tick(&self) -> Option<u64> {
+        self.snapshots.back().map(|s| s.0)
+    }
+    pub fn sample(&self, tick: f64) -> Option<Sample<'_, S>> {
+        if !tick.is_finite() {
+            return None;
+        }
+        let mut previous = self.snapshots.front()?;
+        for next in &self.snapshots {
+            if next.0 as f64 >= tick {
+                let span = (next.0 - previous.0) as f64;
+                let alpha = if span > 0.0 {
+                    ((tick - previous.0 as f64) / span).clamp(0.0, 1.0) as f32
+                } else {
+                    0.0
+                };
+                return Some(Sample {
+                    from: &previous.1,
+                    to: &next.1,
+                    alpha,
+                });
+            }
+            previous = next;
+        }
+        Some(Sample {
+            from: &previous.1,
+            to: &previous.1,
+            alpha: 0.0,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[derive(Clone, Debug, PartialEq)]
+    struct Body {
+        x: i32,
+        velocity: i32,
+        edges: u32,
+    }
+    fn reducer(s: &mut Body, i: &(i32, bool)) {
+        s.velocity = (s.velocity + i.0).clamp(-4, 4);
+        s.x = (s.x + s.velocity).clamp(-40, 40);
+        s.edges += u32::from(i.1);
+    }
+    #[test]
+    fn correction_replays_only_unconfirmed_simulation_for_distinct_states() {
+        for start in [-32, 11] {
+            let initial = Body {
+                x: start,
+                velocity: 0,
+                edges: 0,
+            };
+            let mut p = Predictor::<_, _, 16>::new(0, initial.clone());
+            let inputs: alloc::vec::Vec<_> = (0..10)
+                .map(|i| (if i < 4 { 1 } else { -1 }, i == 6))
+                .collect();
+            for i in &inputs {
+                p.predict(*i, reducer).unwrap();
+            }
+            let mut authority = initial;
+            for i in &inputs[..4] {
+                reducer(&mut authority, i);
+            }
+            authority.x -= 2; // e.g. an authoritative collision response
+            let mut expected = authority.clone();
+            for i in &inputs[4..] {
+                reducer(&mut expected, i);
+            }
+            assert_eq!(
+                p.reconcile(4, authority, reducer),
+                Ok(Reconciliation {
+                    corrected: true,
+                    replayed: 6
+                })
+            );
+            assert_eq!(p.state(), &expected);
+            assert_eq!(p.state().edges, 1);
+            assert_eq!(p.pending().len(), 6);
+        }
+    }
+    #[test]
+    fn matching_ack_does_no_work_and_invalid_ack_is_atomic() {
+        let mut p = Predictor::<_, _, 2>::new(7, 0);
+        p.predict(2, |s, i| *s += i).unwrap();
+        p.predict(3, |s, i| *s += i).unwrap();
+        assert_eq!(p.predict(1, |_, _| panic!()), Err(Error::Full));
+        assert_eq!(p.reconcile(10, 99, |_, _| panic!()), Err(Error::Future));
+        assert_eq!(
+            p.reconcile(8, 2, |_, _| panic!()),
+            Ok(Reconciliation::default())
+        );
+        assert_eq!(p.reconcile(8, 99, |_, _| panic!()), Err(Error::Stale));
+        assert_eq!(*p.state(), 5);
+        p.predict(4, |s, i| *s += i).unwrap();
+        assert_eq!(p.reconcile(10, 42, |_, _| panic!()).unwrap().replayed, 0);
+        assert_eq!(*p.state(), 42);
+        assert_eq!(p.pending().len(), 0);
+    }
+    #[test]
+    fn delayed_lossy_ack_stream_matches_authority_and_bounds_history() {
+        let mut p = Predictor::<_, _, 32>::new(0, 0i64);
+        let mut authority = 0;
+        for tick in 1..=4000 {
+            let input = tick % 9 - 4;
+            p.predict(input, |s, i| *s += i).unwrap();
+            authority += input;
+            if tick % 13 == 0 {
+                p.reconcile(tick as u64, authority, |_, _| panic!())
+                    .unwrap();
+            }
+            assert_eq!(*p.state(), authority);
+            assert!(p.pending().len() < 14);
+        }
+    }
+    #[test]
+    fn ordered_commands_do_not_repeat_edges_or_accept_gaps() {
+        let mut q = CommandQueue::<_, 2>::new(0);
+        assert_eq!(q.push(2, true), Err(Error::Gap));
+        assert_eq!(q.push(1, true), Ok(true));
+        assert_eq!(q.push(1, true), Ok(false));
+        assert_eq!(q.push(2, false), Ok(true));
+        assert_eq!(q.push(3, true), Err(Error::Full));
+        assert_eq!(q.pop(), Some((1, true)));
+        assert_eq!(q.push(3, true), Ok(true));
+    }
+    #[test]
+    fn timeline_brackets_jitter_and_holds_at_loss() {
+        let mut t = Timeline::<_, 3>::new();
+        assert!(t.sample(0.0).is_none());
+        for n in [10, 12, 18, 20] {
+            assert!(t.push(n, n * 10));
+        }
+        assert!(!t.push(18, 999));
+        let s = t.sample(15.0).unwrap();
+        assert_eq!((*s.from, *s.to, s.alpha), (120, 180, 0.5));
+        assert_eq!(*t.sample(999.0).unwrap().to, 200);
+        assert_eq!(*t.sample(0.0).unwrap().from, 120);
+        assert!(t.sample(f64::NAN).is_none());
+    }
+}

--- a/hosts/3ds/src/offload.c
+++ b/hosts/3ds/src/offload.c
@@ -7,6 +7,9 @@
 #include <arpa/inet.h>
 #include <errno.h>
 #include <fcntl.h>
+#if __has_include(<netinet/tcp.h>)
+#include <netinet/tcp.h>
+#endif
 #include <stdio.h>
 #include <sys/socket.h>
 #include <unistd.h>
@@ -76,6 +79,10 @@ static void serve(void *unused) {
     int fd = accept(listener, NULL, NULL);
     if (fd < 0) { svcSleepThread(10000000); continue; }
     fcntl(fd, F_SETFL, O_NONBLOCK);
+#ifdef TCP_NODELAY
+    int no_delay = 1;
+    setsockopt(fd, IPPROTO_TCP, TCP_NODELAY, &no_delay, sizeof no_delay);
+#endif
     char offered[64]; unsigned mismatch = 0;
     if (!transfer(fd, offered, sizeof offered, false)) { close(fd); continue; }
     for (unsigned i = 0; i < sizeof key; i++) mismatch |= key[i] ^ offered[i];

--- a/package.json
+++ b/package.json
@@ -76,6 +76,8 @@
     "engine/crates/pocket-mod/Cargo.toml",
     "engine/crates/pocket-net/src",
     "engine/crates/pocket-net/Cargo.toml",
+    "engine/crates/pocket-sim/src",
+    "engine/crates/pocket-sim/Cargo.toml",
     "engine/crates/pocket-ui-surface/src",
     "engine/crates/pocket-ui-surface/Cargo.toml",
     "engine/crates/pocket-ui-wgpu/src",

--- a/tests/companion-session.test.ts
+++ b/tests/companion-session.test.ts
@@ -1,0 +1,54 @@
+import { expect, test } from "bun:test";
+import { createServer, type Socket } from "node:net";
+import { connectCompanionSession } from "../tools/companion-session.ts";
+import { OffloadDecoder, encodeOffloadRecord } from "../tools/offload-wire.ts";
+
+test("paired sessions exchange records, fence reconnect and never retry application sends", async () => {
+  const key = "ab".repeat(32), sockets = new Set<Socket>();
+  let connections = 0;
+  const commands: string[] = [], received: string[] = [];
+  let finish!: () => void;
+  const complete = new Promise<void>(resolve => { finish = resolve; });
+  const server = createServer(socket => {
+    connections++; sockets.add(socket);
+    socket.on("close", () => sockets.delete(socket));
+    let auth = Buffer.alloc(0), paired = false;
+    const decoder = new OffloadDecoder();
+    socket.on("data", chunk => {
+      if (!paired) {
+        auth = Buffer.concat([auth, chunk]);
+        if (auth.length < 64) return;
+        expect(auth.subarray(0, 64).toString()).toBe(key);
+        chunk = auth.subarray(64); paired = true;
+        const record = encodeOffloadRecord(`session-${connections}`);
+        socket.write(record.subarray(0, 3)); socket.write(record.subarray(3));
+      }
+      decoder.push(chunk, raw => {
+        commands.push(raw);
+        socket.write(encodeOffloadRecord(`ack-${raw}`));
+      });
+    });
+  });
+  await new Promise<void>(resolve => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  if (!address || typeof address === "string") throw new Error("listen failed");
+  const session = connectCompanionSession({ address: "127.0.0.1", port: address.port, key, retryMs: 5,
+    record(raw) {
+      received.push(raw);
+      if (raw === "session-1") expect(session.send("move-once")).toBe(true);
+      if (raw === "ack-move-once") session.disconnect();
+      if (raw === "session-2") finish();
+    },
+  });
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    await Promise.race([complete, new Promise((_, reject) => { timer = setTimeout(() => reject(new Error("session test timeout")), 3000); })]);
+    expect(received).toEqual(["session-1", "ack-move-once", "session-2"]);
+    expect(commands).toEqual(["move-once"]);
+  } finally {
+    clearTimeout(timer); session.close();
+    for (const socket of sockets) socket.destroy();
+    await new Promise<void>(resolve => server.close(() => resolve()));
+  }
+  expect(session.send("after-close")).toBe(false);
+});

--- a/tests/npm-package.test.ts
+++ b/tests/npm-package.test.ts
@@ -111,6 +111,8 @@ describe("published npm artifacts", () => {
       "engine/crates/pocket-mod/Cargo.toml",
       "engine/crates/pocket-net/src",
       "engine/crates/pocket-net/Cargo.toml",
+      "engine/crates/pocket-sim/src",
+      "engine/crates/pocket-sim/Cargo.toml",
       "engine/crates/pocket-ui-surface/src",
       "engine/crates/pocket-ui-surface/Cargo.toml",
       "engine/crates/pocket-ui-wgpu/src",
@@ -181,6 +183,8 @@ describe("published npm artifacts", () => {
     expect(files).toEqual(expect.arrayContaining([
       "engine/pocket3d/crates/pocket3d-anim/Cargo.toml",
       "engine/pocket3d/crates/pocket3d-anim/src/lib.rs",
+      "engine/crates/pocket-sim/src/lib.rs",
+      "tools/companion-session.ts",
       "engine/pocket3d/crates/pocket3d-mesh/Cargo.toml",
       "engine/pocket3d/crates/pocket3d-mesh/src/lib.rs",
       "engine/pocket3d/crates/pocket3d-mesh/src/p3m.rs",

--- a/tools/companion-session.ts
+++ b/tools/companion-session.ts
@@ -1,0 +1,70 @@
+/** Paired desktop endpoint for the 3DS bounded worker mailbox.
+ * The record transport is shared by request/reply offload and stateful rooms.
+ * It owns reconnection; applications own replay, identity and session recovery.
+ */
+import { connect } from "node:net";
+import { OFFLOAD } from "../contracts/spec/offload.ts";
+import { OffloadDecoder, encodeOffloadRecord } from "./offload-wire.ts";
+
+export interface CompanionSession {
+  /** False means no transport credit. No hidden retry or unbounded queue. */
+  send(record: string): boolean;
+  disconnect(): void;
+  close(): void;
+}
+export function connectCompanionSession(options: {
+  address: string; key: string; port?: number;
+  connected?: () => void;
+  record: (record: string) => void;
+  disconnected?: () => void;
+  metrics?: (metrics: string) => void;
+  retryMs?: number;
+}): CompanionSession {
+  if (!/^[0-9a-f]{64}$/.test(options.key)) throw new Error("Expected a 256-bit pairing key");
+  let stopped = false;
+  let retry: ReturnType<typeof setTimeout> | undefined;
+  let current: ReturnType<typeof connect> | undefined;
+  const api: CompanionSession = {
+    send(record) {
+      if (!current || current.connecting || current.destroyed || current.writableLength >= OFFLOAD.recordBytes * OFFLOAD.pending) return false;
+      current.write(encodeOffloadRecord(record));
+      return true;
+    },
+    disconnect() { current?.destroy(); },
+    close() { stopped = true; clearTimeout(retry); current?.destroy(); },
+  };
+  const attach = () => {
+    if (stopped) return;
+    const socket = connect({ host: options.address, port: options.port ?? OFFLOAD.port });
+    current = socket;
+    const decoder = new OffloadDecoder();
+    socket.setNoDelay(true);
+    socket.setTimeout(15000, () => socket.destroy());
+    socket.on("connect", () => {
+      socket.write(options.key);
+      // TCP connection is not an authentication receipt. The device's first
+      // application record establishes its protocol session after key checking.
+      try { options.connected?.(); } catch { socket.destroy(); }
+    });
+    socket.on("data", chunk => {
+      try {
+        decoder.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk, raw => {
+          if (raw.startsWith('{"v":1,"id":0,"method":"offload.metrics"')) {
+            const r = JSON.parse(raw);
+            if (typeof r.payload !== "string" || r.payload.length > 160) throw new Error("Invalid metrics");
+            options.metrics?.(r.payload);
+          } else options.record(raw);
+        });
+      } catch { socket.destroy(); }
+    });
+    socket.on("error", () => {});
+    socket.on("close", () => {
+      current = undefined;
+      try { options.disconnected?.(); } finally {
+        if (!stopped) retry = setTimeout(attach, options.retryMs ?? 1500);
+      }
+    });
+  };
+  attach();
+  return api;
+}

--- a/tools/offload-provider.ts
+++ b/tools/offload-provider.ts
@@ -1,72 +1,53 @@
 /** Desktop transport. Capability implementations execute in a Worker owned by
  * each authenticated device connection, never inside the socket callbacks. */
-import { connect } from "node:net";
 import { OFFLOAD, type OffloadRequest, type OffloadReply } from "../contracts/spec/offload.ts";
-import { OffloadDecoder, encodeOffloadRecord } from "./offload-wire.ts";
+import { encodeOffloadRecord } from "./offload-wire.ts";
+import { connectCompanionSession } from "./companion-session.ts";
 
 export function connectOffloadProvider(options: {
   address: string; key: string; worker: string | URL; data?: unknown;
   port?: number; log?: (message: string) => void;
 }) {
-  if (!/^[0-9a-f]{64}$/.test(options.key)) throw new Error("Expected a 256-bit pairing key");
-  let stopped = false;
-  let closeCurrent = () => {};
-  let retry: ReturnType<typeof setTimeout> | undefined;
-  const attach = () => {
-    if (stopped) return;
-    const socket = connect({ host: options.address, port: options.port ?? OFFLOAD.port });
-    const decoder = new OffloadDecoder();
-    let worker: Worker | undefined;
-    const pending = new Set<number>();
-    const deadlines = new Map<number, ReturnType<typeof setTimeout>>();
-    closeCurrent = () => socket.destroy();
-    socket.setNoDelay(true);
-    socket.setTimeout(15000, () => socket.destroy());
-    socket.on("connect", () => {
-      socket.write(options.key);
+  let worker: Worker | undefined;
+  const pending = new Set<number>();
+  const deadlines = new Map<number, ReturnType<typeof setTimeout>>();
+  const session = connectCompanionSession({
+    ...options,
+    connected() {
       worker = new Worker(options.worker, { type: "module" });
+      const owner = worker;
       worker.postMessage({ init: options.data });
-      worker.onerror = () => socket.destroy();
+      worker.onerror = () => { if (worker === owner) session.disconnect(); };
       worker.onmessage = (event: MessageEvent<OffloadReply>) => {
+        if (worker !== owner) return;
         const reply = event.data;
-        if (!pending.delete(reply.id)) return socket.destroy();
+        if (!pending.delete(reply.id)) return session.disconnect();
         clearTimeout(deadlines.get(reply.id)); deadlines.delete(reply.id);
         try {
           if (typeof reply.payload === "string" && reply.payload.length > OFFLOAD.payloadChars) throw new Error("Result budget exceeded");
-          const record = encodeOffloadRecord(JSON.stringify(reply));
-          if (socket.writableLength > OFFLOAD.recordBytes * OFFLOAD.pending) return socket.destroy();
-          socket.write(record);
-        } catch { socket.destroy(); }
+          if (!session.send(JSON.stringify(reply))) session.disconnect();
+        } catch { session.disconnect(); }
       };
       options.log?.("Transport connected; waiting for paired device requests");
-    });
-    socket.on("data", chunk => {
-      try {
-        decoder.push(typeof chunk === "string" ? Buffer.from(chunk) : chunk, raw => {
-          const request = JSON.parse(raw) as OffloadRequest;
-          if (request.v === 1 && request.id === 0 && request.method === "offload.metrics" && typeof request.payload === "string" && request.payload.length < 160) {
-            options.log?.(`Device ${request.payload}`); return;
-          }
-          if (request.v !== 1 || !Number.isSafeInteger(request.id) || request.id < 1 ||
-              typeof request.method !== "string" || !/^[a-z][a-z0-9_.-]{0,63}$/.test(request.method) ||
-              typeof request.payload !== "string" || request.payload.length > OFFLOAD.payloadChars ||
-              pending.size >= OFFLOAD.pending || pending.has(request.id)) throw new Error("Invalid request");
-          pending.add(request.id);
-          // Terminate a wedged provider worker. Sent mutations are never retried.
-          deadlines.set(request.id, setTimeout(() => socket.destroy(), 9000));
-          worker!.postMessage(request);
-        });
-      } catch { socket.destroy(); }
-    });
-    socket.on("error", () => {});
-    socket.on("close", () => {
-      worker?.terminate();
+    },
+    record(raw) {
+      const request = JSON.parse(raw) as OffloadRequest;
+      if (request.v !== 1 || !Number.isSafeInteger(request.id) || request.id < 1 ||
+          typeof request.method !== "string" || !/^[a-z][a-z0-9_.-]{0,63}$/.test(request.method) ||
+          typeof request.payload !== "string" || request.payload.length > OFFLOAD.payloadChars ||
+          pending.size >= OFFLOAD.pending || pending.has(request.id)) throw new Error("Invalid request");
+      pending.add(request.id);
+      deadlines.set(request.id, setTimeout(() => session.disconnect(), 9000));
+      worker!.postMessage(request);
+    },
+    metrics: text => options.log?.(`Device ${text}`),
+    disconnected() {
+      worker?.terminate(); worker = undefined;
       for (const timer of deadlines.values()) clearTimeout(timer);
-      if (!stopped) retry = setTimeout(attach, 1500);
-    });
-  };
-  attach();
-  return { close() { stopped = true; clearTimeout(retry); closeCurrent(); } };
+      deadlines.clear(); pending.clear();
+    },
+  });
+  return { close() { session.close(); } };
 }
 
 /** Worker-side allowlist. A missing method cannot open arbitrary resources. */

--- a/tools/test.ts
+++ b/tools/test.ts
@@ -86,6 +86,7 @@ const SUITE: readonly Stage[] = [
       "tests/fs.test.ts",
       "tests/net.test.ts",
       "tests/offload.test.ts",
+      "tests/companion-session.test.ts",
       "tests/resource-cache.test.ts",
       "tests/net-web.test.js",
       "tests/vita-package.test.ts",


### PR DESCRIPTION
PocketJS frame transactions order input and effect delivery but do not checkpoint simulation state. Add a no_std `pocket-sim` crate with bounded prediction history, authoritative reconciliation, ordered command admission and remote snapshot interpolation. Replaying a reducer excludes presentation and IO; matching acknowledgements perform no replay work.

Extract the desktop paired mailbox connection from the offload provider so stateful companion rooms reuse its framing, reconnect and backpressure. Existing offload request/reply APIs remain compatible. Include generation fencing, TCP_NODELAY on the 3DS worker, scoped CI and a design document with primary GGPO, Valve and VRChat sources.

Validation: 5 Rust simulation tests, Clippy and formatting; 9 companion/offload tests including real TCP reconnect and sanitized native SPSC queues. Pocket Island integration is being validated separately; no hardware timing claim in this PR.
