### PR TITLE
fix(skill): shorten the PocketJS video outro

### DIFF
--- a/skills/pocketjs-video-outro/SKILL.md
+++ b/skills/pocketjs-video-outro/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pocketjs-video-outro
-description: Append the current PocketJS animated end card to a local video (screen recording, demo capture, phone clip). Renders the dark brand card with the logo, wordmark, landing-page VT323 headline and pocketjs.dev, then crossfades it over the source while preserving and fading the original audio. Use when asked to add an outro / end card / 片尾, brand a recording, or produce a shareable PocketJS clip.
+description: Append a short PocketJS animated end card to a local video (screen recording, demo capture, phone clip). Renders the dark brand card with the logo, wordmark, landing-page VT323 headline and pocketjs.dev, then crossfades it over the source while preserving and fading the original audio. Use when asked to add an outro / end card / 片尾, brand a recording, or produce a shareable PocketJS clip.
 ---
 
 # PocketJS Video Outro
@@ -14,15 +14,20 @@ wordmark, and the uppercase VT323 headline. The default positioning is rendered 
 three deliberate lines: `UI FOR` / `EVERY KIND OF` / `COMPUTER`. The exact VT323
 font file is bundled with the skill, so card rendering does not depend on a network
 font request. Headless Chrome renders the layers, then `ffmpeg` crossfades the
-source into the card and animates the text in.
+source into the card and animates the text in. **The default card lasts 2.8 seconds,
+including a 0.35-second crossfade.** Use this short ending unless the user requests
+another duration; `--outro` and `--xfade` remain available for that choice.
 
 Design choices baked into the pipeline:
 
 - **Crossfade first, text second.** The source dissolves into the *empty* branded
   background; the type only starts animating once the transition has settled, so it
   never fights the crossfade.
-- **Staggered entrance.** Logo → tagline → URL, each fades in and eases up
-  (~20-30px, ease-out cubic), ~0.35s apart, then holds.
+- **Staggered entrance.** Logo → tagline → URL start 0.12 seconds apart after
+  the crossfade. Fades last 0.25 / 0.25 / 0.20 seconds, with a 12–20px rise at
+  1080p. The default card settles at 0.79 seconds and holds for about two seconds.
+  Short custom cards compress the entrance to leave at least half the time after
+  the transition for the complete lockup.
 - **Landing-page headline.** The positioning uses the same VT323 face, uppercase
   transform, `0.92` line height and `0.005em` tracking as the site hero. Preserve
   explicit line breaks instead of letting the browser choose the default lockup.
@@ -48,6 +53,7 @@ repo keeps command wrappers in Bun, not shell scripts):
 bun skills/pocketjs-video-outro/scripts/make-outro.ts -i ~/Downloads/clip.mov
 # writes ~/Downloads/clip_outro.mp4  (H.264 high, yuv420p, +faststart, AAC 192k)
 # default card: UI FOR / EVERY KIND OF / COMPUTER
+# 2.8-second card, including its 0.35-second transition
 # prints the output path on stdout; progress/summary on stderr
 ```
 
@@ -81,6 +87,9 @@ ffprobe -v error -select_streams v:0 \
 Do not report a finished video from command success alone. Verify four independent
 properties: full-file decode, delivery metadata, the visible card and its entrance,
 and body-versus-tail audio. Choose a body sample that contains source sound.
+The render log gives the crossfade offset. Subtract it from the final probed
+duration to check that the default ending stays below three seconds, including
+frame-rate rounding. A ten-second source produces about 12.45 seconds in total.
 
 ```bash
 OUTRO_VIDEO=~/Downloads/clip_outro.mp4
@@ -91,9 +100,9 @@ ffprobe -v error -select_streams v:0 \
   -of default=nw=1 "$OUTRO_VIDEO"
 ffmpeg -v error -y -sseof -0.6 -i "$OUTRO_VIDEO" \
   -frames:v 1 /tmp/pocketjs-outro-final.png
