### PR TITLE
perf(core): elide redundant raster clears

### DIFF
--- a/engine/core/examples/raster_clear_bench.rs
+++ b/engine/core/examples/raster_clear_bench.rs
@@ -1,0 +1,64 @@
+use std::hint::black_box;
+use std::time::Instant;
+
+use pocketjs_core::raster;
+use pocketjs_core::spec::draw_op;
+use pocketjs_core::Ui;
+
+const SAMPLES: usize = 31;
+const ITERATIONS: usize = 2_000;
+
+fn xy_word(x: i16, y: i16) -> u32 {
+    x as u16 as u32 | ((y as u16 as u32) << 16)
+}
+
+fn wh_word(width: u16, height: u16) -> u32 {
+    width as u32 | ((height as u32) << 16)
+}
+
+fn measure(ui: &Ui, words: &[u32], framebuffer: &mut [u8]) -> Vec<f64> {
+    for _ in 0..100 {
+        raster::render(black_box(ui), black_box(words), black_box(framebuffer));
+    }
+
+    let mut samples = Vec::with_capacity(SAMPLES);
+    for _ in 0..SAMPLES {
+        let start = Instant::now();
+        for _ in 0..ITERATIONS {
+            raster::render(black_box(ui), black_box(words), black_box(framebuffer));
+        }
+        samples.push(start.elapsed().as_nanos() as f64 / ITERATIONS as f64);
+    }
+    samples
+}
+
+fn median(samples: &[f64]) -> f64 {
+    let mut sorted = samples.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    sorted[sorted.len() / 2]
+}
+
+fn main() {
+    let mut ui = Ui::new();
+    ui.set_viewport(480.0, 272.0);
+    let mut framebuffer = vec![0x5a; 480 * 272 * 4];
+    let full_opaque = [
+        draw_op::RECT,
+        xy_word(0, 0),
+        wh_word(480, 272),
+        0xff33_2211,
+    ];
+    let partial_opaque = [
+        draw_op::RECT,
+        xy_word(0, 0),
+        wh_word(240, 272),
+        0xff33_2211,
+    ];
+    let accepted = measure(&ui, &full_opaque, &mut framebuffer);
+    let fallback = measure(&ui, &partial_opaque, &mut framebuffer);
+    println!(
+        "{{\"samples\":{SAMPLES},\"iterationsPerSample\":{ITERATIONS},\"acceptedNs\":{accepted:?},\"acceptedMedianNs\":{},\"fallbackNs\":{fallback:?},\"fallbackMedianNs\":{}}}",
+        median(&accepted),
+        median(&fallback),
+    );
+}

