### PR TITLE
refactor(apps): native spinner sprites

### DIFF
--- a/apps/blackberry-classic-demo/sprites.json
+++ b/apps/blackberry-classic-demo/sprites.json
@@ -1,0 +1,8 @@
+{
+  "spinner-atlas.svg": {
+    "cols": 4,
+    "rows": 2,
+    "frames": 8,
+    "step": 3
+  }
+}

--- a/apps/gallery/app.tsx
+++ b/apps/gallery/app.tsx
@@ -24,7 +24,6 @@ import {
   FocusScope,
   Gallery,
   Grid,
-  Image,
   Lazy,
   Screen,
   Sprite,
@@ -32,22 +31,9 @@ import {
   View,
   type NodeMirror,
 } from "@pocketjs/framework/components";
-import { createSpriteAnimation } from "@pocketjs/framework/lifecycle";
 import { createSignal, onMount } from "solid-js";
 import { focusNode } from "@pocketjs/framework/input";
 import { GALLERY_PAGES, TILES_PER_PAGE, TILE_SRCS } from "./tiles.ts";
-
-// Same SVG spinner the library demo uses; frame-cycled while a page loads.
-const SPINNER_FRAMES = [
-  "spinner-00.svg",
-  "spinner-01.svg",
-  "spinner-02.svg",
-  "spinner-03.svg",
-  "spinner-04.svg",
-  "spinner-05.svg",
-  "spinner-06.svg",
-  "spinner-07.svg",
-];
 
 const REVEAL_FRAMES = 16; // ~0.27s spinner the first time a page is built
 
@@ -81,14 +67,11 @@ const TILE_FRAME =
 // Pieces
 // ---------------------------------------------------------------------------
 
-/** On-demand loading indicator shown by <Lazy> before a page's tiles reveal.
- *  Owns its own sprite animation, so the per-frame tick lives only while a
- *  spinner is actually on screen. */
+/** On-demand loading indicator shown by <Lazy> before a page's tiles reveal. */
 function Loading(props: { title: string }) {
-  const frame = createSpriteAnimation(SPINNER_FRAMES, { frameStep: 3 });
   return (
     <View debugName="Loading" class="flex-col items-center justify-center gap-2 grow">
-      <Image class="w-9 h-9" src={frame()} />
+      <Sprite class="w-9 h-9" sprite="spinner-atlas.svg" />
       <Text class="text-xs text-slate-300 tracking-wide">LOADING {props.title}</Text>
     </View>
   );

--- a/apps/gallery/app.vue-vapor.tsx
+++ b/apps/gallery/app.vue-vapor.tsx
@@ -4,7 +4,6 @@ import {
   FocusScope,
   Gallery,
   Grid,
-  Image,
   Lazy,
   Screen,
   Sprite,
@@ -12,20 +11,8 @@ import {
   View,
   type NodeMirror,
 } from "@pocketjs/framework/vue-vapor/components";
-import { createSpriteAnimation } from "@pocketjs/framework/vue-vapor/lifecycle";
 import { focusNode } from "@pocketjs/framework/vue-vapor/input";
 import { GALLERY_PAGES, TILES_PER_PAGE, TILE_SRCS } from "./tiles.ts";
-
-const SPINNER_FRAMES = [
-  "spinner-00.svg",
-  "spinner-01.svg",
-  "spinner-02.svg",
-  "spinner-03.svg",
-  "spinner-04.svg",
-  "spinner-05.svg",
-  "spinner-06.svg",
-  "spinner-07.svg",
-];
 
 const REVEAL_FRAMES = 16;
 const PAGE_TITLE = ["SYNTHWAVE", "GOLDEN HOUR", "EVERGREEN", "NEBULA"];
@@ -49,10 +36,9 @@ const TILE_FRAME =
   "w-[68] h-[68] rounded-lg items-center justify-center bg-slate-900 border-slate-700 focus:scale-110 focus:border-white transition-transform duration-150 ease-out";
 
 const Loading = (props: { title: string }) => {
-  const frame = createSpriteAnimation(SPINNER_FRAMES, { frameStep: 3 });
   return (
     <View class="flex-col items-center justify-center gap-2 grow">
-      <Image class="w-9 h-9" src={frame.value} />
+      <Sprite class="w-9 h-9" sprite="spinner-atlas.svg" />
       <Text class="text-xs text-slate-300 tracking-wide">LOADING {props.title}</Text>
     </View>
   );

--- a/apps/hero-vue-vapor/app.tsx
+++ b/apps/hero-vue-vapor/app.tsx
@@ -1,20 +1,7 @@
 import { onMounted, ref } from "vue";
-import { Image, Text, View, type NodeMirror } from "@pocketjs/framework/components";
+import { Image, Sprite, Text, View, type NodeMirror } from "@pocketjs/framework/components";
 import { animate } from "@pocketjs/framework/animation";
-import { createSpriteAnimation } from "@pocketjs/framework/vue-vapor/lifecycle";
 import { frameworkName } from "@pocketjs/framework";
-
-const SPINNER_FRAME_STEP = 3;
-const SPINNER_FRAMES = [
-  "spinner-00.svg",
-  "spinner-01.svg",
-  "spinner-02.svg",
-  "spinner-03.svg",
-  "spinner-04.svg",
-  "spinner-05.svg",
-  "spinner-06.svg",
-  "spinner-07.svg",
-];
 
 function Stat(props: { label: string; value: string; cls: string }) {
   return (
@@ -27,7 +14,6 @@ function Stat(props: { label: string; value: string; cls: string }) {
 
 export default () => {
   const count = ref(0);
-  const spinnerSrc = createSpriteAnimation(SPINNER_FRAMES, { frameStep: SPINNER_FRAME_STEP });
   let underline: NodeMirror | undefined;
 
   onMounted(() => {
@@ -55,7 +41,7 @@ export default () => {
         <Text class="text-xs text-blue-600 tracking-wide">ONE RUST CORE - ONE VUE VAPOR APP</Text>
         <View class="flex-row items-center justify-between">
           <Text class="text-4xl text-slate-950 font-bold">JSX at 60 FPS.</Text>
-          <Image class="w-10 h-10" src={spinnerSrc.value} />
+          <Sprite class="w-10 h-10" sprite="spinner-atlas.svg" />
         </View>
         <View
           nodeRef={(node) => {

--- a/apps/hero-vue-vapor/sprites.json
+++ b/apps/hero-vue-vapor/sprites.json
@@ -1,0 +1,8 @@
+{
+  "spinner-atlas.svg": {
+    "cols": 4,
+    "rows": 2,
+    "frames": 8,
+    "step": 3
+  }
+}

--- a/apps/hero/app.tsx
+++ b/apps/hero/app.tsx
@@ -5,26 +5,14 @@
 import { createEffect, createSignal, onMount, Show } from "solid-js";
 import {
   Image,
+  Sprite,
   Text,
   View,
   type NodeMirror,
 } from "@pocketjs/framework/components";
 import { animate } from "@pocketjs/framework/animation";
 import { TICKS_PER_SECOND } from "@pocketjs/framework/clock";
-import { createSpriteAnimation } from "@pocketjs/framework/lifecycle";
 import { frameworkName } from "@pocketjs/framework/solid";
-
-const SPINNER_FRAME_STEP = 3;
-const SPINNER_FRAMES = [
-  "spinner-00.svg",
-  "spinner-01.svg",
-  "spinner-02.svg",
-  "spinner-03.svg",
-  "spinner-04.svg",
-  "spinner-05.svg",
-  "spinner-06.svg",
-  "spinner-07.svg",
-];
 
 function Stat(props: { label: string; value: string; cls: string; largeLayout?: boolean }) {
   return (
@@ -53,9 +41,6 @@ export default function Hero(props: HeroProps = {}) {
   createEffect(() => {
     const completedCount = count();
     if (completedCount > 0) props.onAction?.(completedCount);
-  });
-  const spinnerSrc = createSpriteAnimation(SPINNER_FRAMES, {
-    frameStep: props.spinnerFrameStep ?? SPINNER_FRAME_STEP,
   });
   let underline: NodeMirror | undefined;
   onMount(() => {
@@ -135,7 +120,11 @@ export default function Hero(props: HeroProps = {}) {
             : "text-4xl text-slate-950 font-bold"}>
             {props.headline ?? `JSX at ${TICKS_PER_SECOND} FPS.`}
           </Text>
-          <Image class={props.largeLayout ? "w-[60] h-[60]" : "w-10 h-10"} src={spinnerSrc()} />
+          <Sprite
+            class={props.largeLayout ? "w-[60] h-[60]" : "w-10 h-10"}
+            frameStep={props.spinnerFrameStep}
+            sprite="spinner-atlas.svg"
+          />
         </View>
         <View
           ref={underline}

--- a/apps/hero/app.vue-vapor.tsx
+++ b/apps/hero/app.vue-vapor.tsx
@@ -1,20 +1,7 @@
 import { onMounted, ref } from "vue";
-import { Image, Text, View, type NodeMirror } from "@pocketjs/framework/vue-vapor/components";
+import { Image, Sprite, Text, View, type NodeMirror } from "@pocketjs/framework/vue-vapor/components";
 import { animate } from "@pocketjs/framework/vue-vapor/animation";
-import { createSpriteAnimation } from "@pocketjs/framework/vue-vapor/lifecycle";
 import { frameworkName } from "@pocketjs/framework/vue-vapor";
-
-const SPINNER_FRAME_STEP = 3;
-const SPINNER_FRAMES = [
-  "spinner-00.svg",
-  "spinner-01.svg",
-  "spinner-02.svg",
-  "spinner-03.svg",
-  "spinner-04.svg",
-  "spinner-05.svg",
-  "spinner-06.svg",
-  "spinner-07.svg",
-];
 
 const Stat = (props: { label: string; value: string; cls: string }) => {
   return (
@@ -27,7 +14,6 @@ const Stat = (props: { label: string; value: string; cls: string }) => {
 
 export default function Hero() {
   const count = ref(0);
-  const spinnerSrc = createSpriteAnimation(SPINNER_FRAMES, { frameStep: SPINNER_FRAME_STEP });
   let underline: NodeMirror | undefined;
 
   onMounted(() => {
@@ -55,7 +41,7 @@ export default function Hero() {
         <Text class="text-xs text-blue-600 tracking-wide">ONE RUST CORE - ONE VUE VAPOR APP</Text>
         <View class="flex-row items-center justify-between">
           <Text class="text-4xl text-slate-950 font-bold">JSX at 60 FPS.</Text>
-          <Image class="w-10 h-10" src={spinnerSrc.value} />
+          <Sprite class="w-10 h-10" sprite="spinner-atlas.svg" />
         </View>
         <View
           nodeRef={(node: NodeMirror | null) => {

--- a/apps/iphone16-demo/sprites.json
+++ b/apps/iphone16-demo/sprites.json
@@ -1,0 +1,8 @@
+{
+  "spinner-atlas.svg": {
+    "cols": 4,
+    "rows": 2,
+    "frames": 8,
+    "step": 3
+  }
+}

--- a/apps/iphone2g-demo/sprites.json
+++ b/apps/iphone2g-demo/sprites.json
@@ -1,0 +1,8 @@
+{
+  "spinner-atlas.svg": {
+    "cols": 4,
+    "rows": 2,
+    "frames": 8,
+    "step": 3
+  }
+}

--- a/apps/iphone4s-demo/sprites.json
+++ b/apps/iphone4s-demo/sprites.json
@@ -1,0 +1,8 @@
+{
+  "spinner-atlas.svg": {
+    "cols": 4,
+    "rows": 2,
+    "frames": 8,
+    "step": 3
+  }
+}

--- a/apps/ipodtouch-demo/sprites.json
+++ b/apps/ipodtouch-demo/sprites.json
@@ -1,0 +1,8 @@
+{
+  "spinner-atlas.svg": {
+    "cols": 4,
+    "rows": 2,
+    "frames": 8,
+    "step": 3
+  }
+}

--- a/apps/meizu-m8-demo/sprites.json
+++ b/apps/meizu-m8-demo/sprites.json
@@ -1,0 +1,8 @@
+{
+  "spinner-atlas.svg": {
+    "cols": 4,
+    "rows": 2,
+    "frames": 8,
+    "step": 3
+  }
+}

--- a/apps/nsengine/app.tsx
+++ b/apps/nsengine/app.tsx
@@ -1,20 +1,9 @@
 // @title NS Engine — pocketjs guest talking to a NativeScript host
 import { createSignal, onMount } from "solid-js";
-import { Image, Screen, Text, View } from "@pocketjs/framework/components";
+import { Image, Screen, Sprite, Text, View } from "@pocketjs/framework/components";
 import { runEffect } from "@pocketjs/framework/effects";
-import { createSpriteAnimation, onFrame } from "@pocketjs/framework/lifecycle";
+import { onFrame } from "@pocketjs/framework/lifecycle";
 import { pumpHostLines } from "./channel.ts";
-
-const SPINNER_FRAMES = [
-  "spinner-00.svg",
-  "spinner-01.svg",
-  "spinner-02.svg",
-  "spinner-03.svg",
-  "spinner-04.svg",
-  "spinner-05.svg",
-  "spinner-06.svg",
-  "spinner-07.svg",
-];
 
 // Bakes the glyphs dynamic host strings may use (digits, punctuation).
 const GLYPH_SEED = "0123456789 #:{}\"pong hello from NativeScript,.!?-_iOS via sandboxed realm";
@@ -40,8 +29,6 @@ export default function App() {
   const [reply, setReply] = createSignal("waiting");
   const [hostEvent, setHostEvent] = createSignal("none yet");
   const [count, setCount] = createSignal(0);
-  const spinnerSrc = createSpriteAnimation(SPINNER_FRAMES, { frameStep: 5 });
-
   onFrame(() => pumpHostLines((message) => {
     setHostEvent(String(message["msg"] ?? JSON.stringify(message)));
   }));
@@ -69,7 +56,7 @@ export default function App() {
             </Text>
           </View>
         </View>
-        <Image class="w-8 h-8" src={spinnerSrc()} />
+        <Sprite class="w-8 h-8" sprite="spinner-atlas.svg" />
       </View>
 
       <View class="flex-row gap-3">

--- a/apps/nsengine/sprites.json
+++ b/apps/nsengine/sprites.json
@@ -1,0 +1,8 @@
+{
+  "spinner-atlas.svg": {
+    "cols": 4,
+    "rows": 2,
+    "frames": 8,
+    "step": 5
+  }
+}

--- a/framework/src/components-octane.tsx
+++ b/framework/src/components-octane.tsx
@@ -135,6 +135,7 @@ export interface ImageProps {
 export interface SpriteProps {
   class?: string;
   className?: string;
+  frameStep?: number;
   sprite?: string;
   style?: StyleObject;
   debugName?: string;

--- a/framework/src/components-vue-vapor.ts
+++ b/framework/src/components-vue-vapor.ts
@@ -76,6 +76,7 @@ export interface ImageProps {
 export interface SpriteProps {
   class?: string;
   className?: string;
+  frameStep?: number;
   sprite?: string;
   style?: StyleObject;
   nodeRef?: NodeRef;

--- a/framework/src/native-tree.ts
+++ b/framework/src/native-tree.ts
@@ -77,6 +77,8 @@ const NATIVE_ATTRIBUTE_NAMES = new Set([
   "className",
   "style",
   "src",
+  "sprite",
+  "frameStep",
   "onPress",
   "on:press",
   "focusable",
@@ -620,6 +622,14 @@ function setSrc(node: NodeMirror, value: unknown): void {
 
 /** `sprite` prop → bind an animated sprite atlas. Auto-play is native; JS never
  *  touches it per frame. Clearing reverts the node to a plain (empty) image. */
+function spriteStep(node: NodeMirror, fallback: number, value: unknown = node.domAttrs?.frameStep): number {
+  if (value == null) return fallback;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error("PocketJS: frameStep must be a finite number");
+  }
+  return Math.min(0xffff, Math.max(1, Math.floor(value)));
+}
+
 function setSpriteSrc(node: NodeMirror, value: unknown): void {
   const ops = getOps();
   if (value == null || value === "") {
@@ -639,7 +649,7 @@ function setSpriteSrc(node: NodeMirror, value: unknown): void {
     missCounters.unknownTexture++;
     return;
   }
-  ops.setSprite(node.id, meta.handle, meta.frames, meta.cols, meta.step);
+  ops.setSprite(node.id, meta.handle, meta.frames, meta.cols, spriteStep(node, meta.step));
 }
 
 function setCompositorBinding(node: NodeMirror): void {
@@ -720,6 +730,24 @@ export function setProp<T>(node: NodeMirror, name: string, value: T, prev?: T): 
       return value;
     case "sprite":
       setSpriteSrc(node, value);
+      return value;
+    case "frameStep":
+      if (value != null) spriteStep(node, 1, value);
+      if (node.domAttrs?.sprite != null) {
+        const key = node.domAttrs.sprite;
+        const meta = sprites.get(String(key));
+        if (meta !== undefined) {
+          getOps().setSprite(
+            node.id,
+            meta.handle,
+            meta.frames,
+            meta.cols,
+            spriteStep(node, meta.step, value),
+          );
+        } else {
+          setSpriteSrc(node, key);
+        }
+      }
       return value;
     case "package":
     case "focused":

--- a/framework/src/primitives.ts
+++ b/framework/src/primitives.ts
@@ -58,6 +58,8 @@ export interface SpriteProps {
   class?: string;
   /** DevTools semantic name shown in the component tree (docs/DEVTOOLS.md). */
   debugName?: string;
+  /** Core ticks per atlas frame. Overrides the sprite manifest when provided. */
+  frameStep?: number;
   /** Sprite-atlas key (a `ui:sprite.<name>` entry baked into the pak). */
   sprite?: string;
   style?: StyleObject;

--- a/site/content/docs/api.md
+++ b/site/content/docs/api.md
@@ -215,10 +215,10 @@ The host primitives, wrapped React Native-style. `View` is the flex container/bo
 
 **`TextProps`** — `class`, `style`, `ref`, `children`, `debugName`.
 **`ImageProps`** — `class`, `src` (`string`), `style`, `ref`, `debugName`.
-**`SpriteProps`** — `class`, `sprite` (`string` — a `ui:sprite.<name>` atlas key), `style`, `ref`, `debugName`.
+**`SpriteProps`** — `class`, `sprite` (`string` — a `ui:sprite.<name>` atlas key), `frameStep` (`number`), `style`, `ref`, `debugName`.
 **`CompositorSurfaceProps`** — `class`, `style`, `package` (installed reverse-DNS package id), `focused`, `ref`, `debugName`.
 
-`Sprite` is a native animated primitive: its atlas (a pow2 texture holding a grid of frames) is baked into the pak, and the Rust core advances the frame cell from its own tick counter — deterministic and with **zero per-frame JS**. It auto-plays from the first frame the moment it is displayed, so a sprite revealed by paging or a `Show`/`Lazy` starts animating on its own. Bake atlases by listing them in a demo's `sprites.json` (`{ "<atlas>.png": { cols, rows, frames, step } }`); `step` is core ticks per frame, so the sprite runs at `tick rate / step` fps (`step: 2` is 30 fps on a 60 Hz bundle). See `apps/gallery` (its covers are shader-baked animated sprites).
+`Sprite` is a native animated primitive: its atlas (a pow2 texture holding a grid of frames) is baked into the pak, and the Rust core advances the frame cell from its own tick counter — deterministic and with **zero per-frame JS**. It auto-plays from the first frame the moment it is displayed, so a sprite revealed by paging or a `Show`/`Lazy` starts animating on its own. Bake atlases by listing them in a demo's `sprites.json` (`{ "<atlas>.png": { cols, rows, frames, step } }`); `step` is core ticks per frame, so the sprite runs at `tick rate / step` fps (`step: 2` is 30 fps on a 60 Hz bundle). **`frameStep` overrides the manifest's `step` at runtime** and is clamped to the core's 1–65535 tick range. See `apps/gallery` (its covers are shader-baked animated sprites).
 
 ### `Screen`
 

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -39,10 +39,12 @@ import {
   insert,
   insertNode,
   missCounters,
+  registerSprite,
   registerTexture,
   release,
   render,
   resetRendererState,
+  resetSprites,
   resetTextures,
   retain,
   runSweep,
@@ -286,6 +288,7 @@ beforeEach(() => {
   installHost(host);
   resetRendererState();
   resetStyles();
+  resetSprites();
   resetTextures();
   resetPack();
   resetInput();
@@ -818,6 +821,35 @@ describe("setProperty dispatch table [R]", () => {
     host.clear();
     setProp(el, "src", null, "");
     expect(host.of("setImage")).toEqual([["setImage", el.id, -1]]);
+  });
+
+  test("sprite frameStep overrides the manifest and can be updated at runtime", () => {
+    registerSprite("spinner-atlas.svg", { handle: 41, frames: 8, cols: 4, step: 3 });
+    const overridden = createElement("image");
+    setProp(overridden, "frameStep", 6, undefined);
+    setProp(overridden, "sprite", "spinner-atlas.svg", undefined);
+    expect(host.of("setSprite")).toEqual([
+      ["setSprite", overridden.id, 41, 8, 4, 6],
+    ]);
+
+    host.clear();
+    setProp(overridden, "frameStep", 2.9, 6);
+    expect(host.of("setSprite")).toEqual([
+      ["setSprite", overridden.id, 41, 8, 4, 2],
+    ]);
+
+    host.clear();
+    setProp(overridden, "frameStep", undefined, 2.9);
+    expect(host.of("setSprite")).toEqual([
+      ["setSprite", overridden.id, 41, 8, 4, 3],
+    ]);
+
+    host.clear();
+    const fromManifest = createElement("image");
+    setProp(fromManifest, "sprite", "spinner-atlas.svg", undefined);
+    expect(host.of("setSprite")).toEqual([
+      ["setSprite", fromManifest.id, 41, 8, 4, 3],
+    ]);
   });
 
   test("classList / bool: / prop: / unknown props are loud errors", () => {


### PR DESCRIPTION
Six spinner sites drive their animation from the guest: `createSpriteAnimation`
advances a signal every frame and `<Image src={spinnerSrc()}>` swaps the texture
every third frame. The core already owns sprite-atlas playback, and the Octane
variants (`apps/hero/app.octane.tsx`, `apps/gallery/app.octane.tsx`,
`apps/library/app.octane.tsx`) have used it all along — the Solid and Vue Vapor
variants just never followed.

This converts `apps/hero`, `apps/hero/app.vue-vapor.tsx`, `apps/hero-vue-vapor`,
`apps/gallery`, `apps/gallery/app.vue-vapor.tsx` and `apps/nsengine` to
`<Sprite sprite="spinner-atlas.svg">`, and removes the frame lists and the guest
hook along with them. Keeping the JSX swap while leaving the frame constants in
place would have packed both the atlas and the eight standalone frames.

## `spinnerFrameStep` is preserved, not dropped

`apps/blackberry-classic-demo` and `apps/iphone4s-demo` both pass a non-default
step of 6, so the prop had to survive the conversion. The core `set_sprite`
surface already takes a runtime step and uses it in the same deterministic cell
calculation, so `Sprite.frameStep` is wired through the native tree with
finite-number validation, floor and clamp to 1–65535, reactive rebinding, and
fallback to the manifest value.

## Measured on `main`

Across the six targets, in-frame traffic drops from 750 calls / 8,136 B to
514 / 6,248 B, and the per-frame `setImage` traffic that drove the animation
(236 calls / 1,888 B) goes to zero. On 480-frame idle runs, 1,049 calls /
10,052 B becomes 453 / 5,284 B. Guest-side HostOps time across the six canonical
runs goes 2.168 ms → 1.314 ms.

Every affected PAK shrinks (five by 416 B, nsengine by 432 B) because the eight
standalone frames stop being packed; aggregate JS grows 424 B for the
`frameStep` plumbing.

## Verification

1080/1080 canonical frames and 2880/2880 zero-input frames match clean `main`
builds, and both step-6 apps match 180/180 on the runtime-step path. The eight
atlas cells are pixel-identical to the standalone frames (0 differing pixels).
Mutating hero's manifest step from 3 to 4 diverges the canonical replay at frame
2, so the check has teeth.

The suite shows the same five pre-existing unit failures as clean `main`, and
the committed `hero-main` tape hashes diverge at the same frame-0 pair on both.
