### PR TITLE
feat(desktop): add windows-app stock target

### DIFF
--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -3,19 +3,29 @@ name: Windows portable renderer
 # windows-app is the third stock target of the hosts/desktop portable host.
 # This workflow validates the Windows execution path advertised by that target;
 # it does not claim Windows support for unrelated device or site tooling.
-# Real native window acceptance runs on local Windows hardware (see docs/BACKENDS.md).
+# Real native window/presentation acceptance is supplied by physical Windows evidence.
 
 on:
   pull_request:
     paths:
       - ".github/workflows/desktop-windows.yml"
+      - "package.json"
+      - "bun.lock"
+      - "pocket.config.ts"
       - "contracts/spec/**"
+      - "contracts/schema/**"
+      - "engine/Cargo.toml"
+      - "engine/Cargo.lock"
       - "engine/core/**"
       - "engine/crates/pocket-mod/**"
       - "engine/crates/pocket-ui-surface/**"
       - "engine/crates/pocket-text/**"
+      - "framework/compiler/**"
+      - "framework/src/config.ts"
       - "framework/src/text-layout.ts"
       - "framework/src/offload.ts"
+      - "framework/src/manifest/**"
+      - "tools/build.ts"
       - "hosts/web/*offload*.js"
       - "hosts/web/text-*"
       - "tools/*offload*"
@@ -25,6 +35,7 @@ on:
       - "tests/fixtures/offload-ready-worker.ts"
       - "tools/text-*"
       - "tests/text-layout-client.test.ts"
+      - "apps/note/**"
       - "apps/text-offload/**"
       - "hosts/desktop/**"
       - "engine/crates/pocket-ui-wgpu/**"
@@ -32,7 +43,6 @@ on:
       - "hosts/web/app-instance.*"
       - "hosts/web/system-engine.js"
       - "hosts/web/wasm-ops.js"
-      - "framework/src/manifest/**"
       - "tests/platform-contracts.test.ts"
       - "tests/symbian-runtime.test.ts"
       - "tests/pocket-system.test.ts"
@@ -41,13 +51,23 @@ on:
     branches: [main]
     paths:
       - ".github/workflows/desktop-windows.yml"
+      - "package.json"
+      - "bun.lock"
+      - "pocket.config.ts"
       - "contracts/spec/**"
+      - "contracts/schema/**"
+      - "engine/Cargo.toml"
+      - "engine/Cargo.lock"
       - "engine/core/**"
       - "engine/crates/pocket-mod/**"
       - "engine/crates/pocket-ui-surface/**"
       - "engine/crates/pocket-text/**"
+      - "framework/compiler/**"
+      - "framework/src/config.ts"
       - "framework/src/text-layout.ts"
       - "framework/src/offload.ts"
+      - "framework/src/manifest/**"
+      - "tools/build.ts"
       - "hosts/web/*offload*.js"
       - "hosts/web/text-*"
       - "tools/*offload*"
@@ -57,6 +77,7 @@ on:
       - "tests/fixtures/offload-ready-worker.ts"
       - "tools/text-*"
       - "tests/text-layout-client.test.ts"
+      - "apps/note/**"
       - "apps/text-offload/**"
       - "hosts/desktop/**"
       - "engine/crates/pocket-ui-wgpu/**"
@@ -64,7 +85,6 @@ on:
       - "hosts/web/app-instance.*"
       - "hosts/web/system-engine.js"
       - "hosts/web/wasm-ops.js"
-      - "framework/src/manifest/**"
       - "tests/platform-contracts.test.ts"
       - "tests/symbian-runtime.test.ts"
       - "tests/pocket-system.test.ts"

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -101,10 +101,10 @@ jobs:
       - run: bun install --frozen-lockfile
 
       - name: Platform registry, System and web host contract tests