--- a/engine/core/src/raster.rs
+++ b/engine/core/src/raster.rs
@@ -351,8 +351,14 @@ pub fn render(ui: &impl RenderResources, words: &[u32], fb: &mut [u8]) {
 /// over that destination and font coverage accounts for the atlas's own raster
 /// density.
 /// `ui` supplies font atlases and textures. The framebuffer is cleared to
-/// opaque black first (the PSP host clears the draw buffer the same way).
-pub fn render_scaled(ui: &impl RenderResources, words: &[u32], fb: &mut [u8], scale: u32) {
+/// opaque black unless the first drawing command provably overwrites every target
+/// pixel with opaque color (the PSP host clears the draw buffer the same way).
+pub fn render_scaled(
+    ui: &impl RenderResources,
+    words: &[u32],
+    fb: &mut [u8],
+    scale: u32,
+) {
     let mut target = RgbaTarget::<false> { bytes: fb };
     render_scaled_impl(ui, words, &mut target, scale, true);
 }
@@ -562,10 +568,51 @@ fn render_scaled_impl<T: RenderTarget>(
     clear: bool,
 ) {
     let (width, _height, screen) = target_geometry(ui, target, scale);
-    if clear {
+    if clear && !first_draw_overwrites_target(words, scale as i32, screen) {
         target.clear_black();
     }
     render_scaled_clipped(ui, words, target, width, scale as i32, screen);
+}
+
+/// Return true only when executing the first command cannot observe the old
+/// target and replaces every target pixel. Once that command has run, later
+/// destination-alpha blends can only read pixels produced by this DrawList.
+///
+/// Keeping this proof to the first drawing command is intentionally
+/// conservative: transparent no-ops, transformed boxes (TRIs), partial
+/// scissors, and malformed or unknown commands all retain the established
+/// clear-before-render behavior. One leading full-target root scissor is
+/// accepted because it leaves the root clip unchanged.
+fn first_draw_overwrites_target(words: &[u32], scale: i32, screen: Clip) -> bool {
+    let i = if words.first() == Some(&draw_op::SCISSOR) {
+        if words.len() < 3 || !command_covers_target(words, 0, scale, screen) {
+            return false;
+        }
+        3
+    } else {
+        0
+    };
+    let opaque = match words.get(i).copied() {
+        Some(draw_op::RECT) if i + 4 <= words.len() => words[i + 3] >> 24 == 255,
+        Some(draw_op::GRAD_RECT) if i + 6 <= words.len() => {
+            words[i + 3] >> 24 == 255 && words[i + 4] >> 24 == 255
+        }
+        _ => false,
+    };
+    if !opaque {
+        return false;
+    }
+    command_covers_target(words, i, scale, screen)
+}
+
+#[inline]
+fn command_covers_target(words: &[u32], i: usize, scale: i32, screen: Clip) -> bool {
+    let (x, y) = xy(words[i + 1], scale);
+    let (width, height) = wh(words[i + 2], scale);
+    x <= screen.x0
+        && y <= screen.y0
+        && x + width >= screen.x1
+        && y + height >= screen.y1
 }
 
 fn render_scaled_regions_impl<T: RenderTarget>(
@@ -1345,6 +1392,234 @@ mod tests {
         let width = spec::SCREEN_W as usize * scale as usize;
         let offset = (y * width + x) * 4;
         fb[offset..offset + 4].try_into().unwrap()
+    }
+
+    fn assert_clear_decision_matches_baseline(words: &[u32], elides_clear: bool) {
+        let mut ui = Ui::new();
+        ui.set_viewport(4.0, 3.0);
+        let scale = 2;
+        let width = 4 * scale as usize;
+        let height = 3 * scale as usize;
+        let screen = Clip {
+            x0: 0,
+            y0: 0,
+            x1: width as i32,
+            y1: height as i32,
+        };
+        assert_eq!(
+            first_draw_overwrites_target(words, scale as i32, screen),
+            elides_clear
+        );
+
+        // A non-black seed makes any missing fallback clear visible. Compare
+        // the optimized public path against an explicitly cleared execution.
+        let mut actual = vec![0x5a; width * height * 4];
+        let mut baseline = actual.clone();
+        let mut target = RgbaTarget::<false> {
+            bytes: &mut baseline,
+        };
+        target.clear_black();
+        render_scaled_clipped(
+            &ui,
+            words,
+            &mut target,
+            width as i32,
+            scale as i32,
+            screen,
+        );
+        render_scaled(&ui, words, &mut actual, scale);
+        assert_eq!(actual, baseline);
+
+        let mut actual_argb = vec![0x5a; width * height * 4];
+        let mut baseline_argb = actual_argb.clone();
+        let mut target = RgbaTarget::<true> {
+            bytes: &mut baseline_argb,
+        };
+        target.clear_black();
+        render_scaled_clipped(
+            &ui,
+            words,
+            &mut target,
+            width as i32,
+            scale as i32,
+            screen,
+        );
+        render_scaled_argb(&ui, words, &mut actual_argb, scale);
+        assert_eq!(actual_argb, baseline_argb);
+
+        let mut actual_rgb565 = vec![0x5a5a; width * height];
+        let mut baseline_rgb565 = actual_rgb565.clone();
+        let mut target = Rgb565Target {
+            pixels: &mut baseline_rgb565,
+        };
+        target.clear_black();
+        render_scaled_clipped(
+            &ui,
+            words,
+            &mut target,
+            width as i32,
+            scale as i32,
+            screen,
+        );
+        render_scaled_rgb565(&ui, words, &mut actual_rgb565, scale);
+        assert_eq!(actual_rgb565, baseline_rgb565);
+    }
+
+    #[test]
+    fn full_opaque_viewport_rect_elides_clear() {
+        let words = [
+            draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(4, 3),
+            0xff33_2211,
+            // Later alpha blending reads only pixels written by the first op.
+            draw_op::RECT,
+            xy_word(1, 1),
+            wh_word(2, 1),
+            0x8080_4020,
+        ];
+        assert_clear_decision_matches_baseline(&words, true);
+    }
+
+    #[test]
+    fn full_opaque_viewport_gradient_elides_clear() {
+        let words = [
+            draw_op::GRAD_RECT,
+            xy_word(0, 0),
+            wh_word(4, 3),
+            0xff33_2211,
+            0xffcc_bbaa,
+            spec::GradDir::ToRight as u32,
+        ];
+        assert_clear_decision_matches_baseline(&words, true);
+    }
+
+    #[test]
+    fn transparent_first_operation_keeps_clear() {
+        let words = [
+            draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(4, 3),
+            0x0033_2211,
+            draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(2, 3),
+            0xff00_ff00,
+        ];
+        assert_clear_decision_matches_baseline(&words, false);
+    }
+
+    #[test]
+    fn partial_first_rect_keeps_clear() {
+        let words = [
+            draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(3, 3),
+            0xff33_2211,
+        ];
+        assert_clear_decision_matches_baseline(&words, false);
+    }
+
+    #[test]
+    fn leading_clip_keeps_clear() {
+        let words = [
+            draw_op::SCISSOR,
+            xy_word(0, 0),
+            wh_word(3, 3),
+            draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(4, 3),
+            0xff33_2211,
+            draw_op::SCISSOR_POP,
+        ];
+        assert_clear_decision_matches_baseline(&words, false);
+    }
+
+    #[test]
+    fn full_viewport_clip_before_opaque_cover_elides_clear() {
+        let words = [
+            draw_op::SCISSOR,
+            xy_word(0, 0),
+            wh_word(4, 3),
+            draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(4, 3),
+            0xff33_2211,
+            draw_op::SCISSOR_POP,
+        ];
+        assert_clear_decision_matches_baseline(&words, true);
+    }
+
+    #[test]
+    fn transformed_first_operation_keeps_clear() {
+        // Transformed boxes are emitted as triangles; even opaque vertices do
+        // not establish that one command covers every target pixel.
+        let words = [
+            draw_op::TRI,
+            xy_word(0, 0),
+            xy_word(4, 0),
+            xy_word(0, 3),
+            0xff33_2211,
+            0xff33_2211,
+            0xff33_2211,
+        ];
+        assert_clear_decision_matches_baseline(&words, false);
+    }
+
+    #[test]
+    fn empty_draw_list_keeps_clear() {
+        assert_clear_decision_matches_baseline(&[], false);
+    }
+
+    #[test]
+    fn nested_scissors_keep_clear() {
+        let mut words = Vec::new();
+        for _ in 0..2 {
+            words.extend_from_slice(&[
+                draw_op::SCISSOR,
+                xy_word(0, 0),
+                wh_word(4, 3),
+            ]);
+        }
+        words.extend_from_slice(&[
+            draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(4, 3),
+            0xff33_2211,
+        ]);
+        assert_clear_decision_matches_baseline(&words, false);
+    }
+
+    #[test]
+    fn malformed_or_unknown_first_command_keeps_clear() {
+        let truncated_rect = [
+            draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(4, 3),
+        ];
+        assert_clear_decision_matches_baseline(&truncated_rect, false);
+        assert_clear_decision_matches_baseline(&[u32::MAX], false);
+    }
+
+    #[test]
+    fn semitransparent_first_colors_keep_clear() {
+        let rect = [
+            draw_op::RECT,
+            xy_word(0, 0),
+            wh_word(4, 3),
+            0x8033_2211,
+        ];
+        assert_clear_decision_matches_baseline(&rect, false);
+
+        let gradient = [
+            draw_op::GRAD_RECT,
+            xy_word(0, 0),
+            wh_word(4, 3),
+            0xff33_2211,
+            0xfecc_bbaa,
+            spec::GradDir::ToBottom as u32,
+        ];
+        assert_clear_decision_matches_baseline(&gradient, false);
     }
 
     #[test]


### PR DESCRIPTION
`render_scaled_impl` clears the framebuffer to opaque black before every full
render. When the DrawList's first drawing command provably covers the whole target
with an opaque colour, that clear writes 130,560 pixels that the next command
immediately overwrites.

The proof stays deliberately narrow: the first command must be a `RECT` or
`GRAD_RECT` whose colour words all carry alpha 255 and whose rectangle covers
the target, optionally preceded by one full-target root `SCISSOR`. Transparent
first operations, partial or clipped rectangles, transforms and TRIs, empty or
truncated streams and unknown opcodes all keep the clear.

## Measured on `main`

An 8-process microbenchmark moves the eligible path from 18,013 ns to 9,058 ns
per render (−49.7%) and leaves the fallback path at 13,722 → 13,706 ns
(−0.12%). A d1/s1 full-render hero replay goes 84.466 → 73.082 ms (−13.5%). The
wasm grows 606 bytes.

## Where it applies, and where it does not

This only helps callers that enter the full raster clear: `tests/golden.ts`,
`tools/tape.ts` record/replay/`--png`, `hosts/sim` and the launcher screenshots
that consume it, the Vita software rasterizer, the Apple/Symbian ARGB
full-redraw fallback, and the ESP32-PPA RGB565 ordered fallback. PSP draws
glyphs through GE hardware and is unaffected.

It fires on all 180 frames of a full-render replay and **zero times** on 180
incremental-render frames, so on the already-incremental web path its
attributable benefit is 0 ms / 0%. Stacked with #411 rather than added to it,
the d2/s2 hero replay goes from 260.030 ms (glyph sparse alone) to 212.682 ms
(−18.2%).

## Verification

A 522-case matrix compares against clean `main` byte for byte: viewports
4×3/5×3/7×5/4.9×3.1/480×272/479.7×271.4, scales 1/2/3, ~29 first-command shapes
including negative origins, dimensions at −1/0/+1 of the target, leading
full/oversize/undersize/shifted scissors, gradient directions, semitransparent
and alpha-254 colours, TRI/empty/truncated/unknown opcodes, across RGBA8, ARGB
and RGB565. Every framebuffer is seeded with nonzero bytes so a missing write
cannot hide behind zero initialisation; 216 of the 522 cases take the elision
branch and none leak.

The coverage predicate and the rasterizer's rect fill share the same integer
`xy()`/`wh()` helpers, so there is no second rounding rule that could leave a
stale edge pixel; a rectangle one pixel short in any direction keeps the clear.

Suite behaviour matches clean `main` exactly: the same five unit failures and the
same frame-0 divergence of the committed `hero-main` tape hashes.
