### PR TITLE
fix(solid): install scheduler globals in the solid entry

### DIFF
--- a/framework/src/index.ts
+++ b/framework/src/index.ts
@@ -6,15 +6,11 @@
 // renderer's end-of-frame sweep [R] — so Solid effects triggered by input run
 // before detached subtrees are destroyed.
 
-// queueMicrotask polyfill (QuickJS lacks it; Solid's resource/transition paths
-// reference it lazily, so installing at module-eval time is early enough).
-if (typeof (globalThis as { queueMicrotask?: unknown }).queueMicrotask !== "function") {
-  (globalThis as { queueMicrotask?: (fn: () => void) => void }).queueMicrotask = (
-    fn: () => void,
-  ) => {
-    Promise.resolve().then(fn);
-  };
-}
+// Runtime scheduler globals (queueMicrotask/setTimeout/clearTimeout/console).
+// QuickJS provides none of them and the Solid entry needs the same shims the
+// Vapor/Octane preludes install: Promise-based user code (IPC handshakes,
+// timeouts) calls setTimeout during mount, before any frame runs.
+import "./scheduler-polyfill.ts";
 
 import {
   detectHost,


### PR DESCRIPTION
Fixes #413.

## What

- import the shared `./scheduler-polyfill.ts` at evaluation time in `framework/src/index.ts`;
- drop the inline `queueMicrotask` shim the polyfill supersedes (it also installs `setTimeout`, `clearTimeout`, and `console`).

## Why

QuickJS hosts expose no timers; the Vapor/Octane entries already import this polyfill, the Solid entry only defined `queueMicrotask`. Promise-based code that arms a timeout before the first frame (IPC handshake, retry) throws `ReferenceError: setTimeout is not defined`.

## Validation

- On an ArtInChip D211 (QuickJS, `d211-linux` abi 11): Solid app's transport handshake rejected before this change (and a later button callback threw inside input handling); with the patch the handshake resolves and presses dispatch normally. Same app, same host build.
- Diff is one import plus the removal of the redundant inline shim; no behavioral change for hosts that already provide the globals (guards in the polyfill).