-        # The two registry suites run scoped to the target-registry blocks this
-        # patch touches: the unscoped files still carry pre-existing Windows
-        # path defects (file:// URL pathnames concatenated into /C:/... paths)
-        # that fail on every Windows machine and are tracked separately.
+        # These two registry files contain pre-existing Windows path failures
+        # where file-URL pathnames are passed to filesystem APIs. That defect is
+        # outside this windows-app admission change, so run the registry blocks
+        # affected by this patch instead of weakening or repairing unrelated code.
         run: |
           bun test tests/platform-contracts.test.ts -t "platform registry"
           bun test tests/symbian-runtime.test.ts -t "keeps the experimental E7 target out of the production registry"

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -1,0 +1,132 @@
+name: Windows portable renderer
+
+# windows-app is the third stock target of the hosts/desktop portable host.
+# The runner builds and tests the host; real native window acceptance runs on
+# local Windows hardware (see docs/BACKENDS.md).
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/desktop-windows.yml"
+      - "contracts/spec/**"
+      - "engine/core/**"
+      - "engine/crates/pocket-mod/**"
+      - "engine/crates/pocket-ui-surface/**"
+      - "engine/crates/pocket-text/**"
+      - "framework/src/text-layout.ts"
+      - "framework/src/offload.ts"
+      - "hosts/web/*offload*.js"
+      - "hosts/web/text-*"
+      - "tools/*offload*"
+      - "tools/companion-session.ts"
+      - "tests/offload-provider.test.ts"
+      - "tests/companion-session.test.ts"
+      - "tests/fixtures/offload-ready-worker.ts"
+      - "tools/text-*"
+      - "tests/text-layout-client.test.ts"
+      - "apps/text-offload/**"
+      - "hosts/desktop/**"
+      - "engine/crates/pocket-ui-wgpu/**"
+      - "engine/pocket3d/crates/pocket3d/**"
+      - "hosts/web/app-instance.*"
+      - "hosts/web/system-engine.js"
+      - "hosts/web/wasm-ops.js"
+      - "framework/src/manifest/**"
+      - "tests/platform-contracts.test.ts"
+      - "tests/symbian-runtime.test.ts"
+      - "tests/pocket-system.test.ts"
+      - "tests/web-system-host.test.ts"
+  push:
+    branches: [main]
+    paths:
+      - ".github/workflows/desktop-windows.yml"
+      - "contracts/spec/**"
+      - "engine/core/**"
+      - "engine/crates/pocket-mod/**"
+      - "engine/crates/pocket-ui-surface/**"
+      - "engine/crates/pocket-text/**"
+      - "framework/src/text-layout.ts"
+      - "framework/src/offload.ts"
+      - "hosts/web/*offload*.js"
+      - "hosts/web/text-*"
+      - "tools/*offload*"
+      - "tools/companion-session.ts"
+      - "tests/offload-provider.test.ts"
+      - "tests/companion-session.test.ts"
+      - "tests/fixtures/offload-ready-worker.ts"
+      - "tools/text-*"
+      - "tests/text-layout-client.test.ts"
+      - "apps/text-offload/**"
+      - "hosts/desktop/**"
+      - "engine/crates/pocket-ui-wgpu/**"
+      - "engine/pocket3d/crates/pocket3d/**"
+      - "hosts/web/app-instance.*"
+      - "hosts/web/system-engine.js"
+      - "hosts/web/wasm-ops.js"
+      - "framework/src/manifest/**"
+      - "tests/platform-contracts.test.ts"
+      - "tests/symbian-runtime.test.ts"
+      - "tests/pocket-system.test.ts"
+      - "tests/web-system-host.test.ts"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  windows:
+    name: windows-app build + contract tests
+    runs-on: windows-latest
+    timeout-minutes: 40
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+          targets: wasm32-unknown-unknown
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: |
+            engine/crates/pocket-text
+            hosts/desktop
+            engine/wasm
+
+      - uses: oven-sh/setup-bun@v2
+
+      - run: bun install --frozen-lockfile
+
+      - name: Platform registry, System and web host contract tests
+        # The two registry suites run scoped to the target-registry blocks this
+        # patch touches: the unscoped files still carry pre-existing Windows
+        # path defects (file:// URL pathnames concatenated into /C:/... paths)
+        # that fail on every Windows machine and are tracked separately.
+        run: |
+          bun test tests/platform-contracts.test.ts -t "platform registry"
+          bun test tests/symbian-runtime.test.ts -t "keeps the experimental E7 target out of the production registry"
+          bun test tests/pocket-system.test.ts tests/web-system-host.test.ts
+
+      - name: Resolve and build the note for windows-app
+        run: |
+          bun -e '
+          import { validateAndResolveBuildPlan } from "./framework/src/manifest/resolve.ts";
+          import { mkdirSync } from "node:fs";
+          const manifest = await Bun.file("apps/note/pocket.json").json();
+          const result = validateAndResolveBuildPlan(manifest, { target: "windows-app" });
+          if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+          mkdirSync(".pocket/windows-app", { recursive: true });
+          await Bun.write(".pocket/windows-app/note-main.plan.json", JSON.stringify(result.plan, null, 2) + "\n");'
+          bun tools/build.ts --plan=.pocket/windows-app/note-main.plan.json
+
+      - name: Rust format, lint and tests
+        run: |
+          cargo fmt --check --manifest-path hosts/desktop/Cargo.toml
+          cargo clippy --locked --manifest-path hosts/desktop/Cargo.toml -- -D warnings
+          cargo test --locked --manifest-path hosts/desktop/Cargo.toml
+
+      - name: Build windows-app release host
+        run: cargo build --release --locked --manifest-path hosts/desktop/Cargo.toml

