### PR TITLE
fix(desktop): restore portable GPU drawing and composition

### DIFF
--- a/.github/workflows/desktop-linux.yml
+++ b/.github/workflows/desktop-linux.yml
@@ -18,6 +18,8 @@ on:
       - "tests/text-layout-client.test.ts"
       - "apps/text-offload/**"
       - "hosts/desktop/**"
+      - "engine/crates/pocket-ui-wgpu/**"
+      - "engine/pocket3d/crates/pocket3d/**"
       - "hosts/web/app-instance.*"
       - "hosts/web/system-engine.js"
       - "hosts/web/wasm-ops.js"
@@ -43,6 +45,8 @@ on:
       - "tests/text-layout-client.test.ts"
       - "apps/text-offload/**"
       - "hosts/desktop/**"
+      - "engine/crates/pocket-ui-wgpu/**"
+      - "engine/pocket3d/crates/pocket3d/**"
       - "hosts/web/app-instance.*"
       - "hosts/web/system-engine.js"
       - "hosts/web/wasm-ops.js"
@@ -68,7 +72,7 @@ jobs:
           sudo apt-get update && sudo apt-get install -y --no-install-recommends
           clang cmake pkg-config libwayland-dev libx11-dev libx11-xcb-dev
           libxkbcommon-dev libxkbcommon-x11-dev libudev-dev libdrm-dev libgbm-dev
-          libxcb-shape0-dev libxcb-xfixes0-dev xvfb xauth
+          libxcb-shape0-dev libxcb-xfixes0-dev xvfb xauth libvulkan1 mesa-vulkan-drivers
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -106,6 +110,7 @@ jobs:
           cargo fmt --check --manifest-path hosts/desktop/Cargo.toml
           cargo clippy --locked --manifest-path hosts/desktop/Cargo.toml -- -D warnings
           cargo test --locked --manifest-path hosts/desktop/Cargo.toml
+          cargo test --locked --manifest-path hosts/desktop/Cargo.toml -- --ignored
           cargo test --locked --manifest-path engine/crates/pocket-text/Cargo.toml
           cargo test --locked --manifest-path engine/wasm/Cargo.toml
           bun tools/text-wasm.ts

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,6 +1,6 @@
 name: macOS portable renderer
 
-# Native and WASM software rendering share the Rust core. Text executes in
+# Native GPU and WASM software rendering share the Rust DrawList core. Text executes in
 # bounded worker adapters; neither host depends on the legacy gpui backend.
 
 on:
@@ -22,6 +22,8 @@ on:
       - "apps/text-offload/**"
       - "engine/wasm/**"
       - "hosts/desktop/**"
+      - "engine/crates/pocket-ui-wgpu/**"
+      - "engine/pocket3d/crates/pocket3d/**"
       - "tools/macos.ts"
       - "framework/src/components*.ts*"
       - "framework/src/host.ts"
@@ -60,6 +62,8 @@ on:
       - "apps/text-offload/**"
       - "engine/wasm/**"
       - "hosts/desktop/**"
+      - "engine/crates/pocket-ui-wgpu/**"
+      - "engine/pocket3d/crates/pocket3d/**"
       - "tools/macos.ts"
       - "framework/src/components*.ts*"
       - "framework/src/host.ts"

--- a/.github/workflows/pocket-ui-overlay.yml
+++ b/.github/workflows/pocket-ui-overlay.yml
@@ -10,6 +10,7 @@ on:
       - 'framework/compiler/subpaths.ts'
       - 'tests/desktop-pointer.test.ts'
       - 'engine/crates/pocket-ui-wgpu/**'
+      - 'engine/core/**'
       - 'engine/crates/pocket-ui-surface/**'
       - 'engine/pocket3d/crates/pocket3d/src/app.rs'
       - 'engine/pocket3d/crates/pocket3d/src/input.rs'
@@ -34,6 +35,7 @@ jobs:
           bun-version: 1.3.14
       - run: bun install --frozen-lockfile
       - run: bun test tests/desktop-pointer.test.ts
+      - run: sudo apt-get update && sudo apt-get install -y libvulkan1 mesa-vulkan-drivers
       - uses: dtolnay/rust-toolchain@1.97.0
         with:
           components: rustfmt, clippy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,6 +83,9 @@ jobs:
       - name: Test Rust core
         run: cargo test --locked --manifest-path engine/core/Cargo.toml
 
+      - name: Install headless GPU test driver
+        run: sudo apt-get update && sudo apt-get install -y libvulkan1 mesa-vulkan-drivers
+
       - name: Test desktop 3D and widget workspace
         run: cargo test --locked --manifest-path engine/Cargo.toml --workspace
 

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -19,20 +19,40 @@ hosts, the PSP GE walker, the ESP32-P4 PPA and Symbian GLES2 ports.
   core measures runs from the atlas advance tables
   (`engine/core/src/text.rs::measure_run`) and emits `GLYPH_RUN` ops —
   glyph ids and cell positions, nothing else.
-- **Pixels are byte-deterministic.** Same bundle + pak + input tape produce
-  the identical framebuffer on every portable host at the same density —
-  that is what `tests/golden.ts`, the PSP/Vita emulator goldens and
-  `tools/tape.ts` session hashes pin.
+- **Software pixels are byte-deterministic.** The Rust rasterizer produces
+  identical bytes for the same DrawList, resources and density on native and
+  WASM. GPU backends preserve DrawList geometry and painter order; blending,
+  filtering and triangle-edge rounding can differ. GPU tests compare selected
+  fixtures against software with explicit per-channel tolerances. Hardware
+  acceptance remains separate from emulator and software goldens.
 - The capability id is `text.glyphs.baked`; hosts that extend atlases at
   runtime (system-font rasterization + `loadFontAtlas` reload, note-widget's
   cjk.rs) add `text.glyphs.runtime`.
 
 ## The portable desktop host
 
-`hosts/desktop` now uses winit and softbuffer for window/input/pixel presentation.
-QuickJS guests, flex layout, software rasterization and the shared
-`engine/core/src/compositor.rs` painter execute on a runtime worker. Each
-AppInstance has an independent text worker through `io.offload`.
+`hosts/desktop` uses winit for windows/input and the existing `pocket-ui-wgpu`
+DrawList backend for drawing and composition (wgpu/Metal on macOS). It reuses
+`pocket3d::gpu::Gpu`; no extra renderer crate or guest API is introduced.
+QuickJS guests, flex layout and GPU command recording execute on a runtime
+worker. Each AppInstance has an independent text worker through `io.offload`.
+
+**Child surfaces stay on the GPU.** Each has an independent renderer/resource
+cache and retained texture. DrawList/resource revisions invalidate content;
+instance generations invalidate reopened apps. `SURFACE_QUAD` samples these
+textures at the shell's painter position, outside guest texture handles.
+The worker leases from a three-target frame pool and submits to a shared queue.
+The window thread presents the retained target with a GPU blit. Frame leases
+prevent reuse until presentation is submitted; queue ordering protects GPU
+reads. The handoff holds one output, and rendering retries when no target is
+available. An output reservation prevents recording more GPU work while the
+window thread has not consumed the previous output. Surface loss/outdated errors reconfigure and retry; fatal GPU errors
+exit with an error. Production presentation performs no framebuffer readback.
+
+The WASM host retains `engine/core/src/compositor.rs` and the software rasterizer.
+Vita/GXM and 3DS/PICA retain their own DrawList adapters and capability profiles;
+wgpu is not added to their dependency graph. Desktop composition support does
+not admit that capability on handheld targets.
 `text.layout.offload` wraps, shapes and rasterizes text using explicit package
 fonts in Rust, including through the same engine compiled to WASM. PSP requires
 a paired companion for this capability. See [TEXT-OFFLOAD.md](TEXT-OFFLOAD.md)
@@ -213,3 +233,9 @@ X,Y[,d|u|r]@TICK` (drags, right clicks), `--key
 
 The desktop benchmark against Tauri and Electron (harness, comparison
 apps, results) lives in its own stacked PR — pocket-stack/pocketjs#294.
+
+
+`hosts/desktop --trace-frames` emits CPU tick, render-submission, worker-total
+and presentation-submission timestamps. These durations exclude GPU completion
+and display scanout. Use a native input tape and record the binary/package hashes
+when comparing renderer changes.