-ffmpeg -v error -y -sseof -6 -i "$OUTRO_VIDEO" \
-  -vf 'fps=4/3,scale=480:-2,tile=4x2' -frames:v 1 /tmp/pocketjs-outro-motion.jpg
-ffmpeg -hide_banner -ss 10 -t 5 -i "$OUTRO_VIDEO" \
+ffmpeg -v error -y -sseof -3 -i "$OUTRO_VIDEO" \
+  -vf 'fps=8,scale=240:-2,tile=6x4' -frames:v 1 /tmp/pocketjs-outro-motion.jpg
+ffmpeg -hide_banner -ss 2 -t 3 -i "$OUTRO_VIDEO" \
   -af volumedetect -f null - 2>&1 | rg 'mean_volume|max_volume'
 ffmpeg -hide_banner -sseof -2 -i "$OUTRO_VIDEO" \
   -af volumedetect -f null - 2>&1 | rg 'mean_volume|max_volume'
@@ -103,7 +112,9 @@ Inspect both images. The final frame must use the bundled VT323 face and show th
 requested copy without clipping; the motion sheet must show a clean crossfade and
 the logo → headline → URL stagger. HDR inputs must finish as `tv`, `yuv420p`, and
 `bt709/bt709/bt709`. The body sample must retain audio and the final two seconds
-must be effectively silent.
+must be effectively silent with the defaults. For a shorter custom card, sample
+only the tail after the original source has ended; that silent interval may be
+shorter than two seconds.
 
 ## Options
 
@@ -114,8 +125,8 @@ must be effectively silent.
 | `--tagline` | `UI for` / `every kind of` / `computer` | hero line; explicit newlines are preserved |
 | `--brand` | `PocketJS` | wordmark next to the glyph |
 | `--url` | `pocketjs.dev` | footer line; pass `--url ""` to hide it |
-| `--outro` | `5.5` | end-card length in seconds |
-| `--xfade` | `0.8` | crossfade length; text entrance keys off it |
+| `--outro` | `2.8` | end-card length in seconds, including the transition |
+| `--xfade` | `0.35` | crossfade length; must be shorter than the card; `0` cuts to it |
 | `--crf` / `--preset` | `18` / `medium` | x264 quality/speed |
 | `--x` / `--x-compatible` | off | emit an X-safe 30fps CFR social upload |
 
@@ -126,6 +137,8 @@ must be effectively silent.
   directly to FFmpeg, avoiding floating-point timebases.
 - By default the card uses the source's native resolution and selected frame rate.
   `--x` switches to 30 fps CFR and orientation-aware 1920x1080/1080x1900 bounds.