--- a/.github/workflows/desktop-windows.yml
+++ b/.github/workflows/desktop-windows.yml
@@ -1,8 +1,9 @@
 name: Windows portable renderer
 
 # windows-app is the third stock target of the hosts/desktop portable host.
-# The runner builds and tests the host; real native window acceptance runs on
-# local Windows hardware (see docs/BACKENDS.md).
+# This workflow validates the Windows execution path advertised by that target;
+# it does not claim Windows support for unrelated device or site tooling.
+# Real native window acceptance runs on local Windows hardware (see docs/BACKENDS.md).
 
 on:
   pull_request:
@@ -100,33 +101,42 @@ jobs:
 
       - run: bun install --frozen-lockfile
 
-      - name: Platform registry, System and web host contract tests
-        # These two registry files contain pre-existing Windows path failures
-        # where file-URL pathnames are passed to filesystem APIs. That defect is
-        # outside this windows-app admission change, so run the registry blocks
-        # affected by this patch instead of weakening or repairing unrelated code.
+      - name: windows-app contracts and portable service tests
+        # The full registry files also exercise unrelated device/tooling paths
+        # that are not part of the windows-app support boundary. Run the target
+        # inventory blocks changed here, then the portable services that
+        # windows-app actually advertises.
         run: |
           bun test tests/platform-contracts.test.ts -t "platform registry"
           bun test tests/symbian-runtime.test.ts -t "keeps the experimental E7 target out of the production registry"
-          bun test tests/pocket-system.test.ts tests/web-system-host.test.ts
+          bun test tests/pocket-system.test.ts tests/text-layout-client.test.ts tests/offload-provider.test.ts tests/companion-session.test.ts
 
-      - name: Resolve and build the note for windows-app
+      - name: Resolve and build windows-app guests
         run: |
           bun -e '
           import { validateAndResolveBuildPlan } from "./framework/src/manifest/resolve.ts";
           import { mkdirSync } from "node:fs";
-          const manifest = await Bun.file("apps/note/pocket.json").json();
-          const result = validateAndResolveBuildPlan(manifest, { target: "windows-app" });
-          if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+          const apps = [
+            ["apps/note/pocket.json", "note-main"],
+            ["apps/text-offload/pocket.json", "text-offload-main"],
+          ];
           mkdirSync(".pocket/windows-app", { recursive: true });
-          await Bun.write(".pocket/windows-app/note-main.plan.json", JSON.stringify(result.plan, null, 2) + "\n");'
+          for (const [manifestPath, output] of apps) {
+            const manifest = await Bun.file(manifestPath).json();
+            const result = validateAndResolveBuildPlan(manifest, { target: "windows-app" });
+            if (!result.ok) throw new Error(JSON.stringify(result.diagnostics));
+            await Bun.write(`.pocket/windows-app/${output}.plan.json`, JSON.stringify(result.plan, null, 2) + "\n");
+          }'
           bun tools/build.ts --plan=.pocket/windows-app/note-main.plan.json
+          bun tools/build.ts --plan=.pocket/windows-app/text-offload-main.plan.json
 
       - name: Rust format, lint and tests
         run: |
           cargo fmt --check --manifest-path hosts/desktop/Cargo.toml
           cargo clippy --locked --manifest-path hosts/desktop/Cargo.toml -- -D warnings
           cargo test --locked --manifest-path hosts/desktop/Cargo.toml