--- a/engine/core/src/lib.rs
+++ b/engine/core/src/lib.rs
@@ -247,6 +247,7 @@ pub struct Ui {
     tree: tree::Tree,
     styles: style::StyleTable,
     fonts: text::Fonts,
+    font_revisions: [u64; spec::MAX_FONT_SLOTS],
     anims: anim::Anims,
     timelines: Vec<TimelineInst>,
     layout: layout::LayoutEngine,
@@ -336,6 +337,7 @@ impl Ui {
             tree: tree::Tree::new(),
             styles: style::StyleTable::new(),
             fonts: text::Fonts::new(),
+            font_revisions: [0; spec::MAX_FONT_SLOTS],
             anims: anim::Anims::new(),
             timelines: Vec::new(),
             layout: layout::LayoutEngine::new(),
@@ -966,6 +968,8 @@ impl Ui {
     pub fn load_font_atlas(&mut self, bytes: &[u8]) -> bool {
         let ok = self.fonts.load(bytes);
         if ok {
+            let slot = bytes[12] as usize;
+            self.font_revisions[slot] = self.font_revisions[slot].wrapping_add(1);
             self.mark_layout_dirty();
             self.bump_raster_revision();
         }
@@ -1750,6 +1754,11 @@ impl Ui {
     /// A registered font atlas (backends read glyph bitmaps through this).
     pub fn font_atlas(&self, slot: u8) -> Option<&text::Atlas> {
         self.fonts.atlas(slot)
+    }
+
+    /// Per-slot GPU cache invalidation, including same-count atlas replacements.
+    pub fn font_atlas_revision(&self, slot: u8) -> u64 {
+        self.font_revisions.get(slot as usize).copied().unwrap_or(0)
     }
 
     // ---- internals -----------------------------------------------------------

--- a/engine/core/src/tests.rs
+++ b/engine/core/src/tests.rs
@@ -3906,3 +3906,20 @@ fn clearing_native_measure_restores_baked_goldens_path() {
     assert_eq!(counts[spec::draw_op::TEXT_RUN as usize], 0);
     assert_eq!(counts[spec::draw_op::GLYPH_RUN as usize], 1);
 }
+
+#[test]
+fn font_revision_changes_only_after_successful_load_and_is_slot_local() {
+    let mut ui = Ui::new();
+    let atlas = encode_atlas(3, 2, 2, 1, 2, 1, &[(65, 0, 2)]);
+    assert_eq!(ui.font_atlas_revision(3), 0);
+    assert!(ui.load_font_atlas(&atlas));
+    assert_eq!(ui.font_atlas_revision(3), 1);
+    assert!(!ui.load_font_atlas(&atlas[..10]));
+    assert_eq!(ui.font_atlas_revision(3), 1);
+    let mut replacement = atlas.clone();
+    *replacement.last_mut().unwrap() = 255;
+    assert!(ui.load_font_atlas(&replacement));
+    assert_eq!(ui.font_atlas_revision(3), 2);
+    assert_eq!(ui.font_atlas_revision(0), 0);
+    assert_eq!(ui.font_atlas_revision(255), 0);
+}

--- a/engine/crates/pocket-ui-wgpu/src/gpu_tests.rs
+++ b/engine/crates/pocket-ui-wgpu/src/gpu_tests.rs
@@ -1,0 +1,360 @@
+//! Execute DrawList fixtures on the selected GPU, then read back the result.
+//! CI must install a GPU driver (Mesa Vulkan is sufficient); absence fails.
+use super::UiRenderer;
+use pocket3d::gpu::{Gpu, OffscreenTarget};
+use pocketjs_core::{
+    Ui, compositor, raster,
+    spec::{self, draw_op as op},
+};
+
+fn packed(x: u16, y: u16) -> u32 {
+    x as u32 | ((y as u32) << 16)
+}
+fn target(gpu: &Gpu, size: u32, format: wgpu::TextureFormat) -> OffscreenTarget {
+    let texture = gpu.device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("DrawList fixture"),
+        size: wgpu::Extent3d {
+            width: size,
+            height: size,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::COPY_SRC
+            | wgpu::TextureUsages::TEXTURE_BINDING,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&Default::default());
+    OffscreenTarget {
+        texture,
+        view,
+        size: (size, size),
+    }
+}
+fn draw(
+    gpu: &Gpu,
+    renderer: &mut UiRenderer,
+    ui: &Ui,
+    words: &[u32],
+    out: &OffscreenTarget,
+    scale: u32,
+) -> Vec<u8> {
+    let mut encoder = gpu.device.create_command_encoder(&Default::default());
+    renderer
+        .render_words_scaled(
+            gpu,
+            ui,
+            words,
+            &mut encoder,
+            &out.view,
+            out.size,
+            scale as f32,
+            wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+        )
+        .unwrap();
+    gpu.queue.submit([encoder.finish()]);
+    out.read_rgba(gpu).unwrap()
+}
+fn close(actual: &[u8], expected: &[u8], tolerance: u8) {
+    assert_eq!(actual.len(), expected.len());
+    for (i, (&a, &e)) in actual.iter().zip(expected).enumerate() {
+        assert!(
+            a.abs_diff(e) <= tolerance,
+            "byte {i}: GPU {a}, software {e}"
+        );
+    }
+}
+fn image(handle: i32, x: u16, y: u16, w: u16, h: u16) -> [u32; 9] {
+    [
+        op::TEX_QUAD,
+        handle as u32,
+        packed(x, y),
+        packed(w, h),
+        0,
+        0,
+        1.0f32.to_bits(),
+        1.0f32.to_bits(),
+        0xffffffff,
+    ]
+}
+fn font(coverage: u8) -> Vec<u8> {
+    let mut bytes = Vec::new();
+    bytes.extend(spec::font_atlas::MAGIC.to_le_bytes());
+    bytes.extend(spec::font_atlas::VERSION.to_le_bytes());
+    bytes.extend(1u16.to_le_bytes());
+    bytes.extend([2, 2, 1, 2, 3, 0, 1, 0]); // slot 3, one 2x2 glyph
+    bytes.extend(65u32.to_le_bytes());
+    bytes.extend([0, 0, 2, 0]);
+    bytes.extend([coverage; 4]);
+    bytes
+}
+
+#[test]
+fn gpu_drawlist_composition_and_resource_lifecycle() {
+    let gpu = Gpu::new_headless().expect("GPU required for DrawList conformance");
+    eprintln!("DrawList conformance: {:?}", gpu.adapter.get_info());
+    for scale in [1, 2] {
+        let mut ui = Ui::new();
+        ui.set_viewport(16.0, 16.0);
+        let out = target(&gpu, 16 * scale, wgpu::TextureFormat::Rgba8Unorm);
+        let mut renderer = UiRenderer::new(&gpu, wgpu::TextureFormat::Rgba8Unorm);
+        let mut words = vec![op::RECT, 0, packed(16, 16), 0xff204060];
+        words.extend([
+            op::SCISSOR,
+            packed(2, 2),
+            packed(8, 8),
+            op::RECT,
+            0,
+            packed(16, 16),
+            0x808020e0,
+            op::SCISSOR_POP,
+        ]);
+        let mut expected = vec![0; (16 * scale * 16 * scale * 4) as usize];
+        raster::render_scaled(&ui, &words, &mut expected, scale);
+        close(
+            &draw(&gpu, &mut renderer, &ui, &words, &out, scale),
+            &expected,
+            1,
+        );
+
+        // Gradient directions and both triangle modes use physical samples.
+        for dir in [
+            spec::GradDir::ToTop,
+            spec::GradDir::ToBottom,
+            spec::GradDir::ToLeft,
+            spec::GradDir::ToRight,
+        ] {
+            let w = [
+                op::GRAD_RECT,
+                0,
+                packed(16, 16),
+                0xff204080,
+                0xffe0a010,
+                dir as u32,
+            ];
+            raster::render_scaled(&ui, &w, &mut expected, scale);
+            close(
+                &draw(&gpu, &mut renderer, &ui, &w, &out, scale),
+                &expected,
+                1,
+            );
+        }
+        let w = [
+            op::TRI,
+            0,
+            packed(16, 0),
+            packed(16, 16),
+            0xff204080,
+            0xff80a040,
+            0xffe0a040,
+            op::TRI,
+            0,
+            packed(16, 16),
+            packed(0, 16),
+            0xff204080,
+            0xffe0a040,
+            0xff804080,
+        ];
+        raster::render_scaled(&ui, &w, &mut expected, scale);
+        close(
+            &draw(&gpu, &mut renderer, &ui, &w, &out, scale),
+            &expected,
+            1,
+        );
+        let handle = ui.upload_texture(&[64, 128, 192, 255], 1, 1, spec::psm::PSM_8888);
+        let one = 1.0f32.to_bits();
+        let w = [
+            op::TEX_TRI,
+            handle as u32,
+            0,
+            0,
+            0,
+            packed(16, 0),
+            one,
+            0,
+            packed(16, 16),
+            one,
+            one,
+            0xffffffff,
+            op::TEX_TRI,
+            handle as u32,
+            0,
+            0,
+            0,
+            packed(16, 16),
+            one,
+            one,
+            packed(0, 16),
+            0,
+            one,
+            0xffffffff,
+        ];
+        raster::render_scaled(&ui, &w, &mut expected, scale);
+        close(
+            &draw(&gpu, &mut renderer, &ui, &w, &out, scale),
+            &expected,
+            0,
+        );
+        ui.free_texture(handle);
+        // Every image format, then a freed handle followed by a solid rectangle.
+        for (psm, data) in [
+            (spec::psm::PSM_8888, vec![32, 64, 128, 128]),
+            (spec::psm::PSM_5650, vec![0x1f, 0x78]),
+            (spec::psm::PSM_4444, vec![0x84, 0x8c]),
+        ] {
+            let handle = ui.upload_texture(&data, 1, 1, psm);
+            assert!(handle >= 0);
+            let w = image(handle, 0, 0, 16, 16);
+            raster::render_scaled(&ui, &w, &mut expected, scale);
+            close(
+                &draw(&gpu, &mut renderer, &ui, &w, &out, scale),
+                &expected,
+                1,
+            );
+            ui.free_texture(handle);
+            let mut stale = w.to_vec();
+            stale.extend([op::RECT, packed(2, 2), packed(4, 4), 0xff802040]);
+            raster::render_scaled(&ui, &stale, &mut expected, scale);
+            close(
+                &draw(&gpu, &mut renderer, &ui, &stale, &out, scale),
+                &expected,
+                0,
+            );
+        }
+        let mut palette = vec![0u8; 1024];
+        palette[..4].copy_from_slice(&[64, 128, 192, 255]);
+        let mut t8 = palette.clone();
+        t8.push(0);
+        let handle = ui.upload_texture(&t8, 1, 1, spec::psm::PSM_T8);
+        let w = image(handle, 0, 0, 16, 16);
+        for color in [[64, 128, 192, 255], [192, 32, 64, 255]] {
+            palette[..4].copy_from_slice(&color);
+            assert!(ui.update_texture_t8(handle, &palette, &[0]));
+            raster::render_scaled(&ui, &w, &mut expected, scale);
+            close(
+                &draw(&gpu, &mut renderer, &ui, &w, &out, scale),
+                &expected,
+                0,
+            );
+        }
+
+        // Same glyph count and metrics with new coverage must refresh the atlas.
+        let w = [op::GLYPH_RUN, 3 | (1 << 16), 0xff80c0ff, packed(2, 2), 0];
+        for coverage in [255, 0, 128] {
+            assert!(ui.load_font_atlas(&font(coverage)));
+            raster::render_scaled(&ui, &w, &mut expected, scale);
+            close(
+                &draw(&gpu, &mut renderer, &ui, &w, &out, scale),
+                &expected,
+                1,
+            );
+        }
+
+        // The child has its own texture namespace, and an unclipped full origin.
+        let mut child_ui = Ui::new();
+        child_ui.set_viewport(16.0, 16.0);
+        let child_handle = child_ui.upload_texture(&[255, 128, 32, 255], 1, 1, spec::psm::PSM_8888);
+        let mut child_words = image(child_handle, 0, 0, 16, 16).to_vec();
+        child_words.extend([op::RECT, packed(8, 0), packed(8, 16), 0xff804020]);
+        let child_target = target(&gpu, 16 * scale, wgpu::TextureFormat::Rgba8Unorm);
+        let mut child_renderer = UiRenderer::new(&gpu, wgpu::TextureFormat::Rgba8Unorm);
+        let child_pixels = draw(
+            &gpu,
+            &mut child_renderer,
+            &child_ui,
+            &child_words,
+            &child_target,
+            scale,
+        );
+        renderer.set_surface(&gpu, 7, &child_target.view, (16, 16));
+        let mut w = vec![
+            op::RECT,
+            0,
+            packed(16, 16),
+            0xff102030,
+            op::SCISSOR,
+            packed(2, 2),
+            packed(10, 10),
+        ];
+        w.extend([
+            op::SURFACE_QUAD,
+            7,
+            (-4.0f32).to_bits(),
+            0,
+            16.0f32.to_bits(),
+            16.0f32.to_bits(),
+            packed(2, 2),
+            packed(10, 10),
+            0,
+        ]);
+        w.extend([
+            op::RECT,
+            packed(0, 10),
+            packed(16, 2),
+            0xff20e040,
+            op::SCISSOR_POP,
+            op::RECT,
+            packed(0, 14),
+            packed(16, 2),
+            0xff503010,
+        ]);
+        let mut surfaces = vec![None; 8];
+        surfaces[7] = Some(compositor::CompositorRaster {
+            pixels: child_pixels,
+            width: 16,
+            height: 16,
+            density: scale,
+        });
+        compositor::render(&ui, &w, &mut expected, scale, &surfaces);
+        close(
+            &draw(&gpu, &mut renderer, &ui, &w, &out, scale),
+            &expected,
+            0,
+        );
+        renderer.retain_surfaces(|_| false);
+        compositor::render(&ui, &w, &mut expected, scale, &[]);
+        close(
+            &draw(&gpu, &mut renderer, &ui, &w, &out, scale),
+            &expected,
+            0,
+        );
+
+        // Bad lengths must fail before encoding or resource submission.
+        let mut encoder = gpu.device.create_command_encoder(&Default::default());
+        for bad in [
+            &[op::SURFACE_QUAD, 1][..],
+            &[op::GLYPH_RUN, u32::MAX][..],
+            &[u32::MAX][..],
+        ] {
+            assert!(
+                renderer
+                    .render_words(
+                        &gpu,
+                        &ui,
+                        bad,
+                        &mut encoder,
+                        &out.view,
+                        out.size,
+                        wgpu::LoadOp::Load
+                    )
+                    .is_err()
+            );
+        }
+    }
+    // Existing sRGB overlay target keeps its established color interpretation.
+    let ui = Ui::new();
+    let out = target(&gpu, 16, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let mut renderer = UiRenderer::new(&gpu, wgpu::TextureFormat::Rgba8UnormSrgb);
+    let pixels = draw(
+        &gpu,
+        &mut renderer,
+        &ui,
+        &[op::RECT, 0, packed(16, 16), 0xff806040],
+        &out,
+        1,
+    );
+    close(&pixels, &[64, 96, 128, 255].repeat(256), 1);
+}

--- a/engine/crates/pocket-ui-wgpu/src/lib.rs
+++ b/engine/crates/pocket-ui-wgpu/src/lib.rs
@@ -23,3 +23,6 @@ pub use render::UiRenderer;
 // The backend-agnostic surface (UiSurface + pak walk) — re-exported so desktop
 // consumers (uihost, OpenStrike) stay source-compatible after the split.
 pub use pocket_ui_surface::{PakEntry, UiSurface, walk_pak};
+
+#[cfg(test)]
+mod gpu_tests;

--- a/engine/crates/pocket-ui-wgpu/src/render.rs
+++ b/engine/crates/pocket-ui-wgpu/src/render.rs
@@ -1,5 +1,5 @@
 //! DrawList → wgpu. The third DrawList backend (after the PSP GE and the
-//! wasm software rasterizer), executing the closed 7-op set pinned in
+//! wasm software rasterizer), executing the DrawList operations pinned in
 //! spec.ts "DRAWLIST op format".
 //!
 //! The core's CPU clip stage guarantees every coordinate is inside
@@ -9,11 +9,13 @@
 //! upscale the result themselves (see `examples/uihost`).
 //!
 //! Color space: DrawList colors and pak images are sRGB-encoded; the shader
-//! linearizes them and the sRGB render target re-encodes on store.
+//! linearizes them for sRGB targets. UNORM targets retain encoded byte-space
+//! blending for the portable desktop compositor.
 
-use anyhow::Result;
+use anyhow::{Result, ensure};
 use pocket3d::gpu::Gpu;
 use pocketjs_core::{TexView, Ui, spec};
+use std::collections::HashMap;
 
 /// One glyph atlas uploaded as an R8 grid texture (16 cells per row).
 /// Cells are stored at coverage resolution (logical cell × raster density);
@@ -31,6 +33,7 @@ struct FontTexture {
     tex_h: f32,
     cols: u32,
     glyph_count: u16,
+    revision: u64,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -68,6 +71,12 @@ enum TexBind {
     White,
     Font(u8),
     Image(i32),
+    Surface(u32),
+}
+
+struct SurfaceBind {
+    bind: wgpu::BindGroup,
+    logical: (u32, u32),
 }
 
 struct DrawCmd {
@@ -80,6 +89,8 @@ struct DrawCmd {
 /// Renders a `pocketjs_core::Ui`'s DrawList into any render target.
 pub struct UiRenderer {
     pipeline: wgpu::RenderPipeline,
+    image_format: wgpu::TextureFormat,
+    surfaces: HashMap<u32, SurfaceBind>,
     bind_layout: wgpu::BindGroupLayout,
     /// Linear sampler: fonts, the white pixel, and `TexView::linear` images.
     sampler: wgpu::Sampler,
@@ -148,7 +159,13 @@ impl UiRenderer {
             fragment: Some(wgpu::FragmentState {
                 module: &shader,
                 entry_point: Some("fs_main"),
-                compilation_options: Default::default(),
+                compilation_options: wgpu::PipelineCompilationOptions {
+                    constants: &[(
+                        "LINEAR_OUTPUT",
+                        if target_format.is_srgb() { 1.0 } else { 0.0 },
+                    )],
+                    ..Default::default()
+                },
                 targets: &[Some(wgpu::ColorTargetState {
                     format: target_format,
                     blend: Some(wgpu::BlendState::ALPHA_BLENDING),
@@ -225,6 +242,12 @@ impl UiRenderer {
 
         UiRenderer {
             pipeline,
+            image_format: if target_format.is_srgb() {
+                wgpu::TextureFormat::Rgba8UnormSrgb
+            } else {
+                wgpu::TextureFormat::Rgba8Unorm
+            },
+            surfaces: HashMap::new(),
             bind_layout,
             sampler,
             sampler_nearest,
@@ -236,6 +259,38 @@ impl UiRenderer {
             verts: Vec::new(),
             cmds: Vec::new(),
         }
+    }
+
+    /// Bind a host-owned child target outside the guest texture namespace.
+    /// The view must use this renderer's color encoding. Rebind only when the
+    /// target is recreated; rendering new content into it retains the binding.
+    pub fn set_surface(
+        &mut self,
+        gpu: &Gpu,
+        handle: u32,
+        view: &wgpu::TextureView,
+        logical: (u32, u32),
+    ) {
+        let bind = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+            label: Some("pocket-ui compositor surface"),
+            layout: &self.bind_layout,
+            entries: &[
+                wgpu::BindGroupEntry {
+                    binding: 0,
+                    resource: wgpu::BindingResource::TextureView(view),
+                },
+                wgpu::BindGroupEntry {
+                    binding: 1,
+                    resource: wgpu::BindingResource::Sampler(&self.sampler_nearest),
+                },
+            ],
+        });
+        self.surfaces.insert(handle, SurfaceBind { bind, logical });
+    }
+
+    /// Retire bindings when AppInstances close or fail.
+    pub fn retain_surfaces(&mut self, mut keep: impl FnMut(u32) -> bool) {
+        self.surfaces.retain(|handle, _| keep(*handle));
     }
 
     /// Build this frame's DrawList from `ui` and record it into `encoder` as
@@ -291,6 +346,19 @@ impl UiRenderer {
         scale: f32,
         load: wgpu::LoadOp<wgpu::Color>,
     ) -> Result<()> {
+        ensure!(
+            target_px.0 > 0 && target_px.1 > 0 && scale.is_finite() && scale > 0.0,
+            "invalid GPU viewport/scale"
+        );
+        let mut at = 0;
+        while at < words.len() {
+            let len = pocketjs_core::compositor::draw_op_len(words, at)
+                .ok_or_else(|| anyhow::anyhow!("invalid DrawList at word {at}"))?;
+            at = at
+                .checked_add(len)
+                .filter(|end| *end <= words.len())
+                .ok_or_else(|| anyhow::anyhow!("truncated DrawList"))?;
+        }
         self.sync_textures(gpu, ui);
         self.build_batches(words, target_px, scale);
 
@@ -347,6 +415,10 @@ impl UiRenderer {
                         None => continue,
                     }
                 }
+                TexBind::Surface(handle) => match self.surfaces.get(&handle) {
+                    Some(surface) => &surface.bind,
+                    None => continue,
+                },
                 TexBind::Image(handle) => {
                     // Generation-tagged handle → slot; draw only while the
                     // cached entry is for this exact handle. A stale handle
@@ -446,6 +518,9 @@ impl UiRenderer {
         while i < words.len() {
             match words[i] {
                 spec::draw_op::RECT => {
+                    if cur_tex != TexBind::White {
+                        flush!(TexBind::White, scissor);
+                    }
                     if i + 4 > words.len() {
                         break;
                     }
@@ -466,6 +541,9 @@ impl UiRenderer {
                     i += 4;
                 }
                 spec::draw_op::GRAD_RECT => {
+                    if cur_tex != TexBind::White {
+                        flush!(TexBind::White, scissor);
+                    }
                     if i + 6 > words.len() {
                         break;
                     }
@@ -651,8 +729,47 @@ impl UiRenderer {
                     i += 8 + (words[i + 7] as usize).div_ceil(4);
                 }
                 spec::draw_op::SURFACE_QUAD => {
-                    if i + 9 > words.len() {
-                        break;
+                    let handle = words[i + 1];
+                    if let Some(surface) = self.surfaces.get(&handle) {
+                        let logical = surface.logical;
+                        let (x, y) = (f32::from_bits(words[i + 2]), f32::from_bits(words[i + 3]));
+                        let w = f32::from_bits(words[i + 4]).min(logical.0 as f32);
+                        let h = f32::from_bits(words[i + 5]).min(logical.1 as f32);
+                        if x.is_finite()
+                            && y.is_finite()
+                            && w.is_finite()
+                            && h.is_finite()
+                            && w > 0.0
+                            && h > 0.0
+                            && logical.0 > 0
+                            && logical.1 > 0
+                        {
+                            let saved = scissor;
+                            let (cx, cy) = xy(words[i + 6]);
+                            let (cw, ch) = wh(words[i + 7]);
+                            let x0 = (cx.max(0.0).ceil() as u32).max(saved.0).min(target_px.0);
+                            let y0 = (cy.max(0.0).ceil() as u32).max(saved.1).min(target_px.1);
+                            let x1 = ((cx + cw).max(0.0).ceil() as u32)
+                                .min(saved.0 + saved.2)
+                                .min(target_px.0);
+                            let y1 = ((cy + ch).max(0.0).ceil() as u32)
+                                .min(saved.1 + saved.3)
+                                .min(target_px.1);
+                            flush!(
+                                TexBind::Surface(handle),
+                                (x0, y0, x1.saturating_sub(x0), y1.saturating_sub(y0))
+                            );
+                            quad(
+                                &mut self.verts,
+                                [x * s, y * s],
+                                [(x + w) * s, (y + h) * s],
+                                [0.0, 0.0],
+                                [w / logical.0 as f32, h / logical.1 as f32],
+                                [0xffffffff; 4],
+                                MODE_IMAGE,
+                            );
+                            flush!(TexBind::White, saved);
+                        }
                     }
                     i += 9;
                 }
@@ -674,29 +791,30 @@ impl UiRenderer {
 
     // ---- texture sync ---------------------------------------------------------
 
-    /// Mirror the core's textures into GPU resources. Font atlases are
-    /// append-only; image slots are not — `freeTexture` empties a slot and
+    /// Mirror the core's textures into GPU resources. Both font and image
+    /// slots have content revisions; `freeTexture` empties a slot and
     /// a later upload reuses it under a new generation-tagged handle, so
     /// each slot re-uploads whenever its current handle or content revision
     /// changes and drops its cache entry when the core frees it.
     fn sync_textures(&mut self, gpu: &Gpu, ui: &Ui) {
-        // Font slots. A slot re-uploads when its glyph count moved — hosts
-        // may extend an atlas at runtime (IME input rasterizing new
-        // codepoints) and reload it via loadFontAtlas.
+        // Replacements can change coverage or metrics without changing the
+        // glyph count (theme switch or runtime glyph delivery).
         if self.fonts.len() < spec::MAX_FONT_SLOTS {
             self.fonts.resize_with(spec::MAX_FONT_SLOTS, || None);
         }
         for slot in 0..spec::MAX_FONT_SLOTS as u8 {
             let Some(atlas) = ui.font_atlas(slot) else {
+                self.fonts[slot as usize] = None;
                 continue;
             };
             if self.fonts[slot as usize]
                 .as_ref()
-                .is_some_and(|f| f.glyph_count == atlas.glyph_count)
+                .is_some_and(|f| f.revision == ui.font_atlas_revision(slot))
             {
                 continue;
             }
-            self.fonts[slot as usize] = Some(self.upload_font(gpu, atlas));
+            self.fonts[slot as usize] =
+                Some(self.upload_font(gpu, atlas, ui.font_atlas_revision(slot)));
         }
         // Image texture slots.
         let slots = ui.texture_slot_count();
@@ -723,7 +841,12 @@ impl UiRenderer {
         }
     }
 
-    fn upload_font(&self, gpu: &Gpu, atlas: &pocketjs_core::text::Atlas) -> FontTexture {
+    fn upload_font(
+        &self,
+        gpu: &Gpu,
+        atlas: &pocketjs_core::text::Atlas,
+        revision: u64,
+    ) -> FontTexture {
         // Cells upload at coverage resolution (logical × raster density) —
         // a density-2 atlas keeps its full detail for scaled rendering.
         let (cov_w, cov_h) = (atlas.coverage_width(), atlas.coverage_height());
@@ -804,6 +927,7 @@ impl UiRenderer {
             tex_h: tex_h as f32,
             cols,
             glyph_count: atlas.glyph_count,
+            revision,
         }
     }
 
@@ -825,7 +949,7 @@ impl UiRenderer {
             mip_level_count: 1,
             sample_count: 1,
             dimension: wgpu::TextureDimension::D2,
-            format: wgpu::TextureFormat::Rgba8UnormSrgb,
+            format: self.image_format,
             usage: wgpu::TextureUsages::TEXTURE_BINDING | wgpu::TextureUsages::COPY_DST,
             view_formats: &[],
         });

--- a/engine/crates/pocket-ui-wgpu/src/shaders/ui.wgsl
+++ b/engine/crates/pocket-ui-wgpu/src/shaders/ui.wgsl
@@ -5,6 +5,8 @@
 // DrawList colors are sRGB-encoded bytes; linearize here so the sRGB target
 // re-encodes correctly on store.
 
+override LINEAR_OUTPUT: bool = true;
+
 struct VsIn {
     @location(0) pos: vec2f,
     @location(1) uv: vec2f,
@@ -41,7 +43,8 @@ fn srgb_to_linear(c: vec3f) -> vec3f {
 @fragment
 fn fs_main(in: VsOut) -> @location(0) vec4f {
     let t = textureSample(tex, samp, in.uv);
-    var rgb = srgb_to_linear(in.color.rgb);
+    var rgb = in.color.rgb;
+    if LINEAR_OUTPUT { rgb = srgb_to_linear(rgb); }
     var a = in.color.a;
     if in.mode == 1u {
         // Image: sRGB texture already sampled linear; modulate.

--- a/hosts/desktop/Cargo.lock
+++ b/hosts/desktop/Cargo.lock
@@ -20,6 +20,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -61,7 +67,7 @@ dependencies = [
  "log",
  "ndk",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "thiserror 2.0.20",
 ]
@@ -71,6 +77,15 @@ name = "android-properties"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "anstream"
@@ -164,16 +179,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175571dd1d178ced59193a6fc02dde1b972eb0bc56c892cde9beeceac5bf0f6b"
 
 [[package]]
+name = "ash"
+version = "0.38.0+1.3.281"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
+dependencies = [
+ "libloading",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -186,6 +237,15 @@ name = "bitflags"
 version = "2.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b588b76d00fde79687d7646a9b5bdf3cc0f655e0bbd080335a95d7e96f3587da"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block2"
@@ -221,6 +281,18 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
 
 [[package]]
 name = "bytes"
@@ -285,6 +357,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
 dependencies = [
  "error-code",
+]
+
+[[package]]
+name = "codespan-reporting"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe6d2e5af09e8c8ad56c969f2157a3d4238cebc7c55f0a517728c38f7b200f81"
+dependencies = [
+ "serde",
+ "termcolor",
+ "unicode-width",
 ]
 
 [[package]]
@@ -373,7 +456,7 @@ dependencies = [
  "linebender_resource_handle",
  "log",
  "rangemap",
- "rustc-hash",
+ "rustc-hash 2.1.3",
  "self_cell",
  "skrifa 0.40.0",
  "smol_str 0.3.6",
@@ -386,19 +469,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
-name = "ctor"
-version = "0.10.1"
+name = "crunchy"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83cf0d42651b16c6dfe68685716d18480d18a9c39c62d76e8cf3eb6ed5d8bcbf"
-dependencies = [
- "dtor",
-]
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "cursor-icon"
@@ -463,6 +552,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
 name = "downcast-rs"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -473,52 +571,6 @@ name = "dpi"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8b14ccef22fc6f5a8f4d7d768562a182c04ce9a3b3157b91390b52ddfdf1a76"
-
-[[package]]
-name = "drm"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80bc8c5c6c2941f70a55c15f8d9f00f9710ebda3ffda98075f996a0e6c92756f"
-dependencies = [
- "bitflags 2.13.1",
- "bytemuck",
- "drm-ffi",
- "drm-fourcc",
- "libc",
- "rustix 0.38.44",
-]
-
-[[package]]
-name = "drm-ffi"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51a91c9b32ac4e8105dec255e849e0d66e27d7c34d184364fb93e469db08f690"
-dependencies = [
- "drm-sys",
- "rustix 1.1.4",
-]
-
-[[package]]
-name = "drm-fourcc"
-version = "2.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aafbcdb8afc29c1a7ee5fbe53b5d62f4565b35a042a662ca9fecd0b54dae6f4"
-
-[[package]]
-name = "drm-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8e1361066d91f5ffccff060a3c3be9c3ecde15be2959c1937595f7a82a9f8"
-dependencies = [
- "libc",
- "linux-raw-sys 0.9.4",
-]
-
-[[package]]
-name = "dtor"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
 
 [[package]]
 name = "env_filter"
@@ -566,16 +618,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b5343afd4a8365a643ac588dab4cf234a190c7f6c88c9f6dd6ffe00837661b7"
 
 [[package]]
-name = "fastrand"
-version = "2.5.0"
+name = "fdeflate"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
 
 [[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+
+[[package]]
+name = "flate2"
+version = "1.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e634e2e0ebac1ee034020da1ca582e17ffe4e0f5e985823721e168928136dcb"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide 0.9.1",
+ "zlib-rs",
+]
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -600,6 +672,12 @@ checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
 dependencies = [
  "bytemuck",
 ]
+
+[[package]]
+name = "font8x8"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "875488b8711a968268c7cf5d139578713097ca4635a76044e8fe8eedf831d07e"
 
 [[package]]
 name = "fontdb"
@@ -699,10 +777,153 @@ dependencies = [
 ]
 
 [[package]]
+name = "gl_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a95dfc23a2b4a9a2f5ab41d194f8bfda3cabec42af4e39f08c339eb2a0c124d"
+dependencies = [
+ "khronos_api",
+ "log",
+ "xml-rs",
+]
+
+[[package]]
+name = "glam"
+version = "0.33.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e762b9b188634fc508d4ec54b62ea3d352c43fd431d18d05d46f559f217f4725"
+dependencies = [
+ "libm",
+]
+
+[[package]]
+name = "glow"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5e5ea60d70410161c8bf5da3fdfeaa1c72ed2c15f8bbb9d19fe3a4fad085f08"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "gltf"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ce1918195723ce6ac74e80542c5a96a40c2b26162c1957a5cd70799b8cacf7"
+dependencies = [
+ "base64 0.13.1",
+ "byteorder",
+ "gltf-json",
+ "image",
+ "lazy_static",
+ "serde_json",
+ "urlencoding",
+]
+
+[[package]]
+name = "gltf-derive"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "14070e711538afba5d6c807edb74bcb84e5dbb9211a3bf5dea0dfab5b24f4c51"
+dependencies = [
+ "inflections",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "gltf-json"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6176f9d60a7eab0a877e8e96548605dedbde9190a7ae1e80bbcc1c9af03ab14"
+dependencies = [
+ "gltf-derive",
+ "serde",
+ "serde_derive",
+ "serde_json",
+]
+
+[[package]]
+name = "glutin_wgl_sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c4ee00b289aba7a9e5306d57c2d05499b2e5dc427f84ac708bd2c090212cf3e"
+dependencies = [
+ "gl_generator",
+]
+
+[[package]]
+name = "gpu-alloc"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45cf04b2726f02df5508c6de726acdc90cdf97ac771a9a0ffd8ba10a6e696bf9"
+dependencies = [
+ "bitflags 2.13.1",
+ "gpu-alloc-types",
+]
+
+[[package]]
+name = "gpu-alloc-types"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bbed164dd10ed526c2e4fe3e721ca4a71c61730e5aafac6844b417b3227058"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
+name = "gpu-allocator"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c151a2a5ef800297b4e79efa4f4bec035c5f51d5ae587287c9b952bdf734cacd"
+dependencies = [
+ "log",
+ "presser",
+ "thiserror 1.0.69",
+ "windows",
+]
+
+[[package]]
+name = "gpu-descriptor"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b89c83349105e3732062a895becfc71a8f921bb71ecbbdd8ff99263e3b53a0ca"
+dependencies = [
+ "bitflags 2.13.1",
+ "gpu-descriptor-types",
+ "hashbrown 0.15.5",
+]
+
+[[package]]
+name = "gpu-descriptor-types"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdf242682df893b86f33a73828fb09ca4b2d3bb6cc95249707fc684d27484b91"
+dependencies = [
+ "bitflags 2.13.1",
+]
+
+[[package]]
 name = "grid"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b40ca9252762c466af32d0b1002e91e4e1bc5398f77455e55474deb466355ff5"
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "num-traits",
+ "zerocopy",
+]
 
 [[package]]
 name = "harfrust"
@@ -719,14 +940,29 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hermit-abi"
@@ -735,14 +971,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
+name = "hexf-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa686283ad6dd069f105e5ab091b04c62850d3e4cf5d67debad1933f55023df"
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown",
+ "hashbrown 0.17.1",
 ]
+
+[[package]]
+name = "inflections"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a257582fdcde896fd96463bf2d40eefea0580021c0712a0e2b028b60b47a837a"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -872,6 +1135,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "khronos-egl"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
+dependencies = [
+ "libc",
+ "libloading",
+ "pkg-config",
+]
+
+[[package]]
+name = "khronos_api"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2db585e1d738fc771bf08a151420d3ed193d9d895a36df7f6f8a9456b911ddc"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.189"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,15 +1205,15 @@ checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
-
-[[package]]
-name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -945,6 +1231,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -960,6 +1255,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "metal"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f569fb946490b5743ad69813cb19629130ce9374034abe31614a36402d18f99e"
+dependencies = [
+ "bitflags 2.13.1",
+ "block",
+ "core-graphics-types",
+ "foreign-types",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63fbc4a50860e98e7b2aa7804ded1db5cbc3aff9193adaff57a6931bf7c4b4c"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "naga"
+version = "25.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b977c445f26e49757f9aca3631c3b8b836942cb278d69a92e7b80d3b24da632"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "codespan-reporting",
+ "half",
+ "hashbrown 0.15.5",
+ "hexf-parse",
+ "indexmap",
+ "log",
+ "num-traits",
+ "once_cell",
+ "rustc-hash 1.1.0",
+ "spirv",
+ "strum",
+ "thiserror 2.0.20",
+ "unicode-ident",
+]
+
+[[package]]
 name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -968,7 +1333,7 @@ dependencies = [
  "bitflags 2.13.1",
  "jni-sys 0.3.1",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -982,11 +1347,30 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "ndk-sys"
 version = "0.6.0+11769913"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee6cda3051665f1fb8d9e08fc35c96d5a244fb1be711a03b71118828afc9a873"
 dependencies = [
  "jni-sys 0.3.1",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1009,6 +1393,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
 ]
 
 [[package]]
@@ -1049,7 +1442,7 @@ dependencies = [
  "objc2-core-data",
  "objc2-core-image",
  "objc2-foundation 0.2.2",
- "objc2-quartz-core 0.2.2",
+ "objc2-quartz-core",
 ]
 
 [[package]]
@@ -1227,18 +1620,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "objc2-quartz-core"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
-dependencies = [
- "bitflags 2.13.1",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-foundation 0.3.2",
-]
-
-[[package]]
 name = "objc2-symbols"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1263,7 +1644,7 @@ dependencies = [
  "objc2-core-location",
  "objc2-foundation 0.2.2",
  "objc2-link-presentation",
- "objc2-quartz-core 0.2.2",
+ "objc2-quartz-core",
  "objc2-symbols",
  "objc2-uniform-type-identifiers",
  "objc2-user-notifications",
@@ -1316,6 +1697,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "owned_ttf_parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1346,6 +1736,12 @@ dependencies = [
  "smallvec",
  "windows-link",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "percent-encoding"
@@ -1392,6 +1788,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.13.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide 0.8.9",
+]
+
+[[package]]
 name = "pocket-desktop-host"
 version = "0.1.0"
 dependencies = [
@@ -1402,10 +1811,12 @@ dependencies = [
  "pocket-mod",
  "pocket-text",
  "pocket-ui-surface",
+ "pocket-ui-wgpu",
+ "pocket3d",
  "pocketjs-core",
  "serde",
  "serde_json",
- "softbuffer",
+ "wgpu",
  "winit",
 ]
 
@@ -1423,7 +1834,7 @@ dependencies = [
 name = "pocket-text"
 version = "0.1.0"
 dependencies = [
- "base64",
+ "base64 0.22.1",
  "cosmic-text",
  "pocketjs-core",
  "serde",
@@ -1438,6 +1849,65 @@ dependencies = [
  "log",
  "pocket-mod",
  "pocketjs-core",
+]
+
+[[package]]
+name = "pocket-ui-wgpu"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "pocket-mod",
+ "pocket-ui-surface",
+ "pocket3d",
+ "pocketjs-core",
+ "serde_json",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
+name = "pocket3d"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "bytemuck",
+ "font8x8",
+ "glam",
+ "gltf",
+ "log",
+ "png",
+ "pocket3d-anim",
+ "pocket3d-bsp",
+ "pocket3d-mesh",
+ "pollster",
+ "serde_json",
+ "wgpu",
+ "winit",
+]
+
+[[package]]
+name = "pocket3d-anim"
+version = "0.1.0"
+dependencies = [
+ "glam",
+]
+
+[[package]]
+name = "pocket3d-bsp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "glam",
+ "log",
+]
+
+[[package]]
+name = "pocket3d-mesh"
+version = "0.1.0"
+dependencies = [
+ "glam",
+ "pocket3d-anim",
 ]
 
 [[package]]
@@ -1462,6 +1932,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pollster"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f3a9f18d041e6d0e102a0a46750538147e5e8992d3b4873aaafee2520b00ce3"
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1475,6 +1951,12 @@ checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
+
+[[package]]
+name = "presser"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8cf8e6a8aa66ce33f63993ffc4ea4271eb5b0530a9002db8455ea6050c77bfa"
 
 [[package]]
 name = "proc-macro-crate"
@@ -1493,6 +1975,18 @@ checksum = "985e7ec9bb745e6ce6535b544d84d6cd6f7ad8bd711c398938ae983b91a766d9"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+
+[[package]]
+name = "pxfm"
+version = "0.1.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-xml"
@@ -1523,6 +2017,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "range-alloc"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca45419789ae5a7899559e9512e58ca889e41f04f1f2445e9f4b290ceccd1d08"
 
 [[package]]
 name = "rangemap"
@@ -1624,6 +2124,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "renderdoc-sys"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
+
+[[package]]
 name = "rquickjs"
 version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1638,7 +2144,7 @@ version = "0.12.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16e4f499ac5b943d97ee6dbc44f23c2c10426f420f7d2f1793d6318911b6608c"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.17.1",
  "relative-path",
  "rquickjs-sys",
 ]
@@ -1651,6 +2157,12 @@ checksum = "a13ac243b86a74120814ef7e9e30ad5a2c1199b7b9963b1cf7c84e4cdc1cad99"
 dependencies = [
  "cc",
 ]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -1795,6 +2307,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "simd_cesu8"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,42 +2410,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4aaa7368fcf4852a4c2dd92df0cace6a71f2091ca0a23391ce7f3a31833f1523"
 
 [[package]]
-name = "softbuffer"
-version = "0.4.8"
+name = "spirv"
+version = "0.3.0+sdk-1.3.268.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
+checksum = "eda41003dc44290527a59b13432d4a0379379fa074b70174882adfbdfd917844"
 dependencies = [
- "as-raw-xcb-connection",
- "bytemuck",
- "drm",
- "fastrand",
- "js-sys",
- "memmap2",
- "ndk",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-core-graphics",
- "objc2-foundation 0.3.2",
- "objc2-quartz-core 0.3.2",
- "raw-window-handle",
- "redox_syscall 0.5.18",
- "rustix 1.1.4",
- "tiny-xlib",
- "tracing",
- "wasm-bindgen",
- "wayland-backend",
- "wayland-client",
- "wayland-sys",
- "web-sys",
- "windows-sys 0.61.2",
- "x11rb",
+ "bitflags 2.13.1",
 ]
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strict-num"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6637bab7722d379c8b41ba849228d680cc12d0a45ba1fa2b48f2a30577a06731"
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.119",
+]
 
 [[package]]
 name = "swash"
@@ -1981,6 +2504,15 @@ dependencies = [
  "grid",
  "serde",
  "slotmap",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06794f8f6c5c898b3275aebefa6b8a1cb24cd2c6c79397ab15774837a0bc5755"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -2046,19 +2578,6 @@ dependencies = [
  "arrayref",
  "bytemuck",
  "strict-num",
-]
-
-[[package]]
-name = "tiny-xlib"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a90a0ca3ee6a69f2ad28fd11621a4c3f03b371f366be500b64df260c4ffbafb4"
-dependencies = [
- "as-raw-xcb-connection",
- "ctor",
- "libloading",
- "pkg-config",
- "tracing",
 ]
 
 [[package]]
@@ -2160,6 +2679,18 @@ name = "unicode-segmentation"
 version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8parse"
@@ -2377,6 +2908,153 @@ dependencies = [
 ]
 
 [[package]]
+name = "wgpu"
+version = "25.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec8fb398f119472be4d80bc3647339f56eb63b2a331f6a3d16e25d8144197dd9"
+dependencies = [
+ "arrayvec",
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.15.5",
+ "js-sys",
+ "log",
+ "naga",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "smallvec",
+ "static_assertions",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "wgpu-core",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core"
+version = "25.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7b882196f8368511d613c6aeec80655160db6646aebddf8328879a88d54e500"
+dependencies = [
+ "arrayvec",
+ "bit-set",
+ "bit-vec",
+ "bitflags 2.13.1",
+ "cfg_aliases",
+ "document-features",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "log",
+ "naga",
+ "once_cell",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "raw-window-handle",
+ "rustc-hash 1.1.0",
+ "smallvec",
+ "thiserror 2.0.20",
+ "wgpu-core-deps-apple",
+ "wgpu-core-deps-emscripten",
+ "wgpu-core-deps-windows-linux-android",
+ "wgpu-hal",
+ "wgpu-types",
+]
+
+[[package]]
+name = "wgpu-core-deps-apple"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd488b3239b6b7b185c3b045c39ca6bf8af34467a4c5de4e0b1a564135d093d"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-emscripten"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f09ad7aceb3818e52539acc679f049d3475775586f3f4e311c30165cf2c00445"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-core-deps-windows-linux-android"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cba5fb5f7f9c98baa7c889d444f63ace25574833df56f5b817985f641af58e46"
+dependencies = [
+ "wgpu-hal",
+]
+
+[[package]]
+name = "wgpu-hal"
+version = "25.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f968767fe4d3d33747bbd1473ccd55bf0f6451f55d733b5597e67b5deab4ad17"
+dependencies = [
+ "android_system_properties",
+ "arrayvec",
+ "ash",
+ "bit-set",
+ "bitflags 2.13.1",
+ "block",
+ "bytemuck",
+ "cfg-if",
+ "cfg_aliases",
+ "core-graphics-types",
+ "glow",
+ "glutin_wgl_sys",
+ "gpu-alloc",
+ "gpu-allocator",
+ "gpu-descriptor",
+ "hashbrown 0.15.5",
+ "js-sys",
+ "khronos-egl",
+ "libc",
+ "libloading",
+ "log",
+ "metal",
+ "naga",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "objc",
+ "ordered-float",
+ "parking_lot",
+ "portable-atomic",
+ "profiling",
+ "range-alloc",
+ "raw-window-handle",
+ "renderdoc-sys",
+ "smallvec",
+ "thiserror 2.0.20",
+ "wasm-bindgen",
+ "web-sys",
+ "wgpu-types",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
+name = "wgpu-types"
+version = "25.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2aa49460c2a8ee8edba3fca54325540d904dd85b2e086ada762767e17d06e8bc"
+dependencies = [
+ "bitflags 2.13.1",
+ "bytemuck",
+ "js-sys",
+ "log",
+ "thiserror 2.0.20",
+ "web-sys",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,10 +3064,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd04d41d93c4992d421894c18c8b43496aa748dd4c081bac0dc93eb0489272b6"
+dependencies = [
+ "windows-core",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ba6d44ec8c2591c134257ce647b7ea6b20335bf6379a27dac5f1641fcf59f99"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-result",
+ "windows-strings",
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.58.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-result"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d1043d8214f791817bab27572aaa8af63732e11bf84aa21a45a78d6c317ae0e"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd9b125c486025df0eabcb585e62173c6c9eddcec5d117d3b6e8c30e2ee4d10"
+dependencies = [
+ "windows-result",
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -2607,6 +3349,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
+
+[[package]]
 name = "yazi"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2639,7 +3387,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "zlib-rs"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34b31d188d9d685a4f9c7b46d6e36631b07058d2cfe190267adce54dc230bf12"
+
+[[package]]
 name = "zmij"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29666d0abbfad1e3dc4dcf6144730dd3a3ab225bbbdac83319345b1b44ccfc1b"
+
+[[package]]
+name = "zune-core"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/hosts/desktop/Cargo.toml
+++ b/hosts/desktop/Cargo.toml
@@ -10,8 +10,10 @@ pocketjs-core = { path = "../../engine/core", features = ["std"] }
 pocket-mod = { path = "../../engine/crates/pocket-mod" }
 pocket-ui-surface = { path = "../../engine/crates/pocket-ui-surface" }
 pocket-text = { path = "../../engine/crates/pocket-text" }
+pocket-ui-wgpu = { path = "../../engine/crates/pocket-ui-wgpu" }
+pocket3d = { path = "../../engine/pocket3d/crates/pocket3d", default-features = false }
+wgpu = "25"
 winit = "0.30"
-softbuffer = "0.4"
 arboard = { version = "3", default-features = false }
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/hosts/desktop/src/gpu.rs
+++ b/hosts/desktop/src/gpu.rs
@@ -1,0 +1,330 @@
+//! GPU resources stay outside the guest ABI. The runtime worker records and
+//! submits rendering; the window thread presents a retained GPU image.
+use super::*;
+use pocket_ui_wgpu::{Blit, UiRenderer};
+use pocket3d::gpu::Gpu;
+use std::sync::{Arc, Weak};
+
+const FORMAT: wgpu::TextureFormat = wgpu::TextureFormat::Rgba8Unorm;
+const FRAME_TARGETS: usize = 3;
+
+pub struct Target {
+    pub _texture: wgpu::Texture,
+    pub view: wgpu::TextureView,
+    pub size: (u32, u32),
+}
+impl Target {
+    fn new(gpu: &Gpu, size: (u32, u32)) -> Result<Self> {
+        let limit = gpu.device.limits().max_texture_dimension_2d;
+        anyhow::ensure!(
+            size.0 > 0 && size.1 > 0 && size.0 <= limit && size.1 <= limit,
+            "GPU target exceeds device limits: {size:?}"
+        );
+        let texture = gpu.device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("Pocket retained render target"),
+            size: wgpu::Extent3d {
+                width: size.0,
+                height: size.1,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: FORMAT,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&Default::default());
+        Ok(Self {
+            _texture: texture,
+            view,
+            size,
+        })
+    }
+}
+struct Child {
+    generation: u64,
+    target: Target,
+    renderer: UiRenderer,
+    hash: Option<u64>,
+}
+pub struct Renderer {
+    gpu: Arc<Gpu>,
+    shell: UiRenderer,
+    children: HashMap<u32, Child>,
+    frames: Vec<Arc<Target>>,
+}
+impl Renderer {
+    pub fn new(gpu: Arc<Gpu>) -> Self {
+        Self {
+            shell: UiRenderer::new(&gpu, FORMAT),
+            gpu,
+            children: HashMap::new(),
+            frames: Vec::new(),
+        }
+    }
+    fn acquire_target(&mut self, size: (u32, u32)) -> Result<Option<Arc<Target>>> {
+        if self.frames.first().is_some_and(|frame| frame.size != size) {
+            self.frames.clear();
+        }
+        let index = if let Some(i) = self
+            .frames
+            .iter()
+            .position(|frame| Arc::strong_count(frame) == 1)
+        {
+            i
+        } else if self.frames.len() < FRAME_TARGETS {
+            self.frames.push(Arc::new(Target::new(&self.gpu, size)?));
+            self.frames.len() - 1
+        } else {
+            return Ok(None); // bounded backpressure; the next tick supplies the latest state
+        };
+        Ok(Some(self.frames[index].clone()))
+    }
+    /// A target remains leased until presentation has submitted its sampling
+    /// commands. Shared queue ordering then makes reuse safe without readback
+    /// or waiting for GPU completion on either CPU thread.
+    pub fn render(&mut self, runtime: &mut Runtime) -> Result<Option<Arc<Target>>> {
+        let density = runtime.args.density;
+        let size = (runtime.viewport.0 * density, runtime.viewport.1 * density);
+        let Some(frame) = self.acquire_target(size)? else {
+            return Ok(None);
+        };
+        let active: HashSet<u32> = runtime
+            .supervisor
+            .instances
+            .iter()
+            .filter(|child| child.state != AppInstanceState::Failed)
+            .map(|child| child.surface_handle)
+            .collect();
+        self.children.retain(|handle, _| active.contains(handle));
+        self.shell
+            .retain_surfaces(|handle| active.contains(&handle));
+        let mut encoder = self
+            .gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Pocket runtime frame"),
+            });
+        for instance in &runtime.supervisor.instances {
+            if !instance.visible || instance.state == AppInstanceState::Failed {
+                continue;
+            }
+            let logical = instance.package.plan.viewport.logical;
+            let child_size = (logical[0] * density, logical[1] * density);
+            if !self
+                .children
+                .get(&instance.surface_handle)
+                .is_some_and(|child| {
+                    child.target.size == child_size && child.generation == instance.generation
+                })
+            {
+                let target = Target::new(&self.gpu, child_size)?;
+                self.shell.set_surface(
+                    &self.gpu,
+                    instance.surface_handle,
+                    &target.view,
+                    (logical[0], logical[1]),
+                );
+                self.children.insert(
+                    instance.surface_handle,
+                    Child {
+                        generation: instance.generation,
+                        target,
+                        renderer: UiRenderer::new(&self.gpu, FORMAT),
+                        hash: None,
+                    },
+                );
+            }
+            let child = self.children.get_mut(&instance.surface_handle).unwrap();
+            instance.surface.with_ui(|ui| -> Result<()> {
+                let words = ui.draw().words.clone();
+                let hash = fnv1a64(&words) ^ ui.raster_revision().rotate_left(7);
+                if child.hash != Some(hash) {
+                    child.renderer.render_words_scaled(
+                        &self.gpu,
+                        ui,
+                        &words,
+                        &mut encoder,
+                        &child.target.view,
+                        child_size,
+                        density as f32,
+                        wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                    )?;
+                    child.hash = Some(hash);
+                }
+                Ok(())
+            })?;
+        }
+        runtime.surface.with_ui(|ui| -> Result<()> {
+            let words = ui.draw().words.clone();
+            self.shell.render_words_scaled(
+                &self.gpu,
+                ui,
+                &words,
+                &mut encoder,
+                &frame.view,
+                size,
+                density as f32,
+                wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+            )
+        })?;
+        self.gpu.queue.submit([encoder.finish()]);
+        Ok(Some(frame))
+    }
+}
+
+pub struct Presentation {
+    pub gpu: Arc<Gpu>,
+    surface: wgpu::Surface<'static>,
+    config: wgpu::SurfaceConfiguration,
+    blits: Vec<(Weak<Target>, Blit)>,
+}
+impl Presentation {
+    pub fn new(window: Arc<Window>) -> Result<Self> {
+        let instance = Gpu::new_instance();
+        let surface = instance.create_surface(window.clone())?;
+        let gpu = Arc::new(Gpu::from_instance_for_surface_with_power_preference(
+            instance,
+            &surface,
+            wgpu::PowerPreference::LowPower,
+        )?);
+        let caps = surface.get_capabilities(&gpu.adapter);
+        // Encoded byte-space color matches package colors and the portable
+        // rasterizer. Avoid an additional sRGB conversion on final presentation.
+        let format = [
+            wgpu::TextureFormat::Bgra8Unorm,
+            wgpu::TextureFormat::Rgba8Unorm,
+        ]
+        .into_iter()
+        .find(|format| caps.formats.contains(format))
+        .ok_or_else(|| anyhow!("GPU surface has no portable 8-bit color format"))?;
+        let size = window.inner_size();
+        let config = wgpu::SurfaceConfiguration {
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT,
+            format,
+            width: size.width.max(1),
+            height: size.height.max(1),
+            present_mode: wgpu::PresentMode::Fifo,
+            desired_maximum_frame_latency: 1,
+            alpha_mode: wgpu::CompositeAlphaMode::Auto,
+            view_formats: vec![],
+        };
+        surface.configure(&gpu.device, &config);
+        let info = gpu.adapter.get_info();
+        log::info!(
+            "Pocket UI GPU: {:?} / {} / {:?}",
+            info.backend,
+            info.name,
+            format
+        );
+        Ok(Self {
+            gpu,
+            surface,
+            config,
+            blits: Vec::new(),
+        })
+    }
+    pub fn present(&mut self, window: &Window, target: &Arc<Target>) -> Result<bool> {
+        let size = window.inner_size();
+        if size.width == 0 || size.height == 0 {
+            return Ok(false);
+        }
+        if (self.config.width, self.config.height) != (size.width, size.height) {
+            self.config.width = size.width;
+            self.config.height = size.height;
+            self.surface.configure(&self.gpu.device, &self.config);
+        }
+        let output = match self.surface.get_current_texture() {
+            Ok(output) => output,
+            Err(wgpu::SurfaceError::Lost | wgpu::SurfaceError::Outdated) => {
+                self.surface.configure(&self.gpu.device, &self.config);
+                window.request_redraw();
+                return Ok(false);
+            }
+            Err(wgpu::SurfaceError::Timeout) => {
+                window.request_redraw();
+                return Ok(false);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        // Weak identities retain bind groups without leasing a frame from the
+        // worker's bounded pool. Rebuild only when the pool changes on resize.
+        self.blits.retain(|(frame, _)| frame.strong_count() > 0);
+        let key = Arc::downgrade(target);
+        let index = match self
+            .blits
+            .iter()
+            .position(|(frame, _)| Weak::ptr_eq(frame, &key))
+        {
+            Some(index) => index,
+            None => {
+                let blit = Blit::new(
+                    &self.gpu,
+                    &target.view,
+                    self.config.format,
+                    wgpu::FilterMode::Nearest,
+                    false,
+                );
+                self.blits.push((key, blit));
+                self.blits.len() - 1
+            }
+        };
+        let view = output.texture.create_view(&Default::default());
+        let mut encoder = self
+            .gpu
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("Pocket present"),
+            });
+        {
+            let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+                label: Some("Pocket present"),
+                color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                    view: &view,
+                    resolve_target: None,
+                    ops: wgpu::Operations {
+                        load: wgpu::LoadOp::Clear(wgpu::Color::BLACK),
+                        store: wgpu::StoreOp::Store,
+                    },
+                })],
+                depth_stencil_attachment: None,
+                timestamp_writes: None,
+                occlusion_query_set: None,
+            });
+            self.blits[index].1.draw(&mut pass);
+        }
+        self.gpu.queue.submit([encoder.finish()]);
+        window.pre_present_notify();
+        output.present();
+        Ok(true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    #[ignore = "requires a GPU; run with --ignored on GPU acceptance hosts"]
+    fn retained_targets_bound_leases_and_survive_resize() {
+        let gpu = Arc::new(Gpu::new_headless().unwrap());
+        let mut renderer = Renderer::new(gpu);
+        let first = renderer.acquire_target((32, 32)).unwrap().unwrap();
+        let second = renderer.acquire_target((32, 32)).unwrap().unwrap();
+        let third = renderer.acquire_target((32, 32)).unwrap().unwrap();
+        assert!(renderer.acquire_target((32, 32)).unwrap().is_none());
+        let identity = Arc::downgrade(&first);
+        drop(first);
+        let reused = renderer.acquire_target((32, 32)).unwrap().unwrap();
+        assert!(Weak::ptr_eq(&identity, &Arc::downgrade(&reused)));
+        let resized = renderer.acquire_target((64, 48)).unwrap().unwrap();
+        assert_eq!(resized.size, (64, 48));
+        assert_eq!(second.size, (32, 32));
+        assert_eq!(third.size, (32, 32));
+        assert_eq!(renderer.frames.len(), 1);
+        assert!(renderer.acquire_target((0, 0)).is_err());
+    }
+}

--- a/hosts/desktop/src/main.rs
+++ b/hosts/desktop/src/main.rs
@@ -1,20 +1,21 @@
-//! Native platform adapter: window, input, clipboard and pixel presentation.
-//! Guests, layout, composition and rasterization belong to the runtime worker.
+//! Native platform adapter: window, input, clipboard and GPU presentation.
+//! Guests, layout, composition and GPU recording belong to the runtime worker.
 //! Text capabilities run in separately budgeted io.offload workers. No platform
 //! text system participates in layout, shaping or drawing.
 use anyhow::{Context as _, Result, anyhow};
 use pocket_mod::Guest;
 use pocket_ui_surface::{UiSurface, offload::OffloadWorker};
-use pocketjs_core::compositor::{self, CompositorRaster};
 use serde::Deserialize;
 use serde_json::{Value, json};
 use std::{
     cmp::Reverse,
     collections::{HashMap, HashSet, VecDeque},
-    num::NonZeroU32,
     path::PathBuf,
-    rc::Rc,
     sync::mpsc::{Receiver, SyncSender, sync_channel},
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
     thread,
     time::{Duration, Instant},
 };
@@ -26,6 +27,7 @@ use winit::{
     keyboard::{Key, ModifiersState, NamedKey},
     window::{CursorIcon, Window, WindowId},
 };
+mod gpu;
 mod net;
 include!("plan.rs");
 include!("supervisor.rs");
@@ -47,10 +49,25 @@ enum Input {
     Reset,
     Quit,
 }
+// Reservation covers queued GPU work as well as the output channel.
+struct OutputPermit(Arc<AtomicBool>);
+impl OutputPermit {
+    fn acquire(available: &Arc<AtomicBool>) -> Option<Self> {
+        available
+            .compare_exchange(true, false, Ordering::AcqRel, Ordering::Acquire)
+            .ok()
+            .map(|_| Self(available.clone()))
+    }
+}
+impl Drop for OutputPermit {
+    fn drop(&mut self) {
+        self.0.store(true, Ordering::Release);
+    }
+}
 struct Output {
-    pixels: Option<Vec<u32>>,
-    width: u32,
-    height: u32,
+    _permit: OutputPermit,
+    tick: u64,
+    target: Option<Arc<gpu::Target>>,
     intents: Vec<Value>,
 }
 #[derive(Debug)]
@@ -242,48 +259,7 @@ impl Runtime {
         self.surface
             .with_ui(|ui| fnv1a64(&ui.draw().words) ^ ui.raster_revision().rotate_left(7))
             ^ self.supervisor.visible_hash().rotate_left(17)
-    }
-    fn render(&mut self) -> Vec<u32> {
-        let mut surfaces = vec![None; self.supervisor.catalog.len() + 1];
-        for instance in &self.supervisor.instances {
-            if !instance.visible || instance.state == AppInstanceState::Failed {
-                continue;
-            }
-            let (w, h) = (
-                instance.package.plan.viewport.logical[0],
-                instance.package.plan.viewport.logical[1],
-            );
-            let density = self.args.density;
-            let mut pixels = vec![0u8; (w * density) as usize * (h * density) as usize * 4];
-            instance.surface.with_ui(|ui| {
-                let words = ui.draw().words.clone();
-                pocketjs_core::raster::render_scaled(ui, &words, &mut pixels, density);
-            });
-            let handle = instance.surface_handle as usize;
-            if surfaces.len() <= handle {
-                surfaces.resize(handle + 1, None);
-            }
-            surfaces[handle] = Some(CompositorRaster {
-                pixels,
-                width: w,
-                height: h,
-                density,
-            });
-        }
-        let (w, h) = (
-            self.viewport.0 * self.args.density,
-            self.viewport.1 * self.args.density,
-        );
-        let mut rgba = vec![0u8; w as usize * h as usize * 4];
-        self.surface.with_ui(|ui| {
-            let words = ui.draw().words.clone();
-            compositor::render(ui, &words, &mut rgba, self.args.density, &surfaces);
-        });
-        rgba.as_chunks::<4>()
-            .0
-            .iter()
-            .map(|p| (p[0] as u32) << 16 | (p[1] as u32) << 8 | p[2] as u32)
-            .collect()
+            ^ ((self.viewport.0 as u64) << 32 | self.viewport.1 as u64)
     }
     fn run_script(&mut self) {
         let tick = self.ticks;
@@ -345,7 +321,10 @@ fn run_runtime(
     inputs: Receiver<Input>,
     outputs: SyncSender<Output>,
     proxy: EventLoopProxy<Wake>,
+    gpu: Arc<pocket3d::gpu::Gpu>,
 ) -> Result<()> {
+    let available = Arc::new(AtomicBool::new(true));
+    let mut renderer = gpu::Renderer::new(gpu);
     let mut runtime = Runtime::boot(args)?;
     let mut hash = None;
     let mut intents = Vec::new();
@@ -356,7 +335,9 @@ fn run_runtime(
                 return Ok(());
             }
         }
+        let work_start = Instant::now();
         intents.extend(runtime.tick()?);
+        trace_frame(runtime.args.trace_frames, "tick", runtime.ticks, work_start);
         if intents.iter().any(|v| v["t"] == "quit") {
             return Ok(());
         }
@@ -364,26 +345,41 @@ fn run_runtime(
             return Err(anyhow!("Host intent queue exceeded budget"));
         }
         let next = runtime.hash();
-        if hash != Some(next) || !intents.is_empty() {
+        if (hash != Some(next) || !intents.is_empty())
+            && let Some(permit) = OutputPermit::acquire(&available)
+        {
+            let target = if hash != Some(next) {
+                let start = Instant::now();
+                let frame = renderer.render(&mut runtime)?;
+                trace_frame(
+                    runtime.args.trace_frames,
+                    "render-submit",
+                    runtime.ticks,
+                    start,
+                );
+                frame
+            } else {
+                None
+            };
+            let rendered = target.is_some();
             let output = Output {
-                pixels: if hash != Some(next) {
-                    Some(runtime.render())
-                } else {
-                    None
-                },
-                width: runtime.viewport.0 * runtime.args.density,
-                height: runtime.viewport.1 * runtime.args.density,
+                _permit: permit,
+                tick: runtime.ticks,
+                target,
                 intents: std::mem::take(&mut intents),
             };
             match outputs.try_send(output) {
                 Ok(()) => {
-                    hash = Some(next);
+                    if rendered {
+                        hash = Some(next);
+                    }
                     let _ = proxy.send_event(Wake::Output);
                 }
                 Err(std::sync::mpsc::TrySendError::Full(output)) => intents = output.intents,
                 Err(_) => return Ok(()),
             }
         }
+        trace_frame(runtime.args.trace_frames, "work", runtime.ticks, work_start);
         if runtime
             .args
             .quit_after_ticks
@@ -399,13 +395,20 @@ fn run_runtime(
         }
     }
 }
+struct RuntimeStartup {
+    args: Args,
+    inputs: Receiver<Input>,
+    outputs: SyncSender<Output>,
+    proxy: EventLoopProxy<Wake>,
+}
 struct Host {
-    window: Option<Rc<Window>>,
-    surface: Option<softbuffer::Surface<Rc<Window>, Rc<Window>>>,
+    window: Option<Arc<Window>>,
+    surface: Option<gpu::Presentation>,
+    startup: Option<RuntimeStartup>,
     tx: SyncSender<Input>,
     rx: Receiver<Output>,
     pending: VecDeque<Input>,
-    frame: Option<Output>,
+    frame: Option<(u64, Arc<gpu::Target>)>,
     title: String,
     viewport: (u32, u32),
     fixed: bool,
@@ -416,6 +419,7 @@ struct Host {
     clipboard: Option<arboard::Clipboard>,
     ready: bool,
     announce_ready: bool,
+    trace_frames: bool,
     failure: Option<String>,
 }
 impl Host {
@@ -478,29 +482,12 @@ impl Host {
         else {
             return Ok(());
         };
-        let Some(pixels) = &frame.pixels else {
-            return Ok(());
-        };
-        let size = window.inner_size();
-        if size.width == 0 || size.height == 0 {
+        let (tick, target) = frame;
+        let start = Instant::now();
+        if !surface.present(window, target)? {
             return Ok(());
         }
-        surface
-            .resize(
-                NonZeroU32::new(size.width).unwrap(),
-                NonZeroU32::new(size.height).unwrap(),
-            )
-            .map_err(|e| anyhow!(e.to_string()))?;
-        let mut buffer = surface.buffer_mut().map_err(|e| anyhow!(e.to_string()))?;
-        for y in 0..size.height {
-            for x in 0..size.width {
-                let sx = (x as u64 * frame.width as u64 / size.width as u64) as usize;
-                let sy = (y as u64 * frame.height as u64 / size.height as u64) as usize;
-                buffer[y as usize * size.width as usize + x as usize] =
-                    pixels[sy * frame.width as usize + sx];
-            }
-        }
-        buffer.present().map_err(|e| anyhow!(e.to_string()))?;
+        trace_frame(self.trace_frames, "present-submit", *tick, start);
         if !self.ready {
             self.ready = true;
             if self.announce_ready {
@@ -515,7 +502,7 @@ impl ApplicationHandler<Wake> for Host {
         if self.window.is_some() {
             return;
         }
-        let window = Rc::new(
+        let window = Arc::new(
             event_loop
                 .create_window(
                     Window::default_attributes()
@@ -526,9 +513,35 @@ impl ApplicationHandler<Wake> for Host {
                 .expect("create window"),
         );
         window.set_ime_allowed(true);
-        let context = softbuffer::Context::new(window.clone()).expect("pixel context");
-        self.surface =
-            Some(softbuffer::Surface::new(&context, window.clone()).expect("pixel surface"));
+        let presentation = match gpu::Presentation::new(window.clone()) {
+            Ok(presentation) => presentation,
+            Err(error) => {
+                self.failure = Some(format!("GPU initialization: {error:#}"));
+                event_loop.exit();
+                return;
+            }
+        };
+        let gpu = presentation.gpu.clone();
+        self.surface = Some(presentation);
+        let RuntimeStartup {
+            args,
+            inputs,
+            outputs,
+            proxy,
+        } = self.startup.take().expect("runtime startup");
+        if let Err(error) = thread::Builder::new()
+            .name("pocket-runtime".into())
+            .spawn(move || {
+                let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                    run_runtime(args, inputs, outputs, proxy.clone(), gpu)
+                }))
+                .unwrap_or_else(|_| Err(anyhow!("Runtime worker panicked")));
+                let _ = proxy.send_event(Wake::Exit(result.err().map(|e| format!("{e:#}"))));
+            })
+        {
+            self.failure = Some(format!("Runtime startup: {error}"));
+            event_loop.exit();
+        }
         self.window = Some(window);
     }
     fn user_event(&mut self, event_loop: &ActiveEventLoop, event: Wake) {
@@ -587,8 +600,8 @@ impl ApplicationHandler<Wake> for Host {
                             _ => {}
                         }
                     }
-                    if output.pixels.is_some() {
-                        self.frame = Some(output);
+                    if let Some(target) = output.target.take() {
+                        self.frame = Some((output.tick, target));
                         if let Some(window) = &self.window {
                             window.request_redraw();
                         }
@@ -616,6 +629,7 @@ impl ApplicationHandler<Wake> for Host {
             WindowEvent::RedrawRequested => {
                 if let Err(error) = self.present() {
                     log::error!("{error}");
+                    self.failure = Some(error.to_string());
                     event_loop.exit();
                 }
             }
@@ -625,6 +639,7 @@ impl ApplicationHandler<Wake> for Host {
                     (size.width as f64 / scale).round().clamp(240.0, 4096.0) as u32,
                     (size.height as f64 / scale).round().clamp(180.0, 4096.0) as u32,
                 ));
+                self.window.as_ref().unwrap().request_redraw();
             }
             WindowEvent::ModifiersChanged(m) => self.modifiers = m.state(),
             WindowEvent::Focused(false) => {
@@ -710,6 +725,7 @@ fn main() -> Result<()> {
     let mut host = Host {
         window: None,
         surface: None,
+        startup: None,
         tx,
         rx,
         pending: VecDeque::new(),
@@ -724,23 +740,32 @@ fn main() -> Result<()> {
         clipboard: arboard::Clipboard::new().ok(),
         ready: false,
         announce_ready: args.announce_ready,
+        trace_frames: args.trace_frames,
         failure: None,
     };
-    let proxy = event_loop.create_proxy();
-    thread::Builder::new()
-        .name("pocket-runtime".into())
-        .spawn(move || {
-            let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                run_runtime(args, inputs, outputs, proxy.clone())
-            }))
-            .unwrap_or_else(|_| Err(anyhow!("Runtime worker panicked")));
-            let _ = proxy.send_event(Wake::Exit(result.err().map(|e| e.to_string())));
-        })?;
+    host.startup = Some(RuntimeStartup {
+        args,
+        inputs,
+        outputs,
+        proxy: event_loop.create_proxy(),
+    });
     event_loop.run_app(&mut host)?;
     if let Some(error) = host.failure {
         return Err(anyhow!(error));
     }
     Ok(())
+}
+
+// These are CPU submission durations, not GPU completion or display latency.
+fn trace_frame(enabled: bool, stage: &str, tick: u64, start: Instant) {
+    if enabled {
+        let elapsed = start.elapsed().as_micros();
+        let wall = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_micros();
+        eprintln!("FRAME_TRACE,{stage},{tick},{wall},{elapsed}");
+    }
 }
 
 include!("tests.rs");

--- a/hosts/desktop/src/plan.rs
+++ b/hosts/desktop/src/plan.rs
@@ -250,6 +250,8 @@ struct Args {
     /// Print "READY <epoch_ms>" on the first painted frame — the desktop
     /// benchmark runner's cold-start marker (PR #294). Off by default.
     announce_ready: bool,
+    /// Emit CPU stage timestamps for native frame profiling.
+    trace_frames: bool,
 }
 
 fn parse_args() -> Result<Args> {
@@ -271,6 +273,7 @@ fn parse_args() -> Result<Args> {
         quit_after_ticks: None,
         storm: None,
         announce_ready: false,
+        trace_frames: false,
     };
     let mut system_plan_path = None;
     let mut it = std::env::args().skip(1);
@@ -381,6 +384,7 @@ fn parse_args() -> Result<Args> {
             }
             "--quit-after" => args.quit_after_ticks = Some(val("--quit-after")?.parse()?),
             "--announce-ready" => args.announce_ready = true,
+            "--trace-frames" => args.trace_frames = true,
             "--press" => {
                 // --press NAME@TICK (console button script: up/down/left/
                 // right/cross/circle/square/triangle/l/r/start/select)

--- a/hosts/desktop/src/supervisor.rs
+++ b/hosts/desktop/src/supervisor.rs
@@ -5,6 +5,7 @@ struct AppCatalogEntry {
 }
 
 struct AppInstance {
+    generation: u64,
     package: SystemPackagePlan,
     surface_handle: u32,
     surface: UiSurface,
@@ -18,6 +19,7 @@ struct AppInstance {
 }
 
 struct AppSupervisor {
+    next_generation: u64,
     catalog: Vec<AppCatalogEntry>,
     instances: Vec<AppInstance>,
     suppressed: HashSet<u32>,
@@ -66,6 +68,7 @@ impl AppSupervisor {
     fn new(system: Option<&ResolvedSystemPlan>, shell: &UiSurface) -> Result<Self> {
         let Some(system) = system else {
             return Ok(Self {
+                next_generation: 0,
                 catalog: Vec::new(),
                 instances: Vec::new(),
                 suppressed: HashSet::new(),
@@ -89,6 +92,7 @@ impl AppSupervisor {
             });
         }
         Ok(Self {
+            next_generation: 0,
             catalog,
             instances: Vec::new(),
             suppressed: HashSet::new(),
@@ -137,7 +141,9 @@ impl AppSupervisor {
             return Err(anyhow!("{output} evaluated but installed no frame()"));
         }
 
+        self.next_generation += 1;
         self.instances.push(AppInstance {
+            generation: self.next_generation,
             package: entry.package.clone(),
             surface_handle: entry.surface_handle,
             surface,
@@ -307,7 +313,7 @@ impl AppSupervisor {
                 continue;
             }
             instance.surface.with_ui(|ui| {
-                let draw_hash = fnv1a64(&ui.draw().words);
+                let draw_hash = fnv1a64(&ui.draw().words) ^ instance.generation.rotate_left(23);
                 let raster_revision = ui.raster_revision();
                 mix_app_instance_repaint_hash(
                     &mut hash,

--- a/hosts/desktop/src/tests.rs
+++ b/hosts/desktop/src/tests.rs
@@ -3,6 +3,16 @@ mod tests {
     use super::*;
 
     #[test]
+    fn output_backpressure_reserves_before_gpu_submission() {
+        let available = Arc::new(AtomicBool::new(true));
+        let permit = OutputPermit::acquire(&available).unwrap();
+        assert!(OutputPermit::acquire(&available).is_none());
+        // Receipt/drop releases the slot even on presentation failure or exit.
+        drop(permit);
+        assert!(OutputPermit::acquire(&available).is_some());
+    }
+
+    #[test]
     fn app_supervisor_uses_lifecycle_focus_and_shell_painter_order() {
         let mut facts = [
             SchedulingFact {


### PR DESCRIPTION
Moving a System UI window currently rerasterizes a full CPU framebuffer and copies/resamples it through softbuffer. Restore native GPU drawing through the existing `pocket-ui-wgpu` backend and `pocket3d::gpu::Gpu`. No new crate, DrawList ABI, theme-specific host branch or platform text engine is introduced.

- Implement `SURFACE_QUAD` in painter order, with host-owned texture bindings outside each guest's image namespace. Cache child textures by instance generation, DrawList hash and resource revision.
- Keep guests/layout/GPU recording on the runtime worker. Present retained GPU targets on the window thread, with a three-target lease pool and output reservation before GPU submission. Recover outdated/lost surfaces; propagate fatal errors. Production presentation has no CPU framebuffer readback/copy.
- Preserve existing sRGB overlay behavior while UNORM desktop composition uses encoded byte-space blending. Invalidate font atlases on content replacement even when glyph counts match; prevent missing image binds from swallowing following solid rectangles.
- Add CPU frame traces, actual GPU readback fixtures and frame-pool lifetime tests. Install Mesa Vulkan in Linux GPU/release checks. WASM software, Vita/GXM and 3DS/PICA retain their existing dependency/capability boundaries.

Validation on Apple M3 Max: Metal readback at 1x/2x for all portable draw modes, clipping/composition, image formats and resource lifecycle; six native-host tests including GPU pool/resize; 130 core tests; renderer/host Clippy and rustfmt; Desktop System UI/WASM/text checks and release build; native Aqua drag and Hero open/close/reopen. Default 800x600 drag averaged ~0.23 ms CPU render submission and 0.10–0.15 ms CPU presentation submission, versus the software baseline's ~7.4 ms and ~6.8 ms. These are CPU durations, not GPU completion. Vita Hero VPK and 3DS demo 3DSX built; physical handheld acceptance remains separate.

Stacked on #390 (`feat/portable-desktop-offload`). This PR contains the GPU follow-up only; #390's existing conflict with main is not resolved by this stack. Pocket Desktop #10 pins the published GPU follow-up for manual acceptance.