+- If the source is shorter than the requested crossfade, the transition uses the
+  source duration. The card entrance follows that effective transition time.
 - Display-matrix rotation is applied to the probed dimensions before rendering the
   card, matching FFmpeg's default autorotation for portrait phone footage.
 - **Color:** SDR inputs keep the existing path. HLG and PQ inputs (including the

--- a/skills/pocketjs-video-outro/scripts/make-outro.ts
+++ b/skills/pocketjs-video-outro/scripts/make-outro.ts
@@ -14,7 +14,7 @@
 //        [--crf N] [--preset P] [--x]
 //
 // Defaults: brand "PocketJS", tagline "UI for / every kind of / computer",
-// url "pocketjs.dev", outro 5.5s, xfade 0.8s, crf 18, preset medium. Pass
+// url "pocketjs.dev", outro 2.8s, xfade 0.35s, crf 18, preset medium. Pass
 // --url "" to hide the url.
 
 import { $ } from "bun";
@@ -27,6 +27,21 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 const HTML = resolve(HERE, "..", "assets", "outro.html");
 const FONT = resolve(HERE, "..", "assets", "VT323-Regular.ttf");
 export const DEFAULT_TAGLINE = "UI for\nevery kind of\ncomputer";
+export const DEFAULT_OUTRO = 2.8;
+export const DEFAULT_XFADE = 0.35;
+
+/** Keep a readable hold after the stagger, including on shorter custom cards. */
+export function resolveOutroTiming(outro: number, xfade: number) {
+  if (!Number.isFinite(outro) || outro <= 0) throw new Error("--outro must be a positive number");
+  if (!Number.isFinite(xfade) || xfade < 0) throw new Error("--xfade must be a non-negative number");
+  if (xfade >= outro) throw new Error("--xfade must be shorter than --outro so the card can appear");
+  const pace = Math.min(1, (outro - xfade) / 0.88);
+  return {
+    logo: { start: xfade, duration: 0.25 * pace },
+    tagline: { start: xfade + 0.12 * pace, duration: 0.25 * pace },
+    url: { start: xfade + 0.24 * pace, duration: 0.20 * pace },
+  };
+}
 
 type Args = {
   input: string;
@@ -52,8 +67,8 @@ function usage(): never {
       '  --tagline <str>       hero line (default: "UI for / every kind of / computer")',
       '  --brand <str>         wordmark (default: "PocketJS")',
       '  --url <str>           footer line (default: "pocketjs.dev"; "" hides it)',
-      "  --outro <secs>        end-card length (default: 5.5)",
-      "  --xfade <secs>        crossfade length (default: 0.8)",
+      `  --outro <secs>        end-card length including transition (default: ${DEFAULT_OUTRO})`,
+      `  --xfade <secs>        crossfade length (default: ${DEFAULT_XFADE})`,
       "  --crf <n>             x264 quality (default: 18)",
       "  --preset <p>          x264 preset (default: medium)",
       "  --x, --x-compatible   export X-safe 30fps CFR within web upload bounds",
@@ -74,8 +89,8 @@ export function parseArgs(argv: string[]): Args {
   let brand = "PocketJS";
   let tagline = DEFAULT_TAGLINE;
   let url = "pocketjs.dev";
-  let outro = 5.5;
-  let xfade = 0.8;
+  let outro = DEFAULT_OUTRO;
+  let xfade = DEFAULT_XFADE;
   let crf = 18;
   let preset = "medium";
   let xCompatible = false;
@@ -97,8 +112,7 @@ export function parseArgs(argv: string[]): Args {
 
   if (!input) usage();
   if (!existsSync(input)) throw new Error(`input not found: ${input}`);
-  if (!Number.isFinite(outro) || outro <= 0) throw new Error("--outro must be a positive number");
-  if (!Number.isFinite(xfade) || xfade < 0) throw new Error("--xfade must be a non-negative number");
+  resolveOutroTiming(outro, xfade);
 
   if (!output) {
     const dir = resolve(dirname(input));
@@ -280,25 +294,22 @@ async function main() {
 
   // type tracks resolution across landscape & portrait
   const scale = Math.min(w, h) / 1080;
-  const slideL = round(24 * scale);
-  const slideT = round(30 * scale);
-  const slideU = round(18 * scale);
-  const offset = Math.max(0, dur - a.xfade);
+  const slideL = round(16 * scale);
+  const slideT = round(20 * scale);
+  const slideU = round(12 * scale);
+  const xfade = Math.min(a.xfade, dur);
+  const offset = dur - xfade;
+  const timing = resolveOutroTiming(a.outro, xfade);
 
   // gentle audio fade fully completing at the original end
-  let afadeDur = a.xfade + 0.6;
+  let afadeDur = xfade + 0.15;
   let afadeSt = dur - afadeDur;
   if (afadeSt < 0) { afadeSt = 0; afadeDur = dur; }
-
-  // entrance keys off the crossfade: text arrives as the transition settles
-  const l0 = Math.max(0, a.xfade - 0.1);
-  const t0 = l0 + 0.35;
-  const u0 = t0 + 0.6;
 
   console.error(`input : ${inputW}x${inputH} @ ${inputFps.toFixed(3)}fps (${inputFpsRate})  dur=${dur}s  audio-streams=${audioStreams}${rotation ? `  rotation=${rotation}` : ""}`);
   console.error(`color : ${[colorSpace, colorTransfer, colorPrimaries, colorRange].filter(Boolean).join("/") || "unspecified"}${isHdr ? " -> bt709 SDR" : ""}`);
   console.error(`video : ${w}x${h} @ ${fps.toFixed(3)}fps (${fpsRate})${a.xCompatible ? "  X-compatible CFR" : ""}`);
-  console.error(`card  : scale=${scale.toFixed(4)}  outro=${a.outro}s  xfade=${a.xfade}s (offset=${offset.toFixed(3)}s)`);
+  console.error(`card  : scale=${scale.toFixed(4)}  outro=${a.outro}s  xfade=${xfade}s (offset=${offset.toFixed(3)}s)`);
   console.error(`output: ${a.output}`);
 
   const tmp = mkdtempSync(join(tmpdir(), "pocketjs-outro-"));
@@ -313,7 +324,7 @@ async function main() {
     for (const [layer, out] of Object.entries(layers)) await shotLayer(chrome, layer, out, w, h, params);
     console.error(`rendered card layers (${w}x${h})`);
 
-    const f = (n: number) => n.toFixed(2);
+    const f = (n: number) => n.toFixed(6);
     const bt709 = "setparams=range=tv:color_primaries=bt709:color_trc=bt709:colorspace=bt709";
     const colorFlags = "lanczos+accurate_rnd+full_chroma_int";
     const cardColor = isHdr
@@ -325,14 +336,16 @@ async function main() {
     const outputColor = isHdr ? `,${bt709}` : "";
     const graphLines = [
       `[1:v]${cardColor}setsar=1,fps=${fpsRate},format=yuv420p${outputColor},setpts=PTS-STARTPTS[bg];`,
-      `[2:v]${cardColor}fps=${fpsRate},format=yuva420p${outputColor},fade=t=in:st=${f(l0)}:d=0.60:alpha=1,setpts=PTS-STARTPTS[lg];`,
-      `[3:v]${cardColor}fps=${fpsRate},format=yuva420p${outputColor},fade=t=in:st=${f(t0)}:d=0.60:alpha=1,setpts=PTS-STARTPTS[tg];`,
-      `[4:v]${cardColor}fps=${fpsRate},format=yuva420p${outputColor},fade=t=in:st=${f(u0)}:d=0.50:alpha=1,setpts=PTS-STARTPTS[ur];`,
-      `[bg][lg]overlay=x=0:y='${slideL}*pow(1-clip((t-${f(l0)})/0.60,0,1),3)'[o1];`,
-      `[o1][tg]overlay=x=0:y='${slideT}*pow(1-clip((t-${f(t0)})/0.60,0,1),3)'[o2];`,
-      `[o2][ur]overlay=x=0:y='${slideU}*pow(1-clip((t-${f(u0)})/0.50,0,1),3)',format=yuv420p${outputColor},setpts=PTS-STARTPTS[outro];`,
+      `[2:v]${cardColor}fps=${fpsRate},format=yuva420p${outputColor},fade=t=in:st=${f(timing.logo.start)}:d=${f(timing.logo.duration)}:alpha=1,setpts=PTS-STARTPTS[lg];`,
+      `[3:v]${cardColor}fps=${fpsRate},format=yuva420p${outputColor},fade=t=in:st=${f(timing.tagline.start)}:d=${f(timing.tagline.duration)}:alpha=1,setpts=PTS-STARTPTS[tg];`,
+      `[4:v]${cardColor}fps=${fpsRate},format=yuva420p${outputColor},fade=t=in:st=${f(timing.url.start)}:d=${f(timing.url.duration)}:alpha=1,setpts=PTS-STARTPTS[ur];`,
+      `[bg][lg]overlay=x=0:y='${slideL}*pow(1-clip((t-${f(timing.logo.start)})/${f(timing.logo.duration)},0,1),3)'[o1];`,
+      `[o1][tg]overlay=x=0:y='${slideT}*pow(1-clip((t-${f(timing.tagline.start)})/${f(timing.tagline.duration)},0,1),3)'[o2];`,
+      `[o2][ur]overlay=x=0:y='${slideU}*pow(1-clip((t-${f(timing.url.start)})/${f(timing.url.duration)},0,1),3)',format=yuv420p${outputColor},trim=duration=${a.outro},setpts=PTS-STARTPTS[outro];`,
       `[0:v]fps=${fpsRate},${mainColor},setpts=PTS-STARTPTS[main];`,
-      `[main][outro]xfade=transition=fade:duration=${a.xfade}:offset=${offset.toFixed(3)},format=yuv420p${outputColor}[v];`,
+      xfade > 0
+        ? `[main][outro]xfade=transition=fade:duration=${xfade}:offset=${offset.toFixed(6)},format=yuv420p${outputColor}[v];`
+        : `[main][outro]concat=n=2:v=1:a=0,format=yuv420p${outputColor}[v];`,
     ];
 
     const maps: string[] = ["-map", "[v]"];

--- a/tests/video-outro.test.ts
+++ b/tests/video-outro.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_TAGLINE,
   parseArgs,
   parseProbeOutput,
+  resolveOutroTiming,
   resolveOutputSpec,
   xCompatibilityArgs,
 } from "../skills/pocketjs-video-outro/scripts/make-outro.ts";
@@ -17,6 +18,38 @@ describe("branding defaults", () => {
   test("keeps an explicitly supplied tagline unchanged", () => {
     const tagline = "A custom line\nwith an intentional break";
     expect(parseArgs(["-i", import.meta.path, "--tagline", tagline]).tagline).toBe(tagline);
+  });
+});
+
+describe("short outro timing", () => {
+  test("defaults to a complete card below three seconds with a readable hold", () => {
+    const args = parseArgs(["-i", import.meta.path]);
+    const timing = resolveOutroTiming(args.outro, args.xfade);
+    const settled = Math.max(...Object.values(timing).map(layer => layer.start + layer.duration));
+    expect(args.outro).toBeLessThan(3);
+    expect(args.xfade).toBeLessThan(0.5);
+    expect(settled).toBeLessThan(1);
+    expect(args.outro - settled).toBeGreaterThan(1.5);
+  });
+
+  test("keeps ordered entrances after the transition and fits custom card lengths", () => {
+    for (const [outro, xfade] of [[2.8,0.35], [1,0.35], [5.5,0.8], [0.5,0.1], [2,0]]) {
+      const { logo, tagline, url } = resolveOutroTiming(outro, xfade);
+      expect(logo.start).toBe(xfade);
+      expect(tagline.start).toBeGreaterThan(logo.start);
+      expect(url.start).toBeGreaterThan(tagline.start);
+      for (const layer of [logo,tagline,url]) {
+        expect(layer.duration).toBeGreaterThan(0);
+        expect(layer.start + layer.duration).toBeLessThanOrEqual(xfade + (outro-xfade)/2 + 1e-8);
+      }
+    }
+  });
+
+  test("rejects a transition that would consume the whole card", () => {
+    for (const xfade of [1,2]) {
+      expect(() => parseArgs(["-i", import.meta.path, "--outro", "1", "--xfade", String(xfade)]))
+        .toThrow("--xfade must be shorter than --outro");
+    }
   });
 });
 


### PR DESCRIPTION
The default PocketJS end card lasted 5.5 seconds, which made the ending dominate short demos. Set the default to 2.8 seconds including a 0.35-second crossfade, and bring in the logo, headline and URL within the first 0.79 seconds.

- Shorten the entrance fades, stagger and slide distances; reserve a hold after all layers appear. Custom durations scale the entrance to fit.
- Reject transitions that consume the entire card, cap the transition to the source duration for very short inputs, and support a zero-transition cut.
- Update the skill, CLI help and media QA instructions with the new timing and the under-three-second acceptance check.

Validation:

- 18 video-outro tests passed, covering timing constraints, custom durations, CLI, frame-rate/rotation handling and X compatibility options.
- Strict TypeScript checking and the skill-creator validator passed.
- Rendered a real HDR 4:5 highlight video with a 10-second body: final output is 12.466667 seconds, 864×1080 at 30 fps, H.264 High/yuv420p and limited-range BT.709, with stereo AAC.
- Inspected body frames, the faster staggered entrance and the final card; full decode passed. Body audio remained present (mean −51.6 dB); the final two seconds were silent (−91 dB).
- Rendered and decoded a 0.2-second SDR source with the capped default transition (2.8-second output) and a custom 1-second card with no transition (1.2-second output).

User footage and generated video files remain local and are excluded from this PR.