+          cargo test --locked --manifest-path engine/Cargo.toml -p pocket-ui-surface
+          cargo test --locked --manifest-path engine/crates/pocket-text/Cargo.toml
 
       - name: Build windows-app release host
         run: cargo build --release --locked --manifest-path hosts/desktop/Cargo.toml

--- a/contracts/spec/platforms.ts
+++ b/contracts/spec/platforms.ts
@@ -244,6 +244,7 @@ export const POCKET_TARGETS = defineTargetRegistry<PocketCapabilityId, {
   readonly "macos-widget": TargetProfile<PocketCapabilityId>;
   readonly "macos-app": TargetProfile<PocketCapabilityId>;
   readonly "linux-app": TargetProfile<PocketCapabilityId>;
+  readonly "windows-app": TargetProfile<PocketCapabilityId>;
   readonly "web-app": TargetProfile<PocketCapabilityId>;
 }>({
   psp: {
@@ -373,6 +374,29 @@ export const POCKET_TARGETS = defineTargetRegistry<PocketCapabilityId, {
       dynamicViewport: { min: [240, 180], max: [4096, 4096], acceptsFixed: true },
       presentations: ["native"],
       rasterDensity: 1,
+    },
+    capabilities: [
+      "input.buttons",
+      "display.viewport.live",
+      "text.glyphs.baked",
+      "io.offload",
+      "text.layout.offload",
+    ],
+    roleCapabilities: {
+      systemUI: ["ui.compositor-surfaces"],
+    },
+  },
+  // The same portable host on Windows, at two raster samples per logical pixel.
+  "windows-app": {
+    hostAbi: 4,
+    platform: "windows",
+    form: "window",
+    display: {
+      physicalViewport: [1440, 960],
+      logicalViewports: [[720, 480]],
+      dynamicViewport: { min: [240, 180], max: [4096, 4096], acceptsFixed: true },
+      presentations: ["native"],
+      rasterDensity: 2,
     },
     capabilities: [
       "input.buttons",

--- a/docs/BACKENDS.md
+++ b/docs/BACKENDS.md
@@ -134,11 +134,11 @@ note does (pure-math unit tests over an injected measurer, sim traces,
 
 ## Native desktop targets
 
-`contracts/spec/platforms.ts` registers `macos-app` and `linux-app` at
-hostAbi 4 with `form: "window"`, a dynamic viewport and `acceptsFixed`.
-Both profiles use the same generic host. macOS resolves density 2; Linux
-resolves density 1. Fixed-viewport console apps run size-locked and
-letterboxed with their baked glyph pipeline intact.
+`contracts/spec/platforms.ts` registers `macos-app`, `linux-app` and
+`windows-app` at hostAbi 4 with `form: "window"`, a dynamic viewport and
+`acceptsFixed`. All three profiles use the same generic host. macOS and
+Windows resolve density 2; Linux resolves density 1. Fixed-viewport console
+apps run size-locked and letterboxed with their baked glyph pipeline intact.
 
 ```
 bun run macos note        # dynamic viewport, baked text, svc editor protocol
@@ -224,7 +224,7 @@ X,Y[,d|u|r]@TICK` (drags, right clicks), `--key
 
 |                    | portable                                                         | legacy gpui                                        |
 | ------------------ | ---------------------------------------------------------------- | ------------------------------------------- |
-| hosts              | PSP, Vita, PocketBook, ESP32-P4, Symbian, web, sim, macOS widget, macOS/Linux desktop | optional crate, no stock host           |
+| hosts              | PSP, Vita, PocketBook, ESP32-P4, Symbian, web, sim, macOS widget, macOS/Linux/Windows desktop | optional crate, no stock host           |
 | text measurement   | core, atlas advance tables                                       | gpui platform text system, per-app opt-in   |
 | codepoint coverage | baked charset (+ runtime extension)                              | OS fallback chain, color emoji              |
 | pixel determinism  | byte-exact across hosts                                          | per-host; transactions still deterministic  |

--- a/hosts/desktop/src/plan.rs
+++ b/hosts/desktop/src/plan.rs
@@ -2,8 +2,10 @@
 const HOST_ID: &str = "macos-app";
 #[cfg(target_os = "linux")]
 const HOST_ID: &str = "linux-app";
-#[cfg(not(any(target_os = "macos", target_os = "linux")))]
-compile_error!("pocket-desktop-host supports macOS and Linux");
+#[cfg(target_os = "windows")]
+const HOST_ID: &str = "windows-app";
+#[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+compile_error!("pocket-desktop-host supports macOS, Linux, and Windows");
 const HOST_ABI: u32 = 4;
 const TICK_HZ: f64 = 60.0;
 

--- a/site/content/docs/platform-contracts.md
+++ b/site/content/docs/platform-contracts.md
@@ -148,8 +148,8 @@ one variant:
   logical × `rasterDensity`. The app's own `dynamic.min`/`dynamic.max` are
   schema-valid and unread — the admitted range belongs to the target.
 - A fixed-only app resolves on a dynamic-form target when that profile sets
-  `dynamicViewport.acceptsFixed` (`macos-app`, `linux-app`, `web-app` do;
-  `macos-widget` does not), and runs size-locked in the window.
+  `dynamicViewport.acceptsFixed` (`macos-app`, `linux-app`, `windows-app`,
+  `web-app` do; `macos-widget` does not), and runs size-locked in the window.
 - A fixed-screen target rejects a dynamic-only app, and a dynamic-form target
   without `acceptsFixed` rejects a fixed-only app, both before compilation.
 
@@ -208,9 +208,10 @@ directory in `hosts/`:
 | `vita`         | 2       | vita / takeover   | 480×272 (`integer-fit`)                  | 2       | `input.analog.left`, `input.buttons`, `input.cursor`, `input.touch`, `text.glyphs.baked` |
 | `pocketbook`   | 5       | pocketbook / takeover | 480×272 (`integer-fit`)              | 2       | `input.buttons`, `input.touch`, `text.glyphs.baked` |
 | `macos-widget` | 3       | macos / widget    | 420×560 default, 240×180…4096×4096       | 2       | `input.buttons`, `input.ime`, `input.pointer`, `input.text`, `host.clipboard`, `display.viewport.live`, `text.glyphs.baked`, `text.glyphs.runtime` |
-| `macos-app`    | 4       | macos / window    | 720×480 default, 240×180…4096×4096, accepts fixed | 2 | `input.buttons`, `display.viewport.live`, `text.glyphs.baked`, `text.layout.native`; systemUI role adds `ui.compositor-surfaces` |
+| `macos-app`    | 4       | macos / window    | 720×480 default, 240×180…4096×4096, accepts fixed | 2 | `input.buttons`, `display.viewport.live`, `text.glyphs.baked`, `io.offload`, `text.layout.offload`; systemUI role adds `ui.compositor-surfaces` |
 | `linux-app`    | 4       | linux / window    | 800×600 default, 240×180…4096×4096, accepts fixed | 1 | same as `macos-app` |
-| `web-app`      | 4       | web / window      | 800×600 default, 320×240…4096×4096, accepts fixed | 1 | `input.buttons`, `display.viewport.live`, `text.glyphs.baked`; systemUI role adds `ui.compositor-surfaces` |
+| `windows-app`  | 4       | windows / window  | 720×480 default, 240×180…4096×4096, accepts fixed | 2 | same as `macos-app` |
+| `web-app`      | 4       | web / window      | 800×600 default, 320×240…4096×4096, accepts fixed | 1 | `input.buttons`, `display.viewport.live`, `text.glyphs.baked`, `io.offload`, `text.layout.offload`; systemUI role adds `ui.compositor-surfaces` |
 
 `roleCapabilities.systemUI` is the one conditional column: those APIs reach a
 package only when it resolves in the System-UI role. `ui.compositor-surfaces`
@@ -374,14 +375,14 @@ const targetBackends = {
 await targetBackends[target as PocketTargetId](context);
 ```
 
-**That table holds three of the seven registered targets.** The desktop targets
+**That table holds three of the eight registered targets.** The desktop targets
 build through their own tools instead — `macos-app` through `tools/macos.ts`,
-`macos-widget` through `tools/note.ts` and `tools/widget.ts` — and `linux-app`
-and `web-app` have no `pocket build` path today: the plan resolves and then the
-index throws a TypeError on an undefined backend. The table carries a
-`satisfies Record<PocketTargetId, TargetBackend>` annotation it does not meet,
-and `tools/` sits outside the `tsconfig.json` include list, so no typecheck
-reports the gap.
+`macos-widget` through `tools/note.ts` and `tools/widget.ts` — and `linux-app`,
+`windows-app` and `web-app` have no `pocket build` path today: the plan
+resolves and then the index throws a TypeError on an undefined backend. The
+table carries a `satisfies Record<PocketTargetId, TargetBackend>` annotation
+it does not meet, and `tools/` sits outside the `tsconfig.json` include list,
+so no typecheck reports the gap.
 
 After dispatch, a backend reads resolved fields; it does not recalculate
 physical dimensions or output names from the target id. The serialized plan

--- a/tests/platform-contracts.test.ts
+++ b/tests/platform-contracts.test.ts
@@ -213,6 +213,7 @@ describe("platform registry", () => {
       "macos-widget",
       "macos-app",
       "linux-app",
+      "windows-app",
       "web-app",
     ]);
     expect(validatePlatformContractRegistry(POCKET_PLATFORM_CONTRACTS)).toEqual([]);
@@ -312,6 +313,30 @@ describe("platform registry", () => {
         "text.glyphs.baked",
         "io.offload",
       "text.layout.offload",
+      ],
+      roleCapabilities: { systemUI: ["ui.compositor-surfaces"] },
+    });
+    expect(POCKET_TARGETS["windows-app"]).toEqual({
+      hostAbi: 4,
+      platform: "windows",
+      form: "window",
+      display: {
+        physicalViewport: [1440, 960],
+        logicalViewports: [[720, 480]],
+        dynamicViewport: {
+          min: [240, 180],
+          max: [4096, 4096],
+          acceptsFixed: true,
+        },
+        presentations: ["native"],
+        rasterDensity: 2,
+      },
+      capabilities: [
+        "input.buttons",
+        "display.viewport.live",
+        "text.glyphs.baked",
+        "io.offload",
+        "text.layout.offload",
       ],
       roleCapabilities: { systemUI: ["ui.compositor-surfaces"] },
     });

--- a/tests/symbian-runtime.test.ts
+++ b/tests/symbian-runtime.test.ts
@@ -188,6 +188,7 @@ describe("experimental Nokia E7 runtime profile", () => {
       "macos-widget",
       "macos-app",
       "linux-app",
+      "windows-app",
       "web-app",
     ]);
     expect(POCKET_TARGETS).not.toHaveProperty(SYMBIAN_E7_DEV_TARGET_ID);


### PR DESCRIPTION
## Summary

`windows-app` becomes the third stock target of the existing portable `hosts/desktop`, alongside `macos-app` and `linux-app`.

This is a target-admission change, not a new Windows architecture:

```text
macos-app  ──┐
linux-app ───┼──→ hosts/desktop
windows-app ─┘     ├─ winit window/input
                    ├─ pocket-ui-wgpu rendering/presentation
                    ├─ AppSupervisor runtime worker
                    └─ portable offload/text workers
```

There is no second Windows renderer, no new guest ABI, and no Windows-specific UI stack.

## Target contract

| Field | Value |
| --- | --- |
| Target | `windows-app` |
| Platform / form | `windows` / `window` |
| Host ABI | `4` |
| Logical / physical profile | `720×480` / `1440×960` |
| Dynamic viewport | `240×180 … 4096×4096`, `acceptsFixed: true` |
| Presentation | `native` |
| Raster density | `2` |

`hostAbi: 4` remains the current portable desktop generation. This PR adds no new HostOp, DrawList opcode, service wire format, or manifest semantic.

`rasterDensity: 2` is a package/resource raster contract, not a claim that Windows displays run at 200% scale. Live window scale remains host/runtime state.

## Capability closure

The compile-time host-identity admission gate in `hosts/desktop` is extended from macOS/Linux to Windows through `HOST_ID`.

Other small platform-policy branches, such as macOS Command-vs-Control modifier mapping, remain inside the same shared portable host.

`windows-app` advertises only capabilities already delivered through that generic host path:

| Capability | Windows execution path | Maintained evidence |
| --- | --- | --- |
| `input.buttons` | winit keyboard → desktop button mapping → guest | `hosts/desktop` tests |
| `display.viewport.live` | winit resize + live scale → logical viewport update | `hosts/desktop` tests + physical resize acceptance |
| `text.glyphs.baked` | baked atlas → DrawList → `pocket-ui-wgpu` | desktop host/render tests |
| `io.offload` | desktop host → `pocket-ui-surface::OffloadWorker` | desktop + surface cargo tests |
| `text.layout.offload` | desktop text worker → OffloadWorker → `pocket-text::Engine` | desktop + surface + text cargo tests |
| systemUI: `ui.compositor-surfaces` | desktop supervisor / child-surface composition | `hosts/desktop` tests |

`text-offload`, whose manifest requires `io.offload` and `text.layout.offload`, resolves against `windows-app` and is built in the Windows workflow. These capabilities therefore participate in a real Windows build rather than existing only in the registry.

The target does **not** advertise `input.pointer`, `input.text`, `input.ime`, `host.clipboard`, or runtime/native text capabilities.

## Stock target != `pocket build` backend

This PR adds:

- stock target registration;
- manifest/plan resolution for `windows-app`;
- production guest compilation through `tools/build.ts`;
- Windows admission in the existing `hosts/desktop`.

It does **not** add a Windows `pocket build` distribution backend.

The `tools/pocket.ts` native backend table remains unchanged.

## Windows CI

`.github/workflows/desktop-windows.yml` runs on `windows-latest` and validates the execution closure claimed by `windows-app`:

- platform-registry / production-target invariants;
- portable service tests;
- `note` resolved and built as `windows-app`;
- `text-offload` resolved and built as `windows-app`;
- `hosts/desktop` `cargo fmt --check`;
- `hosts/desktop` clippy with `-D warnings`;
- `hosts/desktop` unit tests;
- ignored host-boundary GPU acceptance;
- `pocket-ui-surface` tests;
- `pocket-text` tests;
- release build of the desktop host.

Current Windows workflow result on this head: **PASS**.

The full shared test files also contain unrelated device/tooling paths, including POSIX sanitizer harnesses, E7 pathname assumptions, and CRLF-sensitive fixtures. Those are outside the `windows-app` execution boundary and remain on their existing lanes.

## GPU acceptance

The ignored host-boundary GPU test passes on `windows-latest`.

Its scope is intentionally narrow:

```text
adapter/device creation
→ retained target allocation
→ retained target reuse
→ resize/resource lifetime
```

This is not claimed as native-window/swapchain end-to-end evidence.

## Physical Windows acceptance

The stock portable desktop host was also exercised on physical Windows 11 with a production `note` guest resolved through the `windows-app` plan.

Verified:

- decorated native window creation;
- first frame presentation;
- `windows-app` / hostAbi 4 identity assertion at mount;
- real OS maximize/resize while the host continues presenting;
- guest edit path remains functional;
- WM_CLOSE → `CloseRequested` → clean exit code 0.

Environment:

```text
Windows 11 Pro 10.0.26200 x64
rustc 1.98.1 x86_64-pc-windows-msvc
Bun 1.2.8
AMD Radeon(TM) integrated GPU
wgpu backend: Vulkan
surface format: Bgra8Unorm
```

Scripted typing used the real guest edit path but was not OS keyboard injection, so no `input.text` capability claim is made.

## Downstream validation

PicoView has also shipped as a real Windows desktop application on top of this portable Desktop/Windows path.

That downstream product evidence is intentionally not additional scope for this PR.

## Non-goals

This PR does **not** include:

- a second Windows renderer or native host;
- a new guest ABI or DrawList opcode;
- Windows-specific guest APIs;
- `pocket build` Windows distribution;
- installer / packaging support;
- runtime CJK / Unicode text work;
- WIC or host-decoded image APIs;
- mipmap/minification work;
- shared Desktop DPI/presentation redesign;
- Per-Monitor DPI policy;
- PicoView product code;
- repository-wide Windows portability cleanup.

## Validation

Current branch:

```text
base: 88cbeedd8be19f60738832cc8459f9a102faf3ae
head: 9802973fffa9298c28371bde83c94cc8df08399e
```

The branch was freshly replayed onto current upstream `main`; it is not carrying the historical intermediate workflow iterations from the earlier PR state.

Current result:

```text
GitHub Actions:
  Windows portable renderer     PASS
  Linux portable renderer       PASS
  macOS portable renderer       PASS
  3DS runtime contracts         PASS
  Native C harness              PASS

Physical Windows acceptance:
  PASS
